### PR TITLE
🐛 Phase 2.5 — fix 3 MCP correctness bugs from PR #1 review

### DIFF
--- a/mcp/trajectory-server/src/schema.sql
+++ b/mcp/trajectory-server/src/schema.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS issues (
     goals_md          TEXT    NOT NULL DEFAULT '',
     goals_md_hash     TEXT    NOT NULL DEFAULT '',
     pre_commit_hash   TEXT    NOT NULL DEFAULT '',
+    post_commit_hash  TEXT,
     status            TEXT    NOT NULL DEFAULT 'open',
     current_task_id   INTEGER REFERENCES tasks(id),
     created_at        TEXT    NOT NULL,
@@ -37,14 +38,15 @@ CREATE TABLE IF NOT EXISTS tasks (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_issue_branch ON tasks(issue_id, branch_id);
 
 CREATE TABLE IF NOT EXISTS ledger (
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    issue_id    INTEGER NOT NULL REFERENCES issues(id),
-    branch_id   TEXT,
-    from_node   TEXT    NOT NULL,
-    event_type  TEXT    NOT NULL,
-    summary     TEXT    NOT NULL DEFAULT '',
-    content     TEXT    NOT NULL DEFAULT '{}',
-    created_at  TEXT    NOT NULL
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_id     INTEGER NOT NULL REFERENCES issues(id),
+    branch_id    TEXT,
+    from_node    TEXT    NOT NULL,
+    event_type   TEXT    NOT NULL,
+    summary      TEXT    NOT NULL DEFAULT '',
+    content      TEXT    NOT NULL DEFAULT '{}',
+    is_truncated INTEGER NOT NULL DEFAULT 0,
+    created_at   TEXT    NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS audit (
@@ -118,4 +120,4 @@ CREATE TABLE IF NOT EXISTS plugin_meta (
     updated_at     TEXT    NOT NULL DEFAULT (datetime('now'))
 );
 
-INSERT OR IGNORE INTO plugin_meta (schema_version, plugin_version) VALUES (1, '0.2.0');
+INSERT OR IGNORE INTO plugin_meta (schema_version, plugin_version) VALUES (2, '0.2.0');

--- a/mcp/trajectory-server/src/test/agent-scope.test.ts
+++ b/mcp/trajectory-server/src/test/agent-scope.test.ts
@@ -16,6 +16,7 @@ function makeIssue(overrides: Partial<Issue> = {}): Issue {
     goals_md: 'SECRET GOALS',
     goals_md_hash: 'abc',
     pre_commit_hash: 'sha123',
+    post_commit_hash: null,
     status: 'open',
     current_task_id: null,
     created_at: '2026-01-01T00:00:00Z',

--- a/mcp/trajectory-server/src/test/db.test.ts
+++ b/mcp/trajectory-server/src/test/db.test.ts
@@ -4,7 +4,7 @@ import { tempDB } from './helpers.js';
 import { nowISO, genId } from '../db.js';
 
 describe('TrajectoryDB', () => {
-  it('opens an in-memory DB and verifies all 9 tables exist with schema_version=1', () => {
+  it('opens an in-memory DB and verifies all 9 tables exist with schema_version=2', () => {
     const db = tempDB();
 
     const expectedTables = [
@@ -31,7 +31,7 @@ describe('TrajectoryDB', () => {
       'SELECT schema_version FROM plugin_meta LIMIT 1',
     );
     assert.ok(meta !== undefined, 'plugin_meta should have a row');
-    assert.equal(meta.schema_version, 1);
+    assert.equal(meta.schema_version, 2);
 
     db.close();
   });

--- a/mcp/trajectory-server/src/test/issues.test.ts
+++ b/mcp/trajectory-server/src/test/issues.test.ts
@@ -159,6 +159,52 @@ describe('issueTools', () => {
     db.close();
   });
 
+  it('issue_close sets post_commit_hash and preserves pre_commit_hash', async () => {
+    const db = tempDB();
+    const tools = issueTools(db);
+
+    const createResult = await call(tools.handlers, 'issue_create', {
+      agent: 'architect',
+      objective: 'SHA preservation test',
+    });
+    const issue = parseResult(createResult);
+    const originalPreHash = issue.pre_commit_hash;
+
+    const closeResult = await call(tools.handlers, 'issue_close', {
+      agent: 'architect',
+      issue_id: String(issue.id),
+      post_git_sha: 'deadbeef',
+    });
+    const closed = parseResult(closeResult);
+    assert.ok(!closeResult.isError);
+    assert.equal(closed.post_commit_hash, 'deadbeef', 'post_commit_hash should be set');
+    assert.equal(closed.pre_commit_hash, originalPreHash, 'pre_commit_hash must not be overwritten');
+
+    db.close();
+  });
+
+  it('issue_close without post_git_sha leaves post_commit_hash as null', async () => {
+    const db = tempDB();
+    const tools = issueTools(db);
+
+    const createResult = await call(tools.handlers, 'issue_create', {
+      agent: 'swe',
+      objective: 'Optional SHA test',
+    });
+    const issue = parseResult(createResult);
+
+    const closeResult = await call(tools.handlers, 'issue_close', {
+      agent: 'swe',
+      issue_id: String(issue.id),
+    });
+    const closed = parseResult(closeResult);
+    assert.ok(!closeResult.isError);
+    assert.equal(closed.status, 'closed');
+    assert.equal(closed.post_commit_hash, null, 'post_commit_hash should remain null');
+
+    db.close();
+  });
+
   it('unknown issue_id returns a JSON-RPC error', async () => {
     const db = tempDB();
     const tools = issueTools(db);

--- a/mcp/trajectory-server/src/test/ledger.test.ts
+++ b/mcp/trajectory-server/src/test/ledger.test.ts
@@ -97,6 +97,66 @@ describe('ledgerTools', () => {
     db.close();
   });
 
+  it('ledger_log with oversized content persists is_truncated = 1', async () => {
+    const db = tempDB();
+    const issueId = await createIssue(db);
+    const tools = ledgerTools(db);
+
+    const bigContent = JSON.stringify({ data: 'x'.repeat(1_100_000) });
+
+    const result = await call(tools.handlers, 'ledger_log', {
+      agent: 'swe',
+      issue_id: String(issueId),
+      from_node: 'swe',
+      event_type: 'large_event',
+      summary: 'Oversized content',
+      content_json: bigContent,
+    });
+    const entry = parseResult(result);
+    assert.ok(!result.isError, `Expected no error: ${JSON.stringify(entry)}`);
+    assert.equal(entry.is_truncated, 1, 'is_truncated should be 1 for oversized content');
+    assert.ok(entry.content.length < bigContent.length, 'content should be truncated');
+
+    db.close();
+  });
+
+  it('ledger_list returns is_truncated flag from persisted row', async () => {
+    const db = tempDB();
+    const issueId = await createIssue(db);
+    const tools = ledgerTools(db);
+
+    const bigContent = JSON.stringify({ data: 'y'.repeat(1_100_000) });
+
+    await call(tools.handlers, 'ledger_log', {
+      agent: 'swe',
+      issue_id: String(issueId),
+      from_node: 'swe',
+      event_type: 'large_event',
+      summary: 'Truncated row',
+      content_json: bigContent,
+    });
+
+    await call(tools.handlers, 'ledger_log', {
+      agent: 'swe',
+      issue_id: String(issueId),
+      from_node: 'swe',
+      event_type: 'small_event',
+      summary: 'Normal row',
+    });
+
+    const listResult = await call(tools.handlers, 'ledger_list', {
+      agent: 'swe',
+      issue_id: String(issueId),
+    });
+    const entries = parseResult(listResult);
+    assert.ok(!listResult.isError);
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].is_truncated, 1, 'first row is_truncated should be 1');
+    assert.equal(entries[1].is_truncated, 0, 'second row is_truncated should be 0');
+
+    db.close();
+  });
+
   it('ledger_list filtered by branch_id returns only matching rows', async () => {
     const db = tempDB();
     const issueId = await createIssue(db);

--- a/mcp/trajectory-server/src/test/remaining_tools.test.ts
+++ b/mcp/trajectory-server/src/test/remaining_tools.test.ts
@@ -103,6 +103,35 @@ describe('auditTools', () => {
 
     db.close();
   });
+
+  it('audit_log round is scoped per (issue_id, branch_id) not per issue_id', async () => {
+    const db = tempDB();
+    const issueId = await createIssue(db);
+    const tools = auditTools(db);
+
+    const logEntry = (branchId: string) =>
+      call(tools.handlers, 'audit_log', {
+        agent: 'swe',
+        issue_id: String(issueId),
+        branch_id: branchId,
+        from_node: 'executor',
+        tool_name: 'bash',
+        tool_args: {},
+        output: 'ok',
+      });
+
+    const r1a = parseResult(await logEntry('task-1'));
+    const r1b = parseResult(await logEntry('task-1'));
+    const r2a = parseResult(await logEntry('task-2'));
+    const r2b = parseResult(await logEntry('task-2'));
+
+    assert.equal(r1a.round, 0, 'task-1 first entry should be round 0');
+    assert.equal(r1b.round, 1, 'task-1 second entry should be round 1');
+    assert.equal(r2a.round, 0, 'task-2 first entry should be round 0 (independent)');
+    assert.equal(r2b.round, 1, 'task-2 second entry should be round 1 (independent)');
+
+    db.close();
+  });
 });
 
 describe('validationTools', () => {

--- a/mcp/trajectory-server/src/tools/audit.ts
+++ b/mcp/trajectory-server/src/tools/audit.ts
@@ -94,7 +94,14 @@ export function auditTools(db: TrajectoryDB): {
       let round: number;
       if (args['round'] !== undefined && args['round'] !== null) {
         round = args['round'] as number;
+      } else if (branchId !== null) {
+        const maxRow = db.get<{ max_round: number | null }>(
+          `SELECT MAX(round) as max_round FROM audit WHERE issue_id = ? AND branch_id = ?`,
+          [issueId, branchId],
+        );
+        round = (maxRow?.max_round ?? -1) + 1;
       } else {
+        // branch_id not provided: fall back to issue-only scope (ambiguous across tasks)
         const maxRow = db.get<{ max_round: number | null }>(
           `SELECT MAX(round) as max_round FROM audit WHERE issue_id = ?`,
           [issueId],

--- a/mcp/trajectory-server/src/tools/issues.ts
+++ b/mcp/trajectory-server/src/tools/issues.ts
@@ -87,7 +87,7 @@ export function issueTools(db: TrajectoryDB): {
           issue_id: { type: 'string' },
           post_git_sha: { type: 'string', description: 'Git SHA after issue work is done' },
         },
-        required: ['agent', 'issue_id', 'post_git_sha'],
+        required: ['agent', 'issue_id'],
       },
     },
     {
@@ -170,9 +170,8 @@ export function issueTools(db: TrajectoryDB): {
     issue_close: wrapHandler(async (args) => {
       requireArg(args, 'agent');
       const issueId = requireArg(args, 'issue_id') as string;
-      requireArg(args, 'post_git_sha');
 
-      const postGitSha = args['post_git_sha'] as string;
+      const postGitSha = (args['post_git_sha'] as string | undefined) ?? null;
       const now = nowISO();
 
       const issue = db.get<Issue>('SELECT * FROM issues WHERE id = ?', [issueId]);
@@ -180,12 +179,21 @@ export function issueTools(db: TrajectoryDB): {
         throw new Error(`Not found: ${issueId}`);
       }
 
-      db.run(
-        `UPDATE issues
-         SET status = 'closed', updated_at = ?, closed_at = COALESCE(closed_at, ?), pre_commit_hash = ?
-         WHERE id = ?`,
-        [now, now, postGitSha, issueId],
-      );
+      if (postGitSha !== null) {
+        db.run(
+          `UPDATE issues
+           SET status = 'closed', updated_at = ?, closed_at = COALESCE(closed_at, ?), post_commit_hash = ?
+           WHERE id = ?`,
+          [now, now, postGitSha, issueId],
+        );
+      } else {
+        db.run(
+          `UPDATE issues
+           SET status = 'closed', updated_at = ?, closed_at = COALESCE(closed_at, ?)
+           WHERE id = ?`,
+          [now, now, issueId],
+        );
+      }
 
       const updated = db.get<Issue>('SELECT * FROM issues WHERE id = ?', [issueId]);
       return ok(updated);

--- a/mcp/trajectory-server/src/tools/ledger.ts
+++ b/mcp/trajectory-server/src/tools/ledger.ts
@@ -98,16 +98,16 @@ export function ledgerTools(db: TrajectoryDB): {
       }
 
       db.run(
-        `INSERT INTO ledger (issue_id, branch_id, from_node, event_type, summary, content, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
-        [issueId, branchId, fromNode, eventType, summary, contentJson, now],
+        `INSERT INTO ledger (issue_id, branch_id, from_node, event_type, summary, content, is_truncated, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [issueId, branchId, fromNode, eventType, summary, contentJson, isTruncated, now],
       );
 
-      const row = db.get<LedgerEntry & { is_truncated?: number }>(
+      const row = db.get<LedgerEntry>(
         'SELECT * FROM ledger WHERE rowid = last_insert_rowid()',
       );
 
-      return ok({ ...row, is_truncated: isTruncated });
+      return ok(row);
     }),
 
     ledger_list: wrapHandler(async (args) => {

--- a/mcp/trajectory-server/src/types.ts
+++ b/mcp/trajectory-server/src/types.ts
@@ -5,6 +5,7 @@ export interface Issue {
   goals_md: string;
   goals_md_hash: string;
   pre_commit_hash: string;
+  post_commit_hash: string | null;
   status: string;
   current_task_id: number | null;
   created_at: string;
@@ -39,6 +40,7 @@ export interface LedgerEntry {
   event_type: string;
   summary: string;
   content: string;
+  is_truncated: number;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary

Closes the 3 correctness bugs flagged by pr-reviewer on PR #1. All three were data-integrity issues that would silently corrupt trajectory state once agents start calling the MCP tools.

- **#B1** `issue_close` was writing `post_git_sha` into the `pre_commit_hash` column (no `post_commit_hash` column existed). Overwrote the pre-SHA captured at create. **Fix:** add `post_commit_hash TEXT` column; write to it; preserve `pre_commit_hash`.
- **#B2** `ledger_log` returned `is_truncated` in the response but didn't persist it (no column existed). Later `ledger_list` callers couldn't tell a row was truncated. **Fix:** add `is_truncated INTEGER NOT NULL DEFAULT 0` to `ledger`; persist on INSERT; surface via `SELECT *`.
- **#B3** `audit_log` scoped `MAX(round)` by `issue_id` only, letting rounds cross-contaminate across tasks in the same issue. **Fix:** scope by `(issue_id, branch_id)` with documented fallback to issue-only when `branch_id` is null.

Schema version bumped 1 → 2. Schema changes are additive (new columns, no renames), backward-compatible.

## Test plan

- [x] `bun install && bun run build && bun run test` from `plugin/mcp/trajectory-server/` → 38 pass / 0 fail
- [x] pr-reviewer sign-off: PASS on all three
- [x] Task XML updated: `bro/tasks/20260421-1700_phase2_5_mcp_bugfixes.xml` closed

## Notes

One informational flag: `issue_close` now allows omitting `post_git_sha` (matches the authorized edge-case spec). Callers omitting it get `post_commit_hash = NULL` instead of a validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)