### PR TITLE
🧹 Cleanup: scrub TMB-internal artifacts; add workspace-boundary warning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,23 @@
 
 This file is loaded automatically by Claude Code when the TMB plugin is enabled in a project. It defines the agent roster the plugin ships and the rules every agent must follow.
 
+## ⚠️ Workspace boundary (critical rule for TMB-internal contributors)
+
+If you are editing **this plugin itself** (i.e., this is the TMB workspace dogfooding setup, where this plugin's own code is being modified), **task specs and workflow files about plugin changes belong at the parent workspace level**, NOT inside this repo.
+
+| Artifact | Correct location | Wrong location |
+|---|---|---|
+| Task specs about plugin changes | `../docs/trustmybot/tasks/*.{md,xml}` (TMB workspace) | ❌ `plugin/docs/trustmybot/tasks/` |
+| Plugin roadmap / blueprint | `../docs/v0.3-blueprint.md` (TMB workspace) | ❌ `plugin/docs/v0.3-blueprint.md` |
+| Implementation code (agents, skills, MCP, hooks) | `plugin/...` ✓ | n/a |
+
+**Why**: this plugin is a public distributable. Downstream users install it and don't need TMB's internal phase-* task specs polluting their `docs/`. The plugin's own `docs/` should hold ONLY user-facing material (`SPEC-FORMAT.md`, `CONFIG_KEYS.md`, etc.).
+
+**Exception**: when this plugin is installed in a downstream user's project, the user's project will legitimately have its OWN `docs/trustmybot/tasks/` directory — that's correct, the plugin teaches that convention. Confusion arises only when developing the plugin itself dogfooding-style at TMB workspace level.
+
+When spawning architect/SWE for plugin work, always direct task spec writes to `/Users/Zax/Git/GitHub/TMB/docs/trustmybot/tasks/`, not `/Users/Zax/Git/GitHub/TMB/plugin/docs/trustmybot/tasks/`.
+
+
 ## Agent Roster (two-tier model)
 
 ### Tier 1 — Global (plugin ships these; always available when enabled)

--- a/docs/trustmybot/tasks/README.md
+++ b/docs/trustmybot/tasks/README.md
@@ -1,21 +1,15 @@
 # Task Specs
 
-All NEW task specs are markdown — see `docs/trustmybot/SPEC-FORMAT.md`.
+This directory holds per-task execution specs in markdown — see
+[`../SPEC-FORMAT.md`](../SPEC-FORMAT.md) for the canonical format.
 
 Filenames map from `branch_id` with `/` → `-`:
 
-  feat/user-login → docs/trustmybot/tasks/feat-user-login.md
+```
+feat/user-login → docs/trustmybot/tasks/feat-user-login.md
+fix/auth-crash  → docs/trustmybot/tasks/fix-auth-crash.md
+```
 
-## Historical XML specs
-
-Files matching `phase-1-*.xml` and `phase-2-*.xml` are HISTORICAL.
-They were the format used during the v0.3 Phase 1 + Phase 2
-transition. They are kept in tree as an audit trail and are
-NOT regenerated. Their `<reviewed-by>` / `<closed-by>` tags are
-the canonical sign-off record for those tasks; SQLite
-`validation_attempts` is empty for them (the rows pre-date Phase 2
-schema migration).
-
-`scripts/hooks/require-review-sign.sh` skips any XML spec with
-`status="completed"` AND a `<reviewed-by>` tag — historical XMLs
-pass through automatically.
+The architect agent writes specs here when authorizing SWE work.
+The SWE agent reads its assigned spec at spawn and updates state via MCP
+(`task_update_status`, `validation_record`) — never edits the spec body.


### PR DESCRIPTION
## Summary

Architectural cleanup. The plugin repo had been polluted with TMB-internal workflow artifacts (phase-* task specs from PRs #6, #7, #8 + the v0.3 blueprint) that don't belong in a public distributable.

This PR finalizes the cleanup. The destructive part (history rewrite + force-push to dev) was already done.

## What was done outside this PR (already pushed)

- 23 phase-* task spec files (Phase 1, 2, 3) + `docs/v0.3-blueprint.md` were moved to the TMB workspace at `/Users/Zax/Git/GitHub/TMB/docs/trustmybot/`.
- `git filter-repo` scrubbed those paths from every commit in plugin history. Force-pushed `dev` (rewritten history); `main` was untouched (the misplaced files never landed there — main is still at the v0.2 scaffolding commit awaiting v0.3.0 release).

## What this PR adds

1. **`CLAUDE.md` workspace-boundary warning** — explicit rule documenting where TMB-internal artifacts vs plugin-distributable artifacts live. Future contributors (and future Claude Code sessions) won't repeat this mistake.
2. **`docs/trustmybot/tasks/README.md` rewrite** — drops the obsolete "Historical XML specs" section that referenced the now-deleted phase-* XMLs. Now a concise user-facing pointer to `SPEC-FORMAT.md` + filename convention.

## Past incident (2026-04-21)

I authored Phase 1, 2, 3 task specs at `plugin/docs/trustmybot/tasks/phase-*.{xml,md}` instead of the TMB workspace. They were merged via PRs #6, #7, #8. User caught it before Phase 3 went out. Recovery:
- `git filter-repo --path docs/v0.3-blueprint.md --path-glob 'docs/trustmybot/tasks/phase-*' --invert-paths`
- Force-push to `dev`
- Files preserved at TMB workspace level for ongoing v0.3 development

A `feedback_workspace_vs_plugin_paths.md` memory note codifies the rule for future sessions.

## Test plan

- [x] `git ls-tree -r HEAD docs/trustmybot/tasks/` returns ONLY `README.md` (no phase-* files)
- [x] `git log --all --oneline -- docs/v0.3-blueprint.md` returns nothing
- [x] `bun run build` clean in mcp/trajectory-server (no plugin code touched in this PR)
- [x] CLAUDE.md renders correctly with the new boundary section

## Note on PR #6, #7, #8

Their commit SHAs in the GitHub UI now point to dangling refs (the rewritten history doesn't contain the misplaced files anymore, but the merge commits' content is otherwise unchanged). PR pages may show "force-pushed" notes. This is cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)