### PR TITLE
🚀 v0.3 Phase 0 — Foundation: schema v3, migration runner, config/identity tools, role gating

### DIFF
--- a/docs/v0.3-blueprint.md
+++ b/docs/v0.3-blueprint.md
@@ -1,0 +1,101 @@
+# v0.3 Workflow Redesign — Blueprint
+
+**Thesis:** SQLite is canonical state; files are generated snapshots; git is the organizing primitive; gatekeeper is silent by default, opinionated when needed.
+
+v0.2 brought the plugin to native Claude Code format. v0.3 collapses the file-based workflow contract (GOALS/DISCUSSION/BLUEPRINT + XML tasks) into a conversation + SQLite model, renames everything to professional branding, and adds a hybrid auto/manual architecture-doc system.
+
+---
+
+## Scope — 10 changes
+
+| # | Change | Phase |
+|---|---|---|
+| A | `bro/` → `docs/trustmybot/` directory rename | 1 |
+| B | Drop task XML envelope; task spec → markdown at `docs/trustmybot/tasks/<branch_id>.md`; state → SQLite only | 2 |
+| C | `PLUGIN_BUGS.md` → GitHub Issues; delete the file, migrate the 9 tracked items | 6 |
+| D | Gatekeeper self-identifies as "bro" on first use; user can rename; identity persists in plugin data | 4 |
+| E | Drop `GOALS.md` + `DISCUSSION.md` + `BLUEPRINT.md` as required files; capture via conversation → SQLite `issues` + `discussions` tables; generate read-only snapshots on demand | 2 |
+| F | `branch_id` = git-convention branch names (`feat/user-login`, `fix/auth-crash`, etc.); auto-proposed by gatekeeper | 1 |
+| G | Silent-default UX; complexity escalation always through architect | 3 |
+| H | First-run onboarding: detect git state, ask branching-model (trunk / dev-branch), persist config; git-guards reads config | 4 |
+| I | Two-path workflow: simple (architect writes tasks → SWE) vs difficult (architect updates architecture + blueprint → tasks → SWE); heuristic = "does this change require an update to `docs/trustmybot/architecture/`?" | 3 |
+| J | `docs/trustmybot/architecture/{auto,manual}/` hybrid; file_registry SQLite table populated by lazy git-log diff parse; on-demand regen of codebase-tree, ERD, module-graph, changelog | 5 |
+
+---
+
+## Phase breakdown (7 PRs)
+
+### Phase 0 — Foundation (blocks everything)
+- Re-add `file_registry` table to SQLite schema (dropped in v0.2; reintroduced for architecture/ derivation per change #J)
+- Add `plugin_config` or similar for branching-model persistence (change #H)
+- Identity persistence for gatekeeper rename (change #D)
+- Schema migration from v0.2 → v0.3
+
+### Phase 1 — Directory rename + branch-name IDs (changes #A, #F)
+- `bro/` → `docs/trustmybot/` everywhere (hooks regex, agent prompts, skill descriptions, README, CLAUDE.md, bro-template/ → templates/docs-trustmybot/)
+- `branch_id` column semantic change to accept git-convention strings; gatekeeper proposes them from intent
+- Update `require-task-xml.sh` hook (or rename to `require-task-spec.sh`) to look at new path
+
+### Phase 2 — State model overhaul (changes #B, #E)
+- Drop task XML envelope; introduce `docs/trustmybot/tasks/<branch_id>.md` markdown spec format (frontmatter + human-readable body)
+- SWE agent: read spec from file, update state via MCP only, no hand-edited XML
+- Drop GOALS/DISCUSSION/BLUEPRINT files; gatekeeper + architect capture intent via conversation into `issues` + `discussions` tables
+- Generate read-only snapshot files (for PR review) on demand
+- Hook updates: `require-review-sign.sh` reads SQLite instead of grepping XMLs
+
+### Phase 3 — Workflow shape (changes #G, #I)
+- gatekeeper agent prompt: simple-vs-difficult triage, silent default, direct handling for read-only
+- architect agent prompt: double-check triage, two task-template sizes (trivial / standard), explicit architecture-doc-impact check
+- Validation loop unchanged (still architect → pr-reviewer)
+
+### Phase 4 — Onboarding + identity (changes #D, #H)
+- gatekeeper first-run flow: detect git, ask/confirm branching model, persist config
+- gatekeeper greeting: introduce as "bro", ask preferred name, persist
+- Subsequent sessions: read persisted identity + branching-model config
+
+### Phase 5 — Architecture-doc derivation (change #J)
+- `docs/trustmybot/architecture/{auto,manual}/` directory structure
+- Lazy git-log diff parser populates `file_registry` table
+- Mermaid ERD renderer from `schema.sql`
+- On-demand regen skill (`/tmb refresh-architecture` or similar)
+- PR Reviewer flags manual edits to `auto/` files
+
+### Phase 6 — GitHub Issues migration + cleanup (change #C)
+- Open GitHub Issues for the 9 items in `bro/PLUGIN_BUGS.md` (most are already partially addressed by v0.2 and v0.3 work)
+- Delete `PLUGIN_BUGS.md`
+- Update `bro/VERIFIED_REFS.md` references → `docs/trustmybot/VERIFIED_REFS.md` OR move to Issues as discussion entries
+- v0.3 tag + release
+
+---
+
+## Design principles locked in (from this session's memory)
+
+1. **Two-tier roster**: global (gatekeeper + prompt-engineer); project-level placeholders (ceo/cto/architect/swe/pr-reviewer); on-demand via agent-creator.
+2. **Two-path workflow**: simple vs difficult, both through architect; heuristic = architecture-doc impact.
+3. **Hybrid architecture dir**: auto/ regenerated from file_registry; manual/ for ADRs + narrative.
+4. **SQLite is canonical; files are snapshots**: conversation + DB state, not file-based GOALS/DISCUSSION/BLUEPRINT.
+5. **Git branch names are the index**: no artificial `1.2.3` numbering.
+
+---
+
+## Known non-trivial questions for Phase 0 architect spawn
+
+1. How does gatekeeper persist identity when the project has no git? Plugin-data-dir only, or project-level config file?
+2. Schema migration: do we hard-break v0.2 DBs or provide a `tmb-migrate` script?
+3. Where does the regen state live (when was last git-log-since timestamp)? `plugin_meta` table or separate `regen_state`?
+4. Does `docs/trustmybot/architecture/auto/` get committed to git (so reviewers see it in PRs) or gitignored (less noise)? My lean: committed, with a generated-header so git-blame is honest.
+5. Trunk-based vs dev-branch config: does it affect which branch `git-guards.sh` treats as protected, or only the PR target? Both — need both in config.
+
+---
+
+## Handoff to next session
+
+This file is the v0.3 blueprint. Next session should:
+
+1. Spawn architect to read this file + the three v0.3 memory notes (two-tier roster, two-path workflow, architecture dir hybrid).
+2. Architect breaks Phase 0 into task specs (new format: markdown, not XML — task stated in natural prose with success criteria list).
+3. SWE spawned per Phase 0 task. Work on a fresh worktree off this branch.
+4. Cherry-pick, open PR, merge, move to Phase 1.
+5. Expect 7 PRs total over multiple sessions. Each phase is independently mergeable (each phase's changes are usable at that commit, not blocked by later phases).
+
+**Before implementation starts, the TMB workspace dogfood loop needs to be restored** (currently the `TMB/.claude` symlink is dangling because v0.2 deleted `plugin/.claude/`). Options: (a) install plugin via `/plugin install tmb@trustmybot --local ./plugin` at TMB workspace root; (b) set up workspace-local `.claude/` that composes with the installed plugin. Without one of these, this Claude Code session can't spawn TMB agents against v0.3 work.

--- a/mcp/trajectory-server/README.md
+++ b/mcp/trajectory-server/README.md
@@ -45,3 +45,30 @@ Set by Claude Code as `${CLAUDE_PLUGIN_DATA}/trajectory.db`. Falls back to
 - `skill_list` — list active skills
 - `skill_record_outcome` — record success/failure for effectiveness tracking
 - `meta_get` — read plugin_meta (schema_version, plugin_version)
+
+## Schema versions
+
+| Version | Release | Changes |
+|---|---|---|
+| 1 | v0.2 initial | 9 tables: issues, tasks, ledger, audit, validation_attempts, skills, roundtables, roundtable_votes, plugin_meta |
+| 2 | v0.2 B1/B2/B3 fixes | Added `post_commit_hash` on issues, `is_truncated` on ledger, audit `round` scoped per (issue_id, branch_id) |
+| 3 | v0.3 Phase 0 | Adds file_registry, plugin_config, identity, regen_state tables |
+
+### Hard-break migration policy
+
+On startup, `TrajectoryDB` reads `plugin_meta.schema_version` from the existing
+database file before running `schema.sql`.
+
+- **Lower version (`< 3`)**: the existing file is renamed to
+  `<path>.v<N>.bak.<epoch>` (along with `-wal` and `-shm` sidecars when
+  present), a warning is logged to stderr, and a fresh schema_version=3
+  database is initialized at the original path.
+- **Same version (`=== 3`)**: no-op, startup continues normally.
+- **Higher version (`> 3`)**: the constructor throws — the database was written
+  by a newer binary; upgrade the plugin or restore from backup.
+- **`:memory:` or non-existent path**: migration check is skipped entirely.
+
+Backup files are user's responsibility to inspect or discard. No
+data-preserving migration script exists in v0.3 by design: later phases
+introduce destructive schema changes that would invalidate any migration
+written now. Hard-break + backup preserves data without burning effort.

--- a/mcp/trajectory-server/docs/CONFIG_KEYS.md
+++ b/mcp/trajectory-server/docs/CONFIG_KEYS.md
@@ -1,0 +1,27 @@
+# plugin_config Key Contract
+
+## 1. Key Registry
+
+| Key | Type | Allowed values | Default | Read by | Written by |
+|-----|------|----------------|---------|---------|------------|
+| `branching_model` | string | `github-flow` \| `gitflow` \| `custom` | (none — first-run prompt sets it) | git-guards.sh (Phase 4), gatekeeper routing (Phase 4) | gatekeeper onboarding (Phase 4) |
+| `pr_target` | string | any valid branch name | derived from `branching_model` when first-run sets it | git-guards.sh PR rule (Phase 4) | gatekeeper onboarding (Phase 4) |
+| `protected_branches` | string[] (JSON) | array of branch names | derived from `branching_model` | git-guards.sh commit rule (Phase 4) | gatekeeper onboarding (Phase 4) |
+
+## 2. Default Derivation
+
+| `branching_model` value | `pr_target` default | `protected_branches` default |
+|-------------------------|---------------------|------------------------------|
+| `github-flow` | `main` | `["main"]` |
+| `gitflow` | `develop` | `["main", "develop"]` |
+| `custom` | (caller required) | (caller required) |
+
+`branching_model` sets sensible defaults for `pr_target` and `protected_branches` but does NOT override them once explicitly set.
+
+## 3. Forward Compatibility
+
+Additional keys can be added to `plugin_config` without schema migration; the table is generic. Any new key that consumers depend on MUST be reflected in this file before Phase 4 or later phases consume it.
+
+## 4. Reading-the-Config Policy
+
+Readers MUST treat a missing key as "uninitialized; trigger onboarding flow" — NOT as "default to a safe value". Silent defaults hide configuration drift and mask missing onboarding steps. This is a deliberate design choice.

--- a/mcp/trajectory-server/src/db.ts
+++ b/mcp/trajectory-server/src/db.ts
@@ -1,18 +1,74 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, existsSync, renameSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 
 export class TrajectoryDB {
+  static readonly TARGET_VERSION = 3;
+
   private db: Database.Database;
 
   constructor(dbPath: string) {
+    this.migrateOrBackup(dbPath);
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('foreign_keys = ON');
     this.db.pragma('busy_timeout = 5000');
     this.migrate();
+  }
+
+  private migrateOrBackup(dbPath: string): void {
+    if (dbPath === ':memory:' || !existsSync(dbPath)) return;
+
+    let existingVersion = 0;
+    let probeDb: Database.Database | null = null;
+
+    try {
+      probeDb = new Database(dbPath, { readonly: true });
+      const row = probeDb
+        .prepare('SELECT schema_version FROM plugin_meta LIMIT 1')
+        .get() as { schema_version: unknown } | undefined;
+      const raw = row?.schema_version;
+      const coerced = Number(raw);
+      existingVersion = Number.isNaN(coerced) ? 0 : coerced;
+    } catch {
+      existingVersion = 0;
+    } finally {
+      try {
+        probeDb?.close();
+      } catch {
+        // ignore close errors on probe
+      }
+    }
+
+    if (existingVersion === TrajectoryDB.TARGET_VERSION) return;
+
+    if (existingVersion > TrajectoryDB.TARGET_VERSION) {
+      throw new Error(
+        `TrajectoryDB: ${dbPath} has schema_version=${existingVersion} but this binary supports up to ${TrajectoryDB.TARGET_VERSION}. Upgrade the plugin or restore from backup.`,
+      );
+    }
+
+    if (existingVersion > 0) {
+      const backupPath = `${dbPath}.v${existingVersion}.bak.${Date.now()}`;
+      renameSync(dbPath, backupPath);
+
+      for (const suffix of ['-wal', '-shm']) {
+        const sidecar = `${dbPath}${suffix}`;
+        if (existsSync(sidecar)) {
+          try {
+            renameSync(sidecar, `${backupPath}${suffix}`);
+          } catch {
+            // sidecars may have been auto-cleaned; swallow
+          }
+        }
+      }
+
+      console.error(
+        `[TrajectoryDB] HARD-BREAK MIGRATION: schema_version=${existingVersion} backed up to ${backupPath}; initializing fresh at v${TrajectoryDB.TARGET_VERSION}`,
+      );
+    }
   }
 
   migrate(): void {

--- a/mcp/trajectory-server/src/middleware/agent-scope.ts
+++ b/mcp/trajectory-server/src/middleware/agent-scope.ts
@@ -2,7 +2,9 @@ import type { Issue } from '../types.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 export type AgentRole =
-  | 'secretary'
+  | 'gatekeeper'
+  | /** @deprecated v0.3 — use 'gatekeeper'; aliased in normalizeAgent */
+  'secretary'
   | 'architect'
   | 'swe'
   | 'pr-reviewer'
@@ -10,6 +12,7 @@ export type AgentRole =
   | 'unknown';
 
 const KNOWN_ROLES = new Set<AgentRole>([
+  'gatekeeper',
   'secretary',
   'architect',
   'swe',
@@ -20,6 +23,8 @@ const KNOWN_ROLES = new Set<AgentRole>([
 export function normalizeAgent(name?: string): AgentRole {
   if (!name) return 'unknown';
   const lower = name.toLowerCase() as AgentRole;
+  // Back-compat: v0.2 callers may still pass 'secretary'.
+  if (lower === 'secretary') return 'gatekeeper';
   return KNOWN_ROLES.has(lower) ? lower : 'unknown';
 }
 
@@ -38,6 +43,30 @@ export type Redactor<T> = (value: T, agent: AgentRole, args: Record<string, unkn
 
 type Fn = (args: Record<string, unknown>) => Promise<CallToolResult>;
 
+export function requireRoles(toolName: string, allowedRoles: AgentRole[], handler: Fn): Fn {
+  const allowed = new Set(allowedRoles);
+  return async (args) => {
+    const agent = normalizeAgent(args['agent'] as string | undefined);
+    if (!allowed.has(agent)) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              error: 'forbidden',
+              tool: toolName,
+              caller_role: agent,
+              allowed_roles: [...allowedRoles],
+            }),
+          },
+        ],
+      };
+    }
+    return handler(args);
+  };
+}
+
 export function redactIssue(
   issue: Issue,
   agent: AgentRole,
@@ -52,6 +81,8 @@ export function redactIssue(
     return { ...rest, objective: truncated };
   }
 
+  // gatekeeper is full-trust: same treatment as architect — no objective truncation,
+  // goals_md gated only on opts.include_goals.
   if (!opts?.include_goals) {
     const { goals_md: _, ...rest } = issue;
     void _;

--- a/mcp/trajectory-server/src/schema.sql
+++ b/mcp/trajectory-server/src/schema.sql
@@ -120,4 +120,38 @@ CREATE TABLE IF NOT EXISTS plugin_meta (
     updated_at     TEXT    NOT NULL DEFAULT (datetime('now'))
 );
 
-INSERT OR IGNORE INTO plugin_meta (schema_version, plugin_version) VALUES (2, '0.2.0');
+INSERT OR IGNORE INTO plugin_meta (schema_version, plugin_version) VALUES (3, '0.3.0-alpha');
+
+CREATE TABLE IF NOT EXISTS file_registry (
+    path             TEXT PRIMARY KEY,
+    type             TEXT NOT NULL DEFAULT 'unknown',
+    language         TEXT,
+    size_bytes       INTEGER,
+    last_commit_sha  TEXT,
+    last_change_type TEXT,
+    last_change_at   TEXT,
+    imports_json     TEXT NOT NULL DEFAULT '[]',
+    exports_json     TEXT NOT NULL DEFAULT '[]',
+    metadata_json    TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE TABLE IF NOT EXISTS plugin_config (
+    key        TEXT PRIMARY KEY,
+    value_json TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS identity (
+    id               INTEGER PRIMARY KEY CHECK (id = 1),
+    gatekeeper_name  TEXT NOT NULL DEFAULT 'bro',
+    human_name       TEXT,
+    created_at       TEXT NOT NULL,
+    updated_at       TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS regen_state (
+    target        TEXT PRIMARY KEY,
+    last_regen_at TEXT,
+    last_seen_sha TEXT,
+    notes         TEXT NOT NULL DEFAULT ''
+);

--- a/mcp/trajectory-server/src/test/agent-scope.test.ts
+++ b/mcp/trajectory-server/src/test/agent-scope.test.ts
@@ -4,9 +4,11 @@ import {
   normalizeAgent,
   redactIssue,
   redactValidationRow,
+  requireRoles,
 } from '../middleware/agent-scope.js';
 import type { Issue } from '../types.js';
-import type { ValidationAttempt } from '../middleware/agent-scope.js';
+import type { ValidationAttempt, AgentRole } from '../middleware/agent-scope.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 function makeIssue(overrides: Partial<Issue> = {}): Issue {
   return {
@@ -42,7 +44,7 @@ function makeValidationRow(overrides: Partial<ValidationAttempt> = {}): Validati
 
 describe('agent-scope middleware', () => {
   it('normalizeAgent maps known names correctly', () => {
-    assert.equal(normalizeAgent('secretary'), 'secretary');
+    assert.equal(normalizeAgent('gatekeeper'), 'gatekeeper');
     assert.equal(normalizeAgent('architect'), 'architect');
     assert.equal(normalizeAgent('swe'), 'swe');
     assert.equal(normalizeAgent('pr-reviewer'), 'pr-reviewer');
@@ -86,5 +88,64 @@ describe('agent-scope middleware', () => {
     const row = makeValidationRow({ task_id: 'task-mine' });
     const result = redactValidationRow(row, 'swe', { own_task_id: 'task-mine' });
     assert.equal(result.feedback_md, 'SENSITIVE FEEDBACK');
+  });
+
+  it('normalizeAgent gatekeeper returns gatekeeper', () => {
+    assert.equal(normalizeAgent('gatekeeper'), 'gatekeeper');
+  });
+
+  it('normalizeAgent Gatekeeper (mixed-case) returns gatekeeper', () => {
+    assert.equal(normalizeAgent('Gatekeeper'), 'gatekeeper');
+  });
+
+  it('normalizeAgent secretary returns gatekeeper (back-compat alias)', () => {
+    assert.equal(normalizeAgent('secretary'), 'gatekeeper');
+  });
+
+  it('normalizeAgent undefined returns unknown', () => {
+    assert.equal(normalizeAgent(undefined), 'unknown');
+  });
+
+  it('requireRoles returns forbidden when caller role is not allowed', async () => {
+    const passthrough = async (_args: Record<string, unknown>): Promise<CallToolResult> => ({
+      content: [{ type: 'text', text: JSON.stringify({ ok: true }) }],
+    });
+
+    const wrapped = requireRoles('identity_set', ['gatekeeper'], passthrough);
+    const result = await wrapped({ agent: 'swe' });
+
+    assert.ok(result.isError, 'Expected isError=true');
+    const payload = JSON.parse((result.content[0] as { type: string; text: string }).text);
+    assert.equal(payload.error, 'forbidden');
+    assert.equal(payload.caller_role, 'swe');
+    assert.deepEqual(payload.allowed_roles, ['gatekeeper']);
+  });
+
+  it('requireRoles delegates to handler when caller role is allowed', async () => {
+    let called = false;
+    const passthrough = async (_args: Record<string, unknown>): Promise<CallToolResult> => {
+      called = true;
+      return { content: [{ type: 'text', text: JSON.stringify({ ok: true }) }] };
+    };
+
+    const wrapped = requireRoles('identity_set', ['gatekeeper'], passthrough);
+    const result = await wrapped({ agent: 'gatekeeper' });
+
+    assert.ok(!result.isError, 'Expected no error');
+    assert.ok(called, 'Expected underlying handler to be invoked');
+  });
+
+  it('requireRoles allows secretary (aliased to gatekeeper) on gatekeeper-only tool', async () => {
+    let called = false;
+    const passthrough = async (_args: Record<string, unknown>): Promise<CallToolResult> => {
+      called = true;
+      return { content: [{ type: 'text', text: JSON.stringify({ ok: true }) }] };
+    };
+
+    const wrapped = requireRoles('identity_set', ['gatekeeper'], passthrough);
+    const result = await wrapped({ agent: 'secretary' });
+
+    assert.ok(!result.isError, 'Expected no error — secretary aliased to gatekeeper');
+    assert.ok(called, 'Expected underlying handler to be invoked');
   });
 });

--- a/mcp/trajectory-server/src/test/config.test.ts
+++ b/mcp/trajectory-server/src/test/config.test.ts
@@ -24,7 +24,7 @@ describe('configTools', () => {
     const db = tempDB();
     const tools = configTools(db);
 
-    await call(tools.handlers, 'config_set', { key: 'my.key', value: 'hello' });
+    await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'my.key', value: 'hello' });
     const result = await call(tools.handlers, 'config_get', { key: 'my.key' });
     assert.ok(!result.isError);
     assert.equal(parseResult(result), 'hello');
@@ -36,7 +36,7 @@ describe('configTools', () => {
     const db = tempDB();
     const tools = configTools(db);
 
-    await call(tools.handlers, 'config_set', { key: 'count', value: 42 });
+    await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'count', value: 42 });
     const result = await call(tools.handlers, 'config_get', { key: 'count' });
     assert.equal(parseResult(result), 42);
 
@@ -48,7 +48,7 @@ describe('configTools', () => {
     const tools = configTools(db);
 
     const obj = { branching: 'trunk', protected: ['main'] };
-    await call(tools.handlers, 'config_set', { key: 'settings', value: obj });
+    await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'settings', value: obj });
     const result = await call(tools.handlers, 'config_get', { key: 'settings' });
     assert.deepEqual(parseResult(result), obj);
 
@@ -59,7 +59,7 @@ describe('configTools', () => {
     const db = tempDB();
     const tools = configTools(db);
 
-    await call(tools.handlers, 'config_set', { key: 'branches', value: ['main', 'dev'] });
+    await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'branches', value: ['main', 'dev'] });
     const result = await call(tools.handlers, 'config_get', { key: 'branches' });
     assert.deepEqual(parseResult(result), ['main', 'dev']);
 
@@ -70,7 +70,7 @@ describe('configTools', () => {
     const db = tempDB();
     const tools = configTools(db);
 
-    await call(tools.handlers, 'config_set', { key: 'nullable', value: null });
+    await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'nullable', value: null });
     const result = await call(tools.handlers, 'config_get', { key: 'nullable' });
     assert.equal(parseResult(result), null);
 
@@ -81,7 +81,7 @@ describe('configTools', () => {
     const db = tempDB();
     const tools = configTools(db);
 
-    const result = await call(tools.handlers, 'config_set', { key: '', value: 'x' });
+    const result = await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: '', value: 'x' });
     assert.ok(result.isError, 'Expected error for empty key');
     assert.match(parseResult(result).error, /Invalid config key/);
 
@@ -92,7 +92,7 @@ describe('configTools', () => {
     const db = tempDB();
     const tools = configTools(db);
 
-    const result = await call(tools.handlers, 'config_set', { key: '1invalid', value: 'x' });
+    const result = await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: '1invalid', value: 'x' });
     assert.ok(result.isError, 'Expected error for leading digit');
     assert.match(parseResult(result).error, /Invalid config key/);
 
@@ -103,7 +103,7 @@ describe('configTools', () => {
     const db = tempDB();
     const tools = configTools(db);
 
-    const result = await call(tools.handlers, 'config_set', { key: 'bad key', value: 'x' });
+    const result = await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'bad key', value: 'x' });
     assert.ok(result.isError, 'Expected error for key with space');
     assert.match(parseResult(result).error, /Invalid config key/);
 
@@ -136,7 +136,7 @@ describe('configTools', () => {
     const db = tempDB();
     const tools = configTools(db);
 
-    await call(tools.handlers, 'config_set', { key: 'alpha', value: 'one' });
+    await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'alpha', value: 'one' });
     const result = await call(tools.handlers, 'config_list', {});
     assert.ok(!result.isError);
     assert.deepEqual(parseResult(result), { alpha: 'one' });
@@ -148,9 +148,9 @@ describe('configTools', () => {
     const db = tempDB();
     const tools = configTools(db);
 
-    await call(tools.handlers, 'config_set', { key: 'alpha', value: 1 });
-    await call(tools.handlers, 'config_set', { key: 'beta', value: 2 });
-    await call(tools.handlers, 'config_set', { key: 'gamma', value: 3 });
+    await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'alpha', value: 1 });
+    await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'beta', value: 2 });
+    await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'gamma', value: 3 });
     const result = await call(tools.handlers, 'config_list', {});
     assert.ok(!result.isError);
     assert.deepEqual(parseResult(result), { alpha: 1, beta: 2, gamma: 3 });
@@ -162,12 +162,12 @@ describe('configTools', () => {
     const db = tempDB();
     const tools = configTools(db);
 
-    const first = await call(tools.handlers, 'config_set', { key: 'evolving', value: 'v1' });
+    const first = await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'evolving', value: 'v1' });
     const firstTs = parseResult(first).updated_at as string;
 
     await new Promise((res) => setTimeout(res, 5));
 
-    const second = await call(tools.handlers, 'config_set', { key: 'evolving', value: 'v2' });
+    const second = await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'evolving', value: 'v2' });
     const secondTs = parseResult(second).updated_at as string;
 
     assert.ok(secondTs >= firstTs, 'second updated_at must be >= first');
@@ -184,8 +184,54 @@ describe('configTools', () => {
 
     const key = 'a' + 'b'.repeat(63);
     assert.equal(key.length, 64);
-    const result = await call(tools.handlers, 'config_set', { key, value: 'ok' });
+    const result = await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key, value: 'ok' });
     assert.ok(!result.isError, 'A 64-char key should be valid');
+
+    db.close();
+  });
+
+  it('config_set called with agent=swe returns forbidden', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    const result = await call(tools.handlers, 'config_set', { agent: 'swe', key: 'blocked', value: 'x' });
+    assert.ok(result.isError, 'Expected forbidden error');
+    const payload = parseResult(result);
+    assert.equal(payload.error, 'forbidden');
+    assert.equal(payload.caller_role, 'swe');
+
+    db.close();
+  });
+
+  it('config_set called with agent=architect succeeds', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    const result = await call(tools.handlers, 'config_set', { agent: 'architect', key: 'arch.key', value: 42 });
+    assert.ok(!result.isError, 'Expected architect to be allowed');
+    assert.equal(parseResult(result).key, 'arch.key');
+
+    db.close();
+  });
+
+  it('config_set called with agent=gatekeeper succeeds', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    const result = await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'gate.key', value: true });
+    assert.ok(!result.isError, 'Expected gatekeeper to be allowed');
+
+    db.close();
+  });
+
+  it('config_get called with agent=swe succeeds (read open to all)', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'open.key', value: 'readable' });
+    const result = await call(tools.handlers, 'config_get', { agent: 'swe', key: 'open.key' });
+    assert.ok(!result.isError, 'Read should be open to all agents');
+    assert.equal(parseResult(result), 'readable');
 
     db.close();
   });

--- a/mcp/trajectory-server/src/test/config.test.ts
+++ b/mcp/trajectory-server/src/test/config.test.ts
@@ -1,0 +1,192 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { tempDB } from './helpers.js';
+import { configTools } from '../tools/config.js';
+
+type RawResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+async function call(
+  handlers: Record<string, (args: Record<string, unknown>) => Promise<unknown>>,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<RawResult> {
+  const handler = handlers[name];
+  assert.ok(handler, `Handler not found: ${name}`);
+  return handler(args) as unknown as RawResult;
+}
+
+function parseResult(result: RawResult) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('configTools', () => {
+  it('config_set + config_get round-trip: string', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    await call(tools.handlers, 'config_set', { key: 'my.key', value: 'hello' });
+    const result = await call(tools.handlers, 'config_get', { key: 'my.key' });
+    assert.ok(!result.isError);
+    assert.equal(parseResult(result), 'hello');
+
+    db.close();
+  });
+
+  it('config_set + config_get round-trip: number', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    await call(tools.handlers, 'config_set', { key: 'count', value: 42 });
+    const result = await call(tools.handlers, 'config_get', { key: 'count' });
+    assert.equal(parseResult(result), 42);
+
+    db.close();
+  });
+
+  it('config_set + config_get round-trip: object', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    const obj = { branching: 'trunk', protected: ['main'] };
+    await call(tools.handlers, 'config_set', { key: 'settings', value: obj });
+    const result = await call(tools.handlers, 'config_get', { key: 'settings' });
+    assert.deepEqual(parseResult(result), obj);
+
+    db.close();
+  });
+
+  it('config_set + config_get round-trip: array', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    await call(tools.handlers, 'config_set', { key: 'branches', value: ['main', 'dev'] });
+    const result = await call(tools.handlers, 'config_get', { key: 'branches' });
+    assert.deepEqual(parseResult(result), ['main', 'dev']);
+
+    db.close();
+  });
+
+  it('config_set + config_get round-trip: null', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    await call(tools.handlers, 'config_set', { key: 'nullable', value: null });
+    const result = await call(tools.handlers, 'config_get', { key: 'nullable' });
+    assert.equal(parseResult(result), null);
+
+    db.close();
+  });
+
+  it('config_set with invalid key: empty string', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    const result = await call(tools.handlers, 'config_set', { key: '', value: 'x' });
+    assert.ok(result.isError, 'Expected error for empty key');
+    assert.match(parseResult(result).error, /Invalid config key/);
+
+    db.close();
+  });
+
+  it('config_set with invalid key: leading digit', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    const result = await call(tools.handlers, 'config_set', { key: '1invalid', value: 'x' });
+    assert.ok(result.isError, 'Expected error for leading digit');
+    assert.match(parseResult(result).error, /Invalid config key/);
+
+    db.close();
+  });
+
+  it('config_set with invalid key: contains space', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    const result = await call(tools.handlers, 'config_set', { key: 'bad key', value: 'x' });
+    assert.ok(result.isError, 'Expected error for key with space');
+    assert.match(parseResult(result).error, /Invalid config key/);
+
+    db.close();
+  });
+
+  it('config_get for missing key returns null (not error)', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    const result = await call(tools.handlers, 'config_get', { key: 'nonexistent' });
+    assert.ok(!result.isError, 'Should not be an error');
+    assert.equal(parseResult(result), null);
+
+    db.close();
+  });
+
+  it('config_list with 0 entries returns empty object', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    const result = await call(tools.handlers, 'config_list', {});
+    assert.ok(!result.isError);
+    assert.deepEqual(parseResult(result), {});
+
+    db.close();
+  });
+
+  it('config_list with 1 entry returns correct shape', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    await call(tools.handlers, 'config_set', { key: 'alpha', value: 'one' });
+    const result = await call(tools.handlers, 'config_list', {});
+    assert.ok(!result.isError);
+    assert.deepEqual(parseResult(result), { alpha: 'one' });
+
+    db.close();
+  });
+
+  it('config_list with 3 entries returns correct shape', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    await call(tools.handlers, 'config_set', { key: 'alpha', value: 1 });
+    await call(tools.handlers, 'config_set', { key: 'beta', value: 2 });
+    await call(tools.handlers, 'config_set', { key: 'gamma', value: 3 });
+    const result = await call(tools.handlers, 'config_list', {});
+    assert.ok(!result.isError);
+    assert.deepEqual(parseResult(result), { alpha: 1, beta: 2, gamma: 3 });
+
+    db.close();
+  });
+
+  it('config_set called twice on same key updates value and bumps updated_at', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    const first = await call(tools.handlers, 'config_set', { key: 'evolving', value: 'v1' });
+    const firstTs = parseResult(first).updated_at as string;
+
+    await new Promise((res) => setTimeout(res, 5));
+
+    const second = await call(tools.handlers, 'config_set', { key: 'evolving', value: 'v2' });
+    const secondTs = parseResult(second).updated_at as string;
+
+    assert.ok(secondTs >= firstTs, 'second updated_at must be >= first');
+
+    const getResult = await call(tools.handlers, 'config_get', { key: 'evolving' });
+    assert.equal(parseResult(getResult), 'v2');
+
+    db.close();
+  });
+
+  it('config_set with 64-char key is accepted (boundary inclusive)', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    const key = 'a' + 'b'.repeat(63);
+    assert.equal(key.length, 64);
+    const result = await call(tools.handlers, 'config_set', { key, value: 'ok' });
+    assert.ok(!result.isError, 'A 64-char key should be valid');
+
+    db.close();
+  });
+});

--- a/mcp/trajectory-server/src/test/config_keys_contract.test.ts
+++ b/mcp/trajectory-server/src/test/config_keys_contract.test.ts
@@ -1,0 +1,86 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tempDB } from './helpers.js';
+import { configTools } from '../tools/config.js';
+
+const docsPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../docs/CONFIG_KEYS.md',
+);
+
+const docContent = readFileSync(docsPath, 'utf8');
+
+type RawResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+function parseResult(result: RawResult) {
+  return JSON.parse(result.content[0].text);
+}
+
+async function call(
+  handlers: Record<string, (args: Record<string, unknown>) => Promise<unknown>>,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<RawResult> {
+  const handler = handlers[name];
+  assert.ok(handler, `Handler not found: ${name}`);
+  return handler(args) as unknown as RawResult;
+}
+
+describe('config_keys_contract', () => {
+  it('docs/CONFIG_KEYS.md names all three registered keys', () => {
+    assert.ok(docContent.includes('branching_model'), 'branching_model missing from docs');
+    assert.ok(docContent.includes('pr_target'), 'pr_target missing from docs');
+    assert.ok(docContent.includes('protected_branches'), 'protected_branches missing from docs');
+  });
+
+  it('docs/CONFIG_KEYS.md names all three branching_model values', () => {
+    assert.ok(docContent.includes('github-flow'), 'github-flow missing from docs');
+    assert.ok(docContent.includes('gitflow'), 'gitflow missing from docs');
+    assert.ok(docContent.includes('custom'), 'custom missing from docs');
+  });
+
+  it('round-trips branching_model = "github-flow" (string)', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    await call(tools.handlers, 'config_set', { key: 'branching_model', value: 'github-flow' });
+    const result = await call(tools.handlers, 'config_get', { key: 'branching_model' });
+    assert.ok(!result.isError);
+    const value = parseResult(result);
+    assert.equal(typeof value, 'string');
+    assert.equal(value, 'github-flow');
+
+    db.close();
+  });
+
+  it('round-trips pr_target = "main" (string)', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    await call(tools.handlers, 'config_set', { key: 'pr_target', value: 'main' });
+    const result = await call(tools.handlers, 'config_get', { key: 'pr_target' });
+    assert.ok(!result.isError);
+    const value = parseResult(result);
+    assert.equal(typeof value, 'string');
+    assert.equal(value, 'main');
+
+    db.close();
+  });
+
+  it('round-trips protected_branches = ["main"] (array)', async () => {
+    const db = tempDB();
+    const tools = configTools(db);
+
+    await call(tools.handlers, 'config_set', { key: 'protected_branches', value: ['main'] });
+    const result = await call(tools.handlers, 'config_get', { key: 'protected_branches' });
+    assert.ok(!result.isError);
+    const value = parseResult(result);
+    assert.ok(Array.isArray(value), 'protected_branches must be an array');
+    assert.deepEqual(value, ['main']);
+
+    db.close();
+  });
+});

--- a/mcp/trajectory-server/src/test/config_keys_contract.test.ts
+++ b/mcp/trajectory-server/src/test/config_keys_contract.test.ts
@@ -46,7 +46,7 @@ describe('config_keys_contract', () => {
     const db = tempDB();
     const tools = configTools(db);
 
-    await call(tools.handlers, 'config_set', { key: 'branching_model', value: 'github-flow' });
+    await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'branching_model', value: 'github-flow' });
     const result = await call(tools.handlers, 'config_get', { key: 'branching_model' });
     assert.ok(!result.isError);
     const value = parseResult(result);
@@ -60,7 +60,7 @@ describe('config_keys_contract', () => {
     const db = tempDB();
     const tools = configTools(db);
 
-    await call(tools.handlers, 'config_set', { key: 'pr_target', value: 'main' });
+    await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'pr_target', value: 'main' });
     const result = await call(tools.handlers, 'config_get', { key: 'pr_target' });
     assert.ok(!result.isError);
     const value = parseResult(result);
@@ -74,7 +74,7 @@ describe('config_keys_contract', () => {
     const db = tempDB();
     const tools = configTools(db);
 
-    await call(tools.handlers, 'config_set', { key: 'protected_branches', value: ['main'] });
+    await call(tools.handlers, 'config_set', { agent: 'gatekeeper', key: 'protected_branches', value: ['main'] });
     const result = await call(tools.handlers, 'config_get', { key: 'protected_branches' });
     assert.ok(!result.isError);
     const value = parseResult(result);

--- a/mcp/trajectory-server/src/test/db.test.ts
+++ b/mcp/trajectory-server/src/test/db.test.ts
@@ -4,7 +4,7 @@ import { tempDB } from './helpers.js';
 import { nowISO, genId } from '../db.js';
 
 describe('TrajectoryDB', () => {
-  it('opens an in-memory DB and verifies all 9 tables exist with schema_version=2', () => {
+  it('opens an in-memory DB and verifies all 13 tables exist with schema_version=3', () => {
     const db = tempDB();
 
     const expectedTables = [
@@ -17,6 +17,10 @@ describe('TrajectoryDB', () => {
       'roundtables',
       'roundtable_votes',
       'plugin_meta',
+      'file_registry',
+      'plugin_config',
+      'identity',
+      'regen_state',
     ];
 
     const rows = db.all<{ name: string }>(
@@ -31,7 +35,7 @@ describe('TrajectoryDB', () => {
       'SELECT schema_version FROM plugin_meta LIMIT 1',
     );
     assert.ok(meta !== undefined, 'plugin_meta should have a row');
-    assert.equal(meta.schema_version, 2);
+    assert.equal(meta.schema_version, 3);
 
     db.close();
   });

--- a/mcp/trajectory-server/src/test/identity.test.ts
+++ b/mcp/trajectory-server/src/test/identity.test.ts
@@ -50,7 +50,7 @@ describe('identityTools', () => {
     const db = tempDB();
     const tools = identityTools(db);
 
-    const setResult = await call(tools.handlers, 'identity_set', { gatekeeper_name: 'mybot' });
+    const setResult = await call(tools.handlers, 'identity_set', { agent: 'gatekeeper', gatekeeper_name: 'mybot' });
     assert.ok(!setResult.isError);
     const set = parseResult(setResult);
     assert.equal(set.gatekeeper_name, 'mybot');
@@ -68,8 +68,8 @@ describe('identityTools', () => {
     const db = tempDB();
     const tools = identityTools(db);
 
-    await call(tools.handlers, 'identity_set', { gatekeeper_name: 'mybot' });
-    await call(tools.handlers, 'identity_set', { human_name: 'Alice' });
+    await call(tools.handlers, 'identity_set', { agent: 'gatekeeper', gatekeeper_name: 'mybot' });
+    await call(tools.handlers, 'identity_set', { agent: 'gatekeeper', human_name: 'Alice' });
 
     const result = await call(tools.handlers, 'identity_get', {});
     const data = parseResult(result);
@@ -83,7 +83,7 @@ describe('identityTools', () => {
     const db = tempDB();
     const tools = identityTools(db);
 
-    const result = await call(tools.handlers, 'identity_set', { gatekeeper_name: '' });
+    const result = await call(tools.handlers, 'identity_set', { agent: 'gatekeeper', gatekeeper_name: '' });
     assert.ok(result.isError, 'Expected error for empty gatekeeper_name');
     assert.match(parseResult(result).error, /Invalid gatekeeper_name/);
 
@@ -95,7 +95,7 @@ describe('identityTools', () => {
     const tools = identityTools(db);
 
     const longName = 'a'.repeat(33);
-    const result = await call(tools.handlers, 'identity_set', { gatekeeper_name: longName });
+    const result = await call(tools.handlers, 'identity_set', { agent: 'gatekeeper', gatekeeper_name: longName });
     assert.ok(result.isError, 'Expected error for 33-char name');
     assert.match(parseResult(result).error, /Invalid gatekeeper_name/);
 
@@ -106,7 +106,7 @@ describe('identityTools', () => {
     const db = tempDB();
     const tools = identityTools(db);
 
-    const result = await call(tools.handlers, 'identity_set', { gatekeeper_name: 'bad\x01name' });
+    const result = await call(tools.handlers, 'identity_set', { agent: 'gatekeeper', gatekeeper_name: 'bad\x01name' });
     assert.ok(result.isError, 'Expected error for control char in name');
     assert.match(parseResult(result).error, /Invalid gatekeeper_name/);
 
@@ -117,7 +117,7 @@ describe('identityTools', () => {
     const db = tempDB();
     const tools = identityTools(db);
 
-    const result = await call(tools.handlers, 'identity_set', { human_name: '' });
+    const result = await call(tools.handlers, 'identity_set', { agent: 'gatekeeper', human_name: '' });
     assert.ok(result.isError, 'Expected error for empty human_name');
     assert.match(parseResult(result).error, /Invalid human_name/);
 
@@ -128,9 +128,9 @@ describe('identityTools', () => {
     const db = tempDB();
     const tools = identityTools(db);
 
-    await call(tools.handlers, 'identity_set', { gatekeeper_name: 'mybot', human_name: 'Alice' });
+    await call(tools.handlers, 'identity_set', { agent: 'gatekeeper', gatekeeper_name: 'mybot', human_name: 'Alice' });
 
-    const resetResult = await call(tools.handlers, 'identity_reset', {});
+    const resetResult = await call(tools.handlers, 'identity_reset', { agent: 'gatekeeper' });
     assert.ok(!resetResult.isError);
     assert.deepEqual(parseResult(resetResult), { ok: true });
 
@@ -148,7 +148,7 @@ describe('identityTools', () => {
     const db = tempDB();
     const tools = identityTools(db);
 
-    const result = await call(tools.handlers, 'identity_reset', {});
+    const result = await call(tools.handlers, 'identity_reset', { agent: 'gatekeeper' });
     assert.ok(!result.isError);
     assert.deepEqual(parseResult(result), { ok: true });
 
@@ -159,11 +159,38 @@ describe('identityTools', () => {
     const db = tempDB();
     const tools = identityTools(db);
 
-    await call(tools.handlers, 'identity_set', { gatekeeper_name: 'mybot' });
-    const result = await call(tools.handlers, 'identity_set', {});
+    await call(tools.handlers, 'identity_set', { agent: 'gatekeeper', gatekeeper_name: 'mybot' });
+    const result = await call(tools.handlers, 'identity_set', { agent: 'gatekeeper' });
     assert.ok(!result.isError);
     const data = parseResult(result);
     assert.equal(data.gatekeeper_name, 'mybot');
+
+    db.close();
+  });
+
+  it('identity_set called with agent=swe returns forbidden; row unchanged', async () => {
+    const db = tempDB();
+    const tools = identityTools(db);
+
+    const result = await call(tools.handlers, 'identity_set', { agent: 'swe', gatekeeper_name: 'hacked' });
+    assert.ok(result.isError, 'Expected forbidden error');
+    const payload = parseResult(result);
+    assert.equal(payload.error, 'forbidden');
+    assert.equal(payload.caller_role, 'swe');
+
+    const row = db.get('SELECT * FROM identity LIMIT 1');
+    assert.equal(row, undefined, 'Row must not be created when forbidden');
+
+    db.close();
+  });
+
+  it('identity_set called with agent=gatekeeper succeeds', async () => {
+    const db = tempDB();
+    const tools = identityTools(db);
+
+    const result = await call(tools.handlers, 'identity_set', { agent: 'gatekeeper', gatekeeper_name: 'mybot' });
+    assert.ok(!result.isError, 'Expected success for gatekeeper');
+    assert.equal(parseResult(result).gatekeeper_name, 'mybot');
 
     db.close();
   });

--- a/mcp/trajectory-server/src/test/identity.test.ts
+++ b/mcp/trajectory-server/src/test/identity.test.ts
@@ -1,0 +1,192 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { tempDB } from './helpers.js';
+import { identityTools } from '../tools/identity.js';
+
+type RawResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+async function call(
+  handlers: Record<string, (args: Record<string, unknown>) => Promise<unknown>>,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<RawResult> {
+  const handler = handlers[name];
+  assert.ok(handler, `Handler not found: ${name}`);
+  return handler(args) as unknown as RawResult;
+}
+
+function parseResult(result: RawResult) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('identityTools', () => {
+  it('identity_get on empty table returns default with gatekeeper_name=bro', async () => {
+    const db = tempDB();
+    const tools = identityTools(db);
+
+    const result = await call(tools.handlers, 'identity_get', {});
+    assert.ok(!result.isError);
+    const data = parseResult(result);
+    assert.equal(data.gatekeeper_name, 'bro');
+    assert.equal(data.human_name, null);
+    assert.equal(data.created_at, null);
+    assert.equal(data.updated_at, null);
+
+    db.close();
+  });
+
+  it('identity_get on empty table does not seed a row', async () => {
+    const db = tempDB();
+    const tools = identityTools(db);
+
+    await call(tools.handlers, 'identity_get', {});
+    const row = db.get('SELECT * FROM identity LIMIT 1');
+    assert.equal(row, undefined, 'identity_get must not seed a row');
+
+    db.close();
+  });
+
+  it('identity_set with gatekeeper_name only: persists; human_name still null', async () => {
+    const db = tempDB();
+    const tools = identityTools(db);
+
+    const setResult = await call(tools.handlers, 'identity_set', { gatekeeper_name: 'mybot' });
+    assert.ok(!setResult.isError);
+    const set = parseResult(setResult);
+    assert.equal(set.gatekeeper_name, 'mybot');
+    assert.equal(set.human_name, null);
+
+    const getResult = await call(tools.handlers, 'identity_get', {});
+    const got = parseResult(getResult);
+    assert.equal(got.gatekeeper_name, 'mybot');
+    assert.equal(got.human_name, null);
+
+    db.close();
+  });
+
+  it('identity_set with human_name only after gatekeeper_name: gatekeeper_name preserved', async () => {
+    const db = tempDB();
+    const tools = identityTools(db);
+
+    await call(tools.handlers, 'identity_set', { gatekeeper_name: 'mybot' });
+    await call(tools.handlers, 'identity_set', { human_name: 'Alice' });
+
+    const result = await call(tools.handlers, 'identity_get', {});
+    const data = parseResult(result);
+    assert.equal(data.gatekeeper_name, 'mybot', 'gatekeeper_name must be preserved (COALESCE)');
+    assert.equal(data.human_name, 'Alice');
+
+    db.close();
+  });
+
+  it('identity_set with invalid gatekeeper_name: empty string', async () => {
+    const db = tempDB();
+    const tools = identityTools(db);
+
+    const result = await call(tools.handlers, 'identity_set', { gatekeeper_name: '' });
+    assert.ok(result.isError, 'Expected error for empty gatekeeper_name');
+    assert.match(parseResult(result).error, /Invalid gatekeeper_name/);
+
+    db.close();
+  });
+
+  it('identity_set with invalid gatekeeper_name: 33 characters', async () => {
+    const db = tempDB();
+    const tools = identityTools(db);
+
+    const longName = 'a'.repeat(33);
+    const result = await call(tools.handlers, 'identity_set', { gatekeeper_name: longName });
+    assert.ok(result.isError, 'Expected error for 33-char name');
+    assert.match(parseResult(result).error, /Invalid gatekeeper_name/);
+
+    db.close();
+  });
+
+  it('identity_set with invalid gatekeeper_name: control character', async () => {
+    const db = tempDB();
+    const tools = identityTools(db);
+
+    const result = await call(tools.handlers, 'identity_set', { gatekeeper_name: 'bad\x01name' });
+    assert.ok(result.isError, 'Expected error for control char in name');
+    assert.match(parseResult(result).error, /Invalid gatekeeper_name/);
+
+    db.close();
+  });
+
+  it('identity_set with invalid human_name: empty string', async () => {
+    const db = tempDB();
+    const tools = identityTools(db);
+
+    const result = await call(tools.handlers, 'identity_set', { human_name: '' });
+    assert.ok(result.isError, 'Expected error for empty human_name');
+    assert.match(parseResult(result).error, /Invalid human_name/);
+
+    db.close();
+  });
+
+  it('identity_reset clears the row; identity_get returns defaults again', async () => {
+    const db = tempDB();
+    const tools = identityTools(db);
+
+    await call(tools.handlers, 'identity_set', { gatekeeper_name: 'mybot', human_name: 'Alice' });
+
+    const resetResult = await call(tools.handlers, 'identity_reset', {});
+    assert.ok(!resetResult.isError);
+    assert.deepEqual(parseResult(resetResult), { ok: true });
+
+    const getResult = await call(tools.handlers, 'identity_get', {});
+    const data = parseResult(getResult);
+    assert.equal(data.gatekeeper_name, 'bro');
+    assert.equal(data.human_name, null);
+    assert.equal(data.created_at, null);
+    assert.equal(data.updated_at, null);
+
+    db.close();
+  });
+
+  it('identity_reset on already-empty table: no-op, returns { ok: true }', async () => {
+    const db = tempDB();
+    const tools = identityTools(db);
+
+    const result = await call(tools.handlers, 'identity_reset', {});
+    assert.ok(!result.isError);
+    assert.deepEqual(parseResult(result), { ok: true });
+
+    db.close();
+  });
+
+  it('identity_set with both fields omitted: no-op, returns current state', async () => {
+    const db = tempDB();
+    const tools = identityTools(db);
+
+    await call(tools.handlers, 'identity_set', { gatekeeper_name: 'mybot' });
+    const result = await call(tools.handlers, 'identity_set', {});
+    assert.ok(!result.isError);
+    const data = parseResult(result);
+    assert.equal(data.gatekeeper_name, 'mybot');
+
+    db.close();
+  });
+
+  it('identity table CHECK constraint: INSERT id=2 via raw SQL fails', async () => {
+    const db = tempDB();
+    const now = new Date().toISOString();
+
+    assert.throws(
+      () =>
+        db.run(
+          `INSERT INTO identity (id, gatekeeper_name, created_at, updated_at) VALUES (2, 'other', ?, ?)`,
+          [now, now],
+        ),
+      (e: Error) => {
+        assert.ok(
+          e.message.includes('SQLITE_CONSTRAINT') || e.message.toLowerCase().includes('constraint'),
+          `Expected constraint error, got: ${e.message}`,
+        );
+        return true;
+      },
+    );
+
+    db.close();
+  });
+});

--- a/mcp/trajectory-server/src/test/migration.test.ts
+++ b/mcp/trajectory-server/src/test/migration.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, existsSync, writeFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { TrajectoryDB } from '../db.js';
+
+const V2_SCHEMA = `
+CREATE TABLE IF NOT EXISTS issues (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  parent_issue_id INTEGER REFERENCES issues(id),
+  objective TEXT NOT NULL,
+  goals_md TEXT NOT NULL DEFAULT '',
+  goals_md_hash TEXT NOT NULL DEFAULT '',
+  pre_commit_hash TEXT NOT NULL DEFAULT '',
+  post_commit_hash TEXT,
+  status TEXT NOT NULL DEFAULT 'open',
+  current_task_id INTEGER REFERENCES tasks(id),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  closed_at TEXT
+);
+CREATE TABLE IF NOT EXISTS tasks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  issue_id INTEGER NOT NULL REFERENCES issues(id),
+  branch_id TEXT NOT NULL,
+  parent_branch_id TEXT,
+  title TEXT NOT NULL DEFAULT '',
+  description TEXT NOT NULL,
+  tools_required TEXT NOT NULL DEFAULT '[]',
+  skills_required TEXT NOT NULL DEFAULT '[]',
+  success_criteria TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  execution_plan_md TEXT NOT NULL DEFAULT '',
+  qa_results TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_issue_branch ON tasks(issue_id, branch_id);
+CREATE TABLE IF NOT EXISTS ledger (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  issue_id INTEGER NOT NULL REFERENCES issues(id),
+  branch_id TEXT,
+  from_node TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  summary TEXT NOT NULL DEFAULT '',
+  content TEXT NOT NULL DEFAULT '{}',
+  is_truncated INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS audit (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  issue_id INTEGER NOT NULL REFERENCES issues(id),
+  branch_id TEXT,
+  from_node TEXT NOT NULL DEFAULT 'executor',
+  round INTEGER NOT NULL DEFAULT 0,
+  tool_name TEXT NOT NULL,
+  tool_args TEXT NOT NULL DEFAULT '{}',
+  output TEXT NOT NULL DEFAULT '',
+  output_chars INTEGER NOT NULL DEFAULT 0,
+  is_truncated INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS validation_attempts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  task_id TEXT NOT NULL,
+  attempt_n INTEGER NOT NULL,
+  agent TEXT NOT NULL DEFAULT '',
+  verdict TEXT NOT NULL,
+  feedback_md TEXT NOT NULL DEFAULT '',
+  reviewer_verdict TEXT,
+  created_at TEXT NOT NULL,
+  UNIQUE(task_id, attempt_n)
+);
+CREATE TABLE IF NOT EXISTS skills (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL,
+  file_path TEXT NOT NULL,
+  tags TEXT NOT NULL DEFAULT '[]',
+  created_by TEXT NOT NULL DEFAULT 'system',
+  trust_tier TEXT NOT NULL DEFAULT 'curated',
+  status TEXT NOT NULL DEFAULT 'active',
+  when_to_use TEXT NOT NULL DEFAULT '',
+  when_not_to_use TEXT NOT NULL DEFAULT '',
+  uses INTEGER NOT NULL DEFAULT 0,
+  successes INTEGER NOT NULL DEFAULT 0,
+  failures INTEGER NOT NULL DEFAULT 0,
+  effectiveness REAL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS roundtables (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  issue_id INTEGER NOT NULL REFERENCES issues(id),
+  topic TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'open',
+  outcome TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL,
+  closed_at TEXT
+);
+CREATE TABLE IF NOT EXISTS roundtable_votes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  roundtable_id INTEGER NOT NULL REFERENCES roundtables(id),
+  agent TEXT NOT NULL,
+  vote TEXT NOT NULL,
+  rationale TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS plugin_meta (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  schema_version INTEGER NOT NULL,
+  plugin_version TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+INSERT OR IGNORE INTO plugin_meta (schema_version, plugin_version) VALUES (2, '0.2.0');
+`;
+
+function makeV2DB(path: string): void {
+  const raw = new Database(path);
+  raw.exec(V2_SCHEMA);
+  raw.close();
+}
+
+function makeSyntheticDB(path: string, version: number): void {
+  const raw = new Database(path);
+  raw.exec(`
+    CREATE TABLE plugin_meta (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      schema_version INTEGER NOT NULL,
+      plugin_version TEXT NOT NULL
+    );
+    INSERT INTO plugin_meta (schema_version, plugin_version) VALUES (${version}, '0.x.0');
+  `);
+  raw.close();
+}
+
+let tmpDirs: string[] = [];
+
+function makeTmpDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'tmb-migration-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+  tmpDirs = [];
+});
+
+describe('migration runner', () => {
+  it('a. fresh DB at non-existent path: no backup, schema_version=3, no error', () => {
+    const dir = makeTmpDir();
+    const dbPath = join(dir, 'fresh.db');
+
+    assert.ok(!existsSync(dbPath), 'file must not exist before open');
+
+    const db = new TrajectoryDB(dbPath);
+    const meta = db.get<{ schema_version: number }>(
+      'SELECT schema_version FROM plugin_meta LIMIT 1',
+    );
+    db.close();
+
+    assert.ok(meta !== undefined);
+    assert.equal(meta.schema_version, TrajectoryDB.TARGET_VERSION);
+
+    const backups = readdirSync(dir).filter((f) => f.includes('.bak.'));
+    assert.equal(backups.length, 0, 'no backup should be created for fresh DB');
+  });
+
+  it('b. existing v2 DB: backup created, fresh schema_version=3 at original path, backup has v2 data', () => {
+    const dir = makeTmpDir();
+    const dbPath = join(dir, 'v2.db');
+    makeV2DB(dbPath);
+
+    assert.ok(existsSync(dbPath));
+
+    const db = new TrajectoryDB(dbPath);
+    const meta = db.get<{ schema_version: number }>(
+      'SELECT schema_version FROM plugin_meta LIMIT 1',
+    );
+    db.close();
+
+    assert.ok(meta !== undefined);
+    assert.equal(meta.schema_version, TrajectoryDB.TARGET_VERSION);
+
+    const allFiles = readdirSync(dir);
+    const backupFiles = allFiles.filter((f) => f.match(/v2\.db\.v2\.bak\.\d+$/));
+    assert.equal(backupFiles.length, 1, 'exactly one backup file expected');
+
+    const backupPath = join(dir, backupFiles[0]);
+    const backupDb = new Database(backupPath, { readonly: true });
+    const backupMeta = backupDb
+      .prepare('SELECT schema_version FROM plugin_meta LIMIT 1')
+      .get() as { schema_version: number } | undefined;
+    backupDb.close();
+
+    assert.ok(backupMeta !== undefined);
+    assert.equal(backupMeta.schema_version, 2, 'backup should contain original v2 data');
+  });
+
+  it('c. existing v3 DB: no backup on re-open', () => {
+    const dir = makeTmpDir();
+    const dbPath = join(dir, 'current.db');
+
+    const db1 = new TrajectoryDB(dbPath);
+    db1.close();
+
+    const beforeFiles = readdirSync(dir);
+
+    const db2 = new TrajectoryDB(dbPath);
+    db2.close();
+
+    const afterFiles = readdirSync(dir);
+    const backups = afterFiles.filter((f) => f.includes('.bak.'));
+    assert.equal(backups.length, 0, 'no backup on re-open of already-initialized DB');
+    assert.equal(beforeFiles.length, afterFiles.length, 'no new files created on re-open');
+  });
+
+  it('d. DB with schema_version > 3 (v=99): constructor throws with clear error', () => {
+    const dir = makeTmpDir();
+    const dbPath = join(dir, 'future.db');
+    makeSyntheticDB(dbPath, 99);
+
+    assert.throws(
+      () => new TrajectoryDB(dbPath),
+      (err: Error) => {
+        assert.ok(
+          err.message.includes('schema_version=99'),
+          `message should mention schema_version=99: ${err.message}`,
+        );
+        assert.ok(
+          err.message.includes('supports up to 3'),
+          `message should mention 'supports up to 3': ${err.message}`,
+        );
+        return true;
+      },
+    );
+  });
+
+  it('e. in-memory DB: no fs side effects, schema_version=3', () => {
+    const db = new TrajectoryDB(':memory:');
+    const meta = db.get<{ schema_version: number }>(
+      'SELECT schema_version FROM plugin_meta LIMIT 1',
+    );
+    db.close();
+
+    assert.ok(meta !== undefined);
+    assert.equal(meta.schema_version, TrajectoryDB.TARGET_VERSION);
+  });
+
+  it('f. WAL + SHM sidecars: renamed alongside backup when v2 DB is backed up', () => {
+    const dir = makeTmpDir();
+    const dbPath = join(dir, 'wal.db');
+    makeV2DB(dbPath);
+
+    writeFileSync(`${dbPath}-wal`, 'fake-wal-content');
+    writeFileSync(`${dbPath}-shm`, 'fake-shm-content');
+
+    assert.ok(existsSync(`${dbPath}-wal`));
+    assert.ok(existsSync(`${dbPath}-shm`));
+
+    const db = new TrajectoryDB(dbPath);
+    db.close();
+
+    const allFiles = readdirSync(dir);
+    const backupBase = allFiles.find(
+      (f) => f.match(/wal\.db\.v2\.bak\.\d+$/) && !f.includes('-wal') && !f.includes('-shm'),
+    );
+    assert.ok(backupBase !== undefined, 'main backup file should exist');
+
+    assert.ok(
+      !existsSync(`${dbPath}-wal`),
+      'original -wal sidecar should no longer exist at original path',
+    );
+    assert.ok(
+      !existsSync(`${dbPath}-shm`),
+      'original -shm sidecar should no longer exist at original path',
+    );
+
+    const walBackup = allFiles.find((f) => f.match(/wal\.db\.v2\.bak\.\d+-wal$/));
+    const shmBackup = allFiles.find((f) => f.match(/wal\.db\.v2\.bak\.\d+-shm$/));
+    assert.ok(walBackup !== undefined, '-wal backup should exist alongside main backup');
+    assert.ok(shmBackup !== undefined, '-shm backup should exist alongside main backup');
+  });
+});

--- a/mcp/trajectory-server/src/test/schema_v3.test.ts
+++ b/mcp/trajectory-server/src/test/schema_v3.test.ts
@@ -1,0 +1,103 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { tempDB } from './helpers.js';
+
+describe('schema v3 — new foundation tables', () => {
+  it('fresh DB contains all 13 tables', () => {
+    const db = tempDB();
+
+    const expectedTables = [
+      'issues',
+      'tasks',
+      'ledger',
+      'audit',
+      'validation_attempts',
+      'skills',
+      'roundtables',
+      'roundtable_votes',
+      'plugin_meta',
+      'file_registry',
+      'plugin_config',
+      'identity',
+      'regen_state',
+    ];
+
+    const rows = db.all<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+    );
+    const actualNames = rows.map((r) => r.name).sort();
+    assert.deepEqual(actualNames, [...expectedTables].sort());
+
+    db.close();
+  });
+
+  it('fresh DB has schema_version = 3 in plugin_meta', () => {
+    const db = tempDB();
+
+    const meta = db.get<{ schema_version: number }>(
+      'SELECT schema_version FROM plugin_meta LIMIT 1',
+    );
+    assert.ok(meta !== undefined, 'plugin_meta must have a seed row');
+    assert.equal(meta.schema_version, 3);
+
+    db.close();
+  });
+
+  it('identity has zero rows on init', () => {
+    const db = tempDB();
+
+    const rows = db.all('SELECT * FROM identity');
+    assert.equal(rows.length, 0);
+
+    db.close();
+  });
+
+  it('plugin_config has zero rows on init', () => {
+    const db = tempDB();
+
+    const rows = db.all('SELECT * FROM plugin_config');
+    assert.equal(rows.length, 0);
+
+    db.close();
+  });
+
+  it('regen_state has zero rows on init', () => {
+    const db = tempDB();
+
+    const rows = db.all('SELECT * FROM regen_state');
+    assert.equal(rows.length, 0);
+
+    db.close();
+  });
+
+  it('file_registry has zero rows on init', () => {
+    const db = tempDB();
+
+    const rows = db.all('SELECT * FROM file_registry');
+    assert.equal(rows.length, 0);
+
+    db.close();
+  });
+
+  it('identity CHECK constraint rejects a second row with id != 1', () => {
+    const db = tempDB();
+    const now = new Date().toISOString();
+
+    db.run(
+      `INSERT INTO identity (id, gatekeeper_name, created_at, updated_at) VALUES (1, 'bro', ?, ?)`,
+      [now, now],
+    );
+
+    assert.throws(
+      () => {
+        db.run(
+          `INSERT INTO identity (id, gatekeeper_name, created_at, updated_at) VALUES (2, 'bro', ?, ?)`,
+          [now, now],
+        );
+      },
+      /CHECK constraint failed/,
+    );
+
+    db.close();
+  });
+});

--- a/mcp/trajectory-server/src/tools/config.ts
+++ b/mcp/trajectory-server/src/tools/config.ts
@@ -1,6 +1,7 @@
 import type { Tool, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { TrajectoryDB } from '../db.js';
 import { nowISO } from '../db.js';
+import { requireRoles } from '../middleware/agent-scope.js';
 
 type Fn = (args: Record<string, unknown>) => Promise<CallToolResult>;
 
@@ -66,7 +67,7 @@ export function configTools(db: TrajectoryDB): {
   ];
 
   const handlers: Record<string, Fn> = {
-    config_set: wrapHandler(async (args) => {
+    config_set: requireRoles('config_set', ['gatekeeper', 'architect'], wrapHandler(async (args) => {
       const key = args['key'];
       if (typeof key !== 'string' || !KEY_REGEX.test(key)) {
         return err(
@@ -92,7 +93,7 @@ export function configTools(db: TrajectoryDB): {
       );
 
       return ok({ key, updated_at: now });
-    }),
+    })),
 
     config_get: wrapHandler(async (args) => {
       const key = args['key'] as string;

--- a/mcp/trajectory-server/src/tools/config.ts
+++ b/mcp/trajectory-server/src/tools/config.ts
@@ -1,0 +1,141 @@
+import type { Tool, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { TrajectoryDB } from '../db.js';
+import { nowISO } from '../db.js';
+
+type Fn = (args: Record<string, unknown>) => Promise<CallToolResult>;
+
+function ok(data: unknown): CallToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+}
+
+function err(message: string): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ error: message }) }],
+    isError: true,
+  };
+}
+
+function wrapHandler(fn: (args: Record<string, unknown>) => Promise<CallToolResult>): Fn {
+  return async (args) => {
+    try {
+      return await fn(args);
+    } catch (e) {
+      return err((e as Error).message);
+    }
+  };
+}
+
+const KEY_REGEX = /^[a-z][a-z0-9_.-]{0,63}$/i;
+
+export function configTools(db: TrajectoryDB): {
+  definitions: Tool[];
+  handlers: Record<string, Fn>;
+} {
+  const definitions: Tool[] = [
+    {
+      name: 'config_set',
+      description: 'Set a plugin config key to a JSON-serializable value.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          key: { type: 'string', description: 'Config key (1-64 chars, must match /^[a-z][a-z0-9_.-]{0,63}$/i)' },
+          value: { description: 'Any JSON-serializable value' },
+        },
+        required: ['key', 'value'],
+      },
+    },
+    {
+      name: 'config_get',
+      description: 'Get a plugin config value by key. Returns null if not set.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          key: { type: 'string' },
+        },
+        required: ['key'],
+      },
+    },
+    {
+      name: 'config_list',
+      description: 'List all plugin config entries as a key→value object.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+    },
+  ];
+
+  const handlers: Record<string, Fn> = {
+    config_set: wrapHandler(async (args) => {
+      const key = args['key'];
+      if (typeof key !== 'string' || !KEY_REGEX.test(key)) {
+        return err(
+          `Invalid config key ${JSON.stringify(key)}: must match /^[a-z][a-z0-9_.-]{0,63}$/i`,
+        );
+      }
+
+      let valueJson: string;
+      try {
+        valueJson = JSON.stringify(args['value']);
+      } catch {
+        return err('config value not JSON-serializable');
+      }
+
+      const now = nowISO();
+      db.run(
+        `INSERT INTO plugin_config (key, value_json, updated_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(key) DO UPDATE SET
+           value_json = excluded.value_json,
+           updated_at = excluded.updated_at`,
+        [key, valueJson, now],
+      );
+
+      return ok({ key, updated_at: now });
+    }),
+
+    config_get: wrapHandler(async (args) => {
+      const key = args['key'] as string;
+      const row = db.get<{ key: string; value_json: string; updated_at: string }>(
+        `SELECT key, value_json, updated_at FROM plugin_config WHERE key = ?`,
+        [key],
+      );
+
+      if (!row) {
+        return ok(null);
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(row.value_json);
+      } catch {
+        return err(
+          `config key ${JSON.stringify(key)}: stored value is not valid JSON — raw: ${row.value_json.slice(0, 200)}`,
+        );
+      }
+
+      return ok(parsed);
+    }),
+
+    config_list: wrapHandler(async () => {
+      const rows = db.all<{ key: string; value_json: string }>(
+        `SELECT key, value_json FROM plugin_config ORDER BY key`,
+      );
+
+      const result: Record<string, unknown> = {};
+      for (const row of rows) {
+        try {
+          result[row.key] = JSON.parse(row.value_json);
+        } catch {
+          return err(
+            `config key ${JSON.stringify(row.key)}: stored value is not valid JSON — raw: ${row.value_json.slice(0, 200)}`,
+          );
+        }
+      }
+
+      return ok(result);
+    }),
+  };
+
+  return { definitions, handlers };
+}

--- a/mcp/trajectory-server/src/tools/identity.ts
+++ b/mcp/trajectory-server/src/tools/identity.ts
@@ -1,0 +1,176 @@
+import type { Tool, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { TrajectoryDB } from '../db.js';
+import { nowISO } from '../db.js';
+
+type Fn = (args: Record<string, unknown>) => Promise<CallToolResult>;
+
+function ok(data: unknown): CallToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+}
+
+function err(message: string): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ error: message }) }],
+    isError: true,
+  };
+}
+
+function wrapHandler(fn: (args: Record<string, unknown>) => Promise<CallToolResult>): Fn {
+  return async (args) => {
+    try {
+      return await fn(args);
+    } catch (e) {
+      const msg = (e as Error & { code?: string }).message;
+      const code = (e as Error & { code?: string }).code;
+      if (code === 'SQLITE_CONSTRAINT_CHECK' || code === 'SQLITE_CONSTRAINT') {
+        return err(`DB constraint violation: ${msg}`);
+      }
+      return err(msg);
+    }
+  };
+}
+
+const NAME_REGEX = /^[a-zA-Z][a-zA-Z0-9 _.-]{0,31}$/;
+
+const DEFAULT_IDENTITY = {
+  gatekeeper_name: 'bro',
+  human_name: null,
+  created_at: null,
+  updated_at: null,
+};
+
+type IdentityRow = {
+  id: number;
+  gatekeeper_name: string;
+  human_name: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export function identityTools(db: TrajectoryDB): {
+  definitions: Tool[];
+  handlers: Record<string, Fn>;
+} {
+  const definitions: Tool[] = [
+    {
+      name: 'identity_get',
+      description:
+        "Get the plugin identity (gatekeeper name + human name). Returns defaults when no identity has been set.",
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+    },
+    {
+      name: 'identity_set',
+      description:
+        'Set gatekeeper_name and/or human_name. Omitted fields are preserved (COALESCE semantics).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          gatekeeper_name: {
+            type: 'string',
+            description: '1-32 chars, must start with a letter',
+          },
+          human_name: {
+            type: 'string',
+            description: '1-32 chars, must start with a letter',
+          },
+        },
+      },
+    },
+    {
+      name: 'identity_reset',
+      description: 'Delete the identity row; identity_get will return defaults again.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+    },
+  ];
+
+  const handlers: Record<string, Fn> = {
+    identity_get: wrapHandler(async () => {
+      const row = db.get<IdentityRow>(`SELECT * FROM identity LIMIT 1`);
+      if (!row) {
+        return ok(DEFAULT_IDENTITY);
+      }
+      return ok({
+        gatekeeper_name: row.gatekeeper_name,
+        human_name: row.human_name,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+      });
+    }),
+
+    identity_set: wrapHandler(async (args) => {
+      const rawGatekeeper = args['gatekeeper_name'];
+      const rawHuman = args['human_name'];
+
+      const hasGatekeeper = rawGatekeeper !== undefined && rawGatekeeper !== null;
+      const hasHuman = rawHuman !== undefined && rawHuman !== null;
+
+      if (!hasGatekeeper && !hasHuman) {
+        const row = db.get<IdentityRow>(`SELECT * FROM identity LIMIT 1`);
+        if (!row) return ok(DEFAULT_IDENTITY);
+        return ok({
+          gatekeeper_name: row.gatekeeper_name,
+          human_name: row.human_name,
+          created_at: row.created_at,
+          updated_at: row.updated_at,
+        });
+      }
+
+      if (hasGatekeeper) {
+        if (typeof rawGatekeeper !== 'string' || !NAME_REGEX.test(rawGatekeeper)) {
+          return err(
+            `Invalid gatekeeper_name ${JSON.stringify(rawGatekeeper)}: must match /^[a-zA-Z][a-zA-Z0-9 _.-]{0,31}$/`,
+          );
+        }
+      }
+
+      if (hasHuman) {
+        if (typeof rawHuman !== 'string' || !NAME_REGEX.test(rawHuman)) {
+          return err(
+            `Invalid human_name ${JSON.stringify(rawHuman)}: must match /^[a-zA-Z][a-zA-Z0-9 _.-]{0,31}$/`,
+          );
+        }
+      }
+
+      const now = nowISO();
+      const gatekeeperValue = hasGatekeeper ? (rawGatekeeper as string) : null;
+      const humanValue = hasHuman ? (rawHuman as string) : null;
+
+      const existingRow = db.get<IdentityRow>(`SELECT * FROM identity WHERE id = 1`);
+      if (existingRow) {
+        const newGatekeeper = gatekeeperValue ?? existingRow.gatekeeper_name;
+        const newHuman = humanValue ?? existingRow.human_name;
+        db.run(
+          `UPDATE identity SET gatekeeper_name = ?, human_name = ?, updated_at = ? WHERE id = 1`,
+          [newGatekeeper, newHuman, now],
+        );
+      } else {
+        db.run(
+          `INSERT INTO identity (id, gatekeeper_name, human_name, created_at, updated_at)
+           VALUES (1, COALESCE(?, 'bro'), ?, ?, ?)`,
+          [gatekeeperValue, humanValue, now, now],
+        );
+      }
+
+      const row = db.get<IdentityRow>(`SELECT * FROM identity WHERE id = 1`);
+      return ok({
+        gatekeeper_name: row!.gatekeeper_name,
+        human_name: row!.human_name,
+        created_at: row!.created_at,
+        updated_at: row!.updated_at,
+      });
+    }),
+
+    identity_reset: wrapHandler(async () => {
+      db.run(`DELETE FROM identity`);
+      return ok({ ok: true });
+    }),
+  };
+
+  return { definitions, handlers };
+}

--- a/mcp/trajectory-server/src/tools/identity.ts
+++ b/mcp/trajectory-server/src/tools/identity.ts
@@ -1,6 +1,7 @@
 import type { Tool, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { TrajectoryDB } from '../db.js';
 import { nowISO } from '../db.js';
+import { requireRoles } from '../middleware/agent-scope.js';
 
 type Fn = (args: Record<string, unknown>) => Promise<CallToolResult>;
 
@@ -103,7 +104,7 @@ export function identityTools(db: TrajectoryDB): {
       });
     }),
 
-    identity_set: wrapHandler(async (args) => {
+    identity_set: requireRoles('identity_set', ['gatekeeper'], wrapHandler(async (args) => {
       const rawGatekeeper = args['gatekeeper_name'];
       const rawHuman = args['human_name'];
 
@@ -164,12 +165,12 @@ export function identityTools(db: TrajectoryDB): {
         created_at: row!.created_at,
         updated_at: row!.updated_at,
       });
-    }),
+    })),
 
-    identity_reset: wrapHandler(async () => {
+    identity_reset: requireRoles('identity_reset', ['gatekeeper'], wrapHandler(async () => {
       db.run(`DELETE FROM identity`);
       return ok({ ok: true });
-    }),
+    })),
   };
 
   return { definitions, handlers };

--- a/mcp/trajectory-server/src/tools/index.ts
+++ b/mcp/trajectory-server/src/tools/index.ts
@@ -8,6 +8,8 @@ import { auditTools } from './audit.js';
 import { validationTools } from './validation.js';
 import { skillTools } from './skills.js';
 import { reportTools } from './reports.js';
+import { configTools } from './config.js';
+import { identityTools } from './identity.js';
 import { withAgentScope } from '../middleware/agent-scope.js';
 
 export let toolDefinitions: Tool[] = [];
@@ -29,6 +31,8 @@ export function registerTools(server: Server, db: TrajectoryDB): void {
   const validation = validationTools(db);
   const skills = skillTools(db);
   const reports = reportTools(db);
+  const config = configTools(db);
+  const identity = identityTools(db);
 
   toolDefinitions = [
     ...issues.definitions,
@@ -38,6 +42,8 @@ export function registerTools(server: Server, db: TrajectoryDB): void {
     ...validation.definitions,
     ...skills.definitions,
     ...reports.definitions,
+    ...config.definitions,
+    ...identity.definitions,
   ];
 
   toolHandlers = {
@@ -48,5 +54,7 @@ export function registerTools(server: Server, db: TrajectoryDB): void {
     ...wrapAll(validation.handlers),
     ...wrapAll(skills.handlers),
     ...wrapAll(reports.handlers),
+    ...wrapAll(config.handlers),
+    ...wrapAll(identity.handlers),
   };
 }

--- a/mcp/trajectory-server/src/types.ts
+++ b/mcp/trajectory-server/src/types.ts
@@ -71,3 +71,37 @@ export interface TaskInput {
   success_criteria: string;
   execution_plan_md?: string;
 }
+
+export interface FileRegistryRow {
+  path: string;
+  type: string;
+  language: string | null;
+  size_bytes: number | null;
+  last_commit_sha: string | null;
+  last_change_type: string | null;
+  last_change_at: string | null;
+  imports_json: string;
+  exports_json: string;
+  metadata_json: string;
+}
+
+export interface PluginConfigRow {
+  key: string;
+  value_json: string;
+  updated_at: string;
+}
+
+export interface IdentityRow {
+  id: number;
+  gatekeeper_name: string;
+  human_name: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RegenStateRow {
+  target: string;
+  last_regen_at: string | null;
+  last_seen_sha: string | null;
+  notes: string;
+}


### PR DESCRIPTION
## Summary

Phase 0 of the v0.3 workflow redesign. Foundation work that unblocks Phases 1-6. Adds 4 new SQLite tables, hard-break migration runner, 6 new MCP tools (config + identity), gatekeeper role with secretary back-compat alias, role gating, and the locked branching-model config-key contract.

## Commits (7)

- **847acf7** `📋 plan(v0.3): workflow redesign blueprint — 10 changes across 7 phases` (the v0.3 plan)
- **1e33923** `feat(mcp): v0.3 Phase 0 — add file_registry, plugin_config, identity, regen_state tables; bump schema to v3` (task 0900)
- **7ba8ca5** `🚀 feat(mcp): v0.3 Phase 0 — schema migration runner with hard-break + auto-backup` (task 0905)
- **d917dcd** `🚀 feat(mcp): v0.3 Phase 0 — config and identity tool handlers (6 tools)` (task 0910)
- **e742bed** `📋 docs(mcp): v0.3 Phase 0 — lock in plugin_config key contract for branching-model` (task 0915)
- **fe81d06** `🚀 feat(mcp): v0.3 Phase 0 — add gatekeeper role, alias secretary, gate identity/config writes` (task 0920)
- **e4d5bd2** `🐛 fix(test): pass agent=gatekeeper to config_set in contract tests` (cross-task patch)

## What's in this PR

### Schema (v2 → v3)
- `file_registry` (path, type, language, imports, exports, last_change_*) — for Phase 5 architecture-doc derivation
- `plugin_config` (key, value_json) — for Phase 4 branching-model persistence
- `identity` (singleton row, gatekeeper_name='bro', human_name) — for Phase 4 first-run rename UX
- `regen_state` — for Phase 5 lazy git-log diff regeneration

### Migration runner
Hard-break with auto-backup. Pre-existing v2 DBs renamed to `<path>.v2.bak.<epoch>` (with WAL/SHM sidecars). Fresh init at v3. In-memory DBs skip migration. Future-version DBs (v>3) refused with clear error.

### MCP tools (6 new — total now 23)
- `config_set` (gated: gatekeeper or architect), `config_get` (open), `config_list` (open)
- `identity_set` (gated: gatekeeper-only), `identity_get` (open, returns virtual default if no row), `identity_reset` (gated: gatekeeper-only)

### Role gating
- `AgentRole` union now includes `gatekeeper`. `secretary` kept with `@deprecated` JSDoc; aliased to gatekeeper in `normalizeAgent` for v0.2 back-compat.
- `requireRoles(toolName, allowedRoles, handler)` middleware primitive with structured forbidden response.

### Branching-model contract (locked)
`docs/CONFIG_KEYS.md` registers 3 keys: `branching_model` (`github-flow` / `gitflow` / `custom`), `pr_target` (default `main` / `develop`), `protected_branches[]` (default `[main]` / `[main, develop]`). Phase 4's onboarding must write these keys exactly; Phase 4's git-guards rewrite must read them. Contract test fails loudly if doc is removed.

## Test plan

- [x] `bun run build` clean
- [x] `bun run test` → 95 pass / 0 fail (51 prior + 44 new)
- [x] Schema migration round-trip: v2 DB on disk → backed up + fresh v3 init
- [x] Identity virtual default: empty table → `{ gatekeeper_name: 'bro', human_name: null, ... }`
- [x] Role gating: SWE calling `config_set` returns `{ error: 'forbidden', tool, caller_role, allowed_roles }`
- [x] Secretary back-compat: `agent: 'secretary'` normalizes to `gatekeeper`

## What's NOT in this PR

This is foundation only. Later phases handle:
- Phase 1: `bro/` → `docs/trustmybot/` rename + branch_id = git names
- Phase 2: drop task XML; spec markdown + state SQLite
- Phase 3: silent-default UX + two-path workflow (simple vs difficult)
- Phase 4: first-run onboarding (writes plugin_config + identity)
- Phase 5: file_registry population + auto/manual architecture-doc derivation
- Phase 6: PLUGIN_BUGS.md → GitHub Issues, cleanup, v0.3 release

## Notes

- Cross-task fix `e4d5bd2`: 0915's contract test was written before 0920's role-gating; needed `agent='gatekeeper'` patch. Worth flagging for Phase 0 retrospective: parallel-safe per file disjoint isn't enough — API-contract changes need explicit cross-task awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)