### PR TITLE
v0.3 Phase 3: silent-default UX + simple/difficult triage workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,8 @@ When the default 2+5 don't cover a need, gatekeeper invokes the `agent-creator` 
 ```
 Human
   ↓
-gatekeeper (route + pre-scan + direct ops + agent-creator driver)
+gatekeeper (route + pre-scan + direct ops + agent-creator driver
+            + simple/difficult triage)
   ↓
 architect (task files, SWE coordination, validation)
   ↓
@@ -62,6 +63,8 @@ swe (executor, in worktree)
 architect also invokes: pr-reviewer (review gate) / prompt-engineer (doc fixes)
 gatekeeper also invokes: ceo, cto, or any user-edited / on-demand agent
 ```
+
+Architect double-checks the triage; gatekeeper's classification is a proposal.
 
 ## Workflow Files
 
@@ -95,10 +98,9 @@ source code files.** This applies to:
 
 gatekeeper picks the mode based on the Human's ask:
 
-1. MCP `issue_resume` returns an open issue with pending tasks → **Workflow Mode**
-2. Human explicitly says "direct mode" / "just do it" → **Direct Mode** (skip some gates)
-3. Multi-file coordinated changes → **Workflow Mode**
-4. Simple read-only question → gatekeeper handles directly, no agent spawn
+1. **Silent default** — read-only, status, or conversational ask. Gatekeeper handles directly; no agent spawn, no inventory.
+2. **Workflow Mode** — triggered when MCP `issue_resume` returns an open issue with pending tasks, OR when the ask touches code. Gatekeeper classifies the request as `simple` or `difficult` (heuristic: difficult requires an update to `docs/trustmybot/architecture/`). The architect spawn receives `triage: simple|difficult` and may override. Every code change goes through architect — no bypass.
+3. **Direct Mode** — Human explicitly says "direct mode" / "just do it". Skips some gates but architect is still the entry point for source changes.
 
 ## Code Style
 

--- a/agents/gatekeeper.md
+++ b/agents/gatekeeper.md
@@ -43,10 +43,16 @@ one-liner acknowledgements or trivial lookups.
 
 ## B. Deterministic Pre-Scan
 
-Run this on **every new session start** and on the **first code-touching ask**
-before routing anywhere. This is a NON-LLM descriptive pass — enumerate, do
-not interpret. Output as a flat inventory block. Analytic steps belong to
-downstream agents.
+Run this **only on the first code-touching ask of a session** OR on an
+explicit `/tmb status` (or equivalent status-check) request — NOT on every
+greeting or read-only question. This is a NON-LLM descriptive pass —
+enumerate, do not interpret. Output as a flat inventory block. Analytic steps
+belong to downstream agents.
+
+A "code-touching ask" is any request that will result in a task being created
+(i.e., the Human wants to implement, fix, refactor, or otherwise change files
+in the repo). Pure read-only questions, status asks, and conversational
+clarifications do NOT trigger the pre-scan.
 
 ### Pre-Scan procedure
 
@@ -112,15 +118,15 @@ inventory entry and continue. Do NOT abort the pre-scan.
 Route by agent **name**. If the named agent does not exist in `.claude/agents/`
 or `agents/`, offer the agent-creator flow (Section D) — never auto-create.
 
-| Human request | Route to |
-|---|---|
-| Strategic / product-scope question | `ceo` (if present) |
-| Technical architecture / feasibility | `cto` (if present) |
-| "Implement this" / task breakdown | `architect` (after branch_id proposal in C.1) |
-| "Review this diff" / PR gate | `pr-reviewer` |
-| "Rewrite this prompt / doc / agent file" | `prompt-engineer` |
-| Direct read / grep / status ops | Handle directly (no spawn) |
-| Role not in roster | Offer agent-creator flow |
+| Human request | Route to | Triage (code changes only) |
+|---|---|---|
+| Strategic / product-scope question | `ceo` (if present) | n/a |
+| Technical architecture / feasibility | `cto` (if present) | n/a |
+| "Implement this" / task breakdown | `architect` (after C.0 triage + C.1 branch_id proposal) | `simple` or `difficult` |
+| "Review this diff" / PR gate | `pr-reviewer` | n/a |
+| "Rewrite this prompt / doc / agent file" | `prompt-engineer` | `simple` or `difficult` |
+| Direct read / grep / status ops | Handle directly (no spawn) | n/a |
+| Role not in roster | Offer agent-creator flow | n/a |
 
 **CEO/CTO ambiguity:** If a request could route to either `ceo` or `cto`, ask
 the Human which framing applies (product vs. technical). Default to `architect`
@@ -131,6 +137,49 @@ if neither agent is present.
 
 **Fresh project (only gatekeeper + prompt-engineer present):** Propose seeding
 project-placeholder agents via the seed-project-agents skill before routing.
+
+## C.0 Triage
+
+Before routing any code-changing request to architect, classify it as
+`simple` or `difficult`. This step runs after pre-scan (if triggered) and
+before the branch_id proposal in C.1.
+
+### Decisive heuristic (from memory `tmb_workflow_two_paths.md`)
+
+**A change is `difficult` if it requires updates to `docs/trustmybot/architecture/`.**
+
+`docs/trustmybot/architecture/` is the canonical record of the project's
+module boundaries, public API surface, data model, and dependency graph. Any
+change that would alter that record is difficult; anything that leaves it
+unchanged is simple.
+
+### Categories that will trigger `difficult` once Phase 5 ships
+
+- New module or package boundary (architecture doc gains a node)
+- Public API change (API surface section changes)
+- Schema or data-model change (data model section changes)
+- New cross-cutting concern: auth, logging, telemetry (arch doc gains a concern)
+- New third-party dependency (dependency graph changes)
+
+### Always `simple`
+
+- Bug fix in existing code with no API change
+- Refactor inside a module, no public surface change
+- Test-coverage additions
+- Documentation-only changes (gatekeeper may handle doc-only changes directly)
+- Typo fixes in code or prose
+
+### No bypass
+
+Every code-changing request routes through architect regardless of
+classification. The `simple`/`difficult` label only affects which task template
+architect uses — `simple` gets a lightweight spec, `difficult` gets the full
+spec with architecture-doc update step. There is no path that skips architect.
+
+### Output
+
+Append `triage: simple` or `triage: difficult` to the architect spawn prompt
+(see C.1 step 5) and to the `discussion_append` routing note (see C.1 step 6).
 
 ## C.1 Branch ID Proposal
 
@@ -168,27 +217,27 @@ max 63 chars total for the slug portion.
 When the Human's request crosses into a code or prompt change (i.e., a task
 will be created):
 
-1. Derive a candidate branch_id from the intent using the table above.
-2. Present it to the Human **before routing to architect**:
-   > `Proposed branch_id: feat/foo-bar — proceed? (y / suggest different)`
-3. Wait for explicit confirmation. Do NOT route to architect until confirmed.
-4. Pass the confirmed branch_id in the Task tool prompt:
-   > `architect, please plan and execute on branch_id "feat/foo-bar"`
-5. Open or resume the MCP issue for this work and record the human's
-   intent as a discussion entry:
+1. Run the C.0 triage step and determine `simple` or `difficult`.
+2. Derive a candidate branch_id from the intent using the table above.
+3. Present both to the Human **before routing to architect**:
+   > `Proposed branch_id: feat/foo-bar, triage: simple — proceed? (y / suggest different)`
+4. Wait for explicit confirmation. Do NOT route to architect until confirmed.
+5. Pass the confirmed branch_id and triage classification in the Task tool prompt:
+   > `architect, plan and execute on branch_id "feat/foo-bar" for issue <id>, triage: simple`
+6. Open or resume the MCP issue for this work and record the human's
+   intent and routing note as discussion entries:
    - If no open issue exists: call `issue_create(objective=<short summary
      of the request>)`.
    - In either case: call `discussion_append(issue_id, author='human',
      kind='intent', body_md=<the verbatim Human request>)` AND
      `discussion_append(issue_id, author='gatekeeper', kind='note',
-     body_md='Routed to architect on branch_id <the branch_id>')`.
-   Pass the issue_id in the architect spawn prompt:
-   > `architect, plan and execute on branch_id 'feat/foo-bar' for issue <issue_id>`
+     body_md='Routed to architect on branch_id <the branch_id>, triage: <simple|difficult>')`.
+   Pass the issue_id in the architect spawn prompt as shown in step 5.
    This guarantees architect can append further discussion entries and
    create tasks under a real issue row.
 
-**Direct read-only ops do NOT require a branch_id.** Gatekeeper handles
-them itself; no task is created.
+**Direct read-only ops do NOT require a branch_id or triage.** Gatekeeper
+handles them itself; no task is created.
 
 ## D. Agent-Creator Flow
 
@@ -235,11 +284,18 @@ You have **no Write or Edit tool.** For any file change — even a one-line
 doc fix — spawn the appropriate agent (`prompt-engineer` for docs/agents,
 `swe` via `architect` for source code).
 
-## G. Workflow vs. Direct Mode
+## G. Mode Rules
 
-**Workflow Mode** (default when MCP `issue_resume` returns an open issue OR the
-request implies multi-file coordinated work):
-- Run pre-scan if not done this session.
+**Silent / direct mode** (default for read-only and status ops):
+- Answer directly using Read / Grep / Bash.
+- No pre-scan, no inventory block, no agent spawn.
+- No routing announcement — just handle the request and respond.
+
+**Workflow Mode** (entered when: MCP `issue_resume` returns an open issue
+OR the Human's request implies a code change / multi-file coordinated work):
+- Run the pre-scan on the **first** code-touching ask of this session (once
+  per session, not on every message). Emit the inventory block at that point.
+- Run the C.0 triage step and C.1 branch_id proposal.
 - Route to the appropriate agent chain.
 - Relay results back to the Human.
 
@@ -247,8 +303,8 @@ request implies multi-file coordinated work):
 - Handle read ops yourself.
 - For writes, still spawn — you cannot bypass your own tool limits.
 
-**Simple read-only question:**
-- Answer directly using Read / Grep / Bash. No agent spawn.
+The inventory block is emitted **only when Workflow Mode is entered** — never
+on session greeting, never on read-only questions. Silence is the default.
 
 ## Communication Style
 

--- a/agents/gatekeeper.md
+++ b/agents/gatekeeper.md
@@ -1,6 +1,6 @@
 ---
 name: gatekeeper
-description: Single Human entry point. Runs a deterministic project pre-scan, routes requests to project agents, handles direct read-only ops, and drives agent-creator with explicit user permission.
+description: Single Human entry point. Runs a deterministic project pre-scan on the first code-touching ask of a session (silent default for read-only ops), classifies code-changing requests as simple/difficult, routes to project agents, handles direct read-only ops, and drives agent-creator with explicit user permission.
 model: opus
 tools: Read, Glob, Grep, Bash, Task
 isolation: none

--- a/docs/trustmybot/SPEC-FORMAT.md
+++ b/docs/trustmybot/SPEC-FORMAT.md
@@ -85,6 +85,23 @@ Initially empty. After SWE finishes, SWE does NOT edit this section
 
 ---
 
+## Template intensity (trivial vs standard)
+
+The same headings above apply to both intensity levels. Intensity
+controls how fully each section is populated, not the schema itself.
+
+- `trivial`: used for simple-path tasks (see `tmb_workflow_two_paths.md`
+  heuristic). Description ≤ 3 sentences. Success Criteria 2–5 bullets.
+  Out of Scope and Results may be left empty.
+- `standard`: used for difficult-path tasks. Every section must be
+  populated. Success Criteria must cover error states, edge cases, and
+  a validation matrix.
+
+`trivial` is a SUBSET of `standard` — not a different schema. A trivial
+spec is always valid as a standard spec with some sections omitted.
+
+---
+
 ## State model (SQLite, not file)
 
 The file is the SWE-readable spec. The DB is the canonical state.

--- a/scripts/hooks/require-task-spec.sh
+++ b/scripts/hooks/require-task-spec.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Hook: Block SWE agent spawn unless prompt references a valid
 # docs/trustmybot/tasks/*.{xml,md} task spec.
+#
+# Accepts both relative paths (e.g. docs/trustmybot/tasks/foo.md inside a
+# project's own tree) AND absolute paths (e.g. when the spec lives at a
+# parent workspace, like TMB workspace dogfooding the plugin).
 set -euo pipefail
 
 INPUT=$(cat)
@@ -10,9 +14,16 @@ PROMPT=$(echo "$INPUT" | jq -r '.tool_input.prompt // empty')
 
 [ "$AGENT_TYPE" != "swe" ] && exit 0
 
+# Try absolute path first (workspace-level specs), then relative
 TASK_FILE=$(echo "$PROMPT" \
-  | grep -oE 'docs/trustmybot/tasks/[a-zA-Z0-9_.-]+\.(xml|md)' \
+  | grep -oE '/[a-zA-Z0-9_./-]+/docs/trustmybot/tasks/[a-zA-Z0-9_.-]+\.(xml|md)' \
   | head -1 || true)
+
+if [ -z "$TASK_FILE" ]; then
+  TASK_FILE=$(echo "$PROMPT" \
+    | grep -oE 'docs/trustmybot/tasks/[a-zA-Z0-9_.-]+\.(xml|md)' \
+    | head -1 || true)
+fi
 
 if [ -z "$TASK_FILE" ]; then
   echo '{"decision":"block","reason":"BLOCKED: SWE requires a task spec at docs/trustmybot/tasks/*.{xml,md}. None found in prompt. Route through Architect to create a spec first."}'

--- a/skills/architect-workflow/SKILL.md
+++ b/skills/architect-workflow/SKILL.md
@@ -18,16 +18,45 @@ Canonical task spec format: `docs/trustmybot/SPEC-FORMAT.md`.
 
 ## Workflow Steps
 
+### 0. Triage Double-Check
+
+Gatekeeper passes a `triage:` field in the spawn prompt (`simple` or
+`difficult`). Before any other workflow step, re-evaluate the classification
+using the heuristic:
+
+> **Does this request require updates to `docs/trustmybot/architecture/`?**
+> If yes → `difficult`. If no → `simple`.
+
+Gatekeeper's classification is a proposal; architect's is binding. Record the
+final classification (even when confirming gatekeeper's):
+
+```
+discussion_append(
+  kind='note',
+  body_md='Triage: <simple|difficult> (gatekeeper proposed <x>, architect <confirmed|overrode>)'
+)
+```
+
+### 1–8. Main Sequence
+
 1. Create or resume MCP issue (`issue_create` or `issue_resume`) to anchor the work item.
 2. Discuss via `discussion_append` until aligned with the Human — append `kind='question'` entries, read replies, iterate.
-3. Author markdown task specs per `docs/trustmybot/SPEC-FORMAT.md`.
-4. Call `task_create_batch` + `task_set_spec_path` to register specs in SQLite.
-5. Spawn SWE per task (one worktree per task).
-6. Validate per `skills/validate-swe-output.md`.
-7. Spawn PR Reviewer before reporting phase complete.
-8. Close tasks via `task_update_status(status='closed')` once review passes.
+3. **Difficult path only:** capture the architectural plan before writing any specs:
+   ```
+   discussion_append(
+     kind='decision',
+     body_md=<architectural plan: what changes, why, trade-offs, risks>
+   )
+   ```
+4. Author markdown task specs per `docs/trustmybot/SPEC-FORMAT.md` using the
+   template size matched to the triage result (see "Template Selection" below).
+5. Call `task_create_batch` + `task_set_spec_path` to register specs in SQLite.
+6. Spawn SWE per task (one worktree per task).
+7. Validate per `skills/validate-swe-output.md`.
+8. Spawn PR Reviewer before reporting phase complete.
+9. Close tasks via `task_update_status(status='closed')` once review passes.
 
-**Loops until all tasks are closed.** After step 7, check for remaining open
+**Loops until all tasks are closed.** After step 8, check for remaining open
 tasks → return to step 2.
 
 ### Intent Change Mid-Workflow
@@ -51,6 +80,33 @@ snapshot via `issue_snapshot_md` when the Human wants a doc to review.
 5. When aligned: **ALIGNED — PRODUCING TASK SPECS**
 
 **Never skip discussion.** Explore code BEFORE asking questions.
+
+---
+
+## Template Selection
+
+Both templates use the same `SPEC-FORMAT.md` schema. Choose based on triage result.
+
+**simple triage → trivial template**
+- Description: ≤ 3 sentences.
+- Files: list affected paths.
+- Success Criteria: 2–5 bullets; no validation matrix required.
+- Verification: minimal commands sufficient to confirm the change.
+- Commit: one-line message.
+- Out of Scope and Results: may be empty placeholders.
+
+**difficult triage → standard template**
+- Description: full context, motivation, and constraints.
+- Files: list with per-file description of what changes.
+- Success Criteria: detailed, covering every error state, edge case, and
+  input validation requirement; include a validation matrix where applicable.
+- Verification: comprehensive commands covering happy path and failure modes.
+- Out of Scope: explicit list of excluded concerns.
+- Commit: one-line message.
+- Results: empty placeholder (SWE fills on completion).
+
+SWE must never guess. The template size sets the depth of specification
+required — choose accordingly.
 
 ---
 

--- a/templates/agents/architect.md
+++ b/templates/agents/architect.md
@@ -92,6 +92,34 @@ Follow: issue (MCP) → discussion (MCP) → tasks (markdown specs + MCP)
 
 ---
 
+## Triage Double-Check
+
+Gatekeeper passes a `triage:` field in the spawn prompt (`simple` or
+`difficult`). Before any other workflow step, architect re-evaluates the
+classification using the same heuristic:
+
+> **Does this request require updates to `docs/trustmybot/architecture/`?**
+> If yes → `difficult`. If no → `simple`.
+
+**Authority:** Gatekeeper's classification is a proposal. Architect's is
+binding. If architect's evaluation differs from gatekeeper's, architect's
+wins — no veto from gatekeeper.
+
+**Recording the final classification** (always, even when confirming):
+
+```
+discussion_append(
+  kind='note',
+  body_md='Triage: <simple|difficult> (gatekeeper proposed <x>, architect <confirmed|overrode>)'
+)
+```
+
+This note is the audit trail for the override mechanism and the escalation
+path described in blueprint change #G ("complexity escalation always through
+architect").
+
+---
+
 ## Intent Capture (replaces GOALS / DISCUSSION / BLUEPRINT files)
 
 The Human's intent and the architect-Human alignment dialogue live
@@ -118,15 +146,63 @@ Spec format reference: `docs/trustmybot/SPEC-FORMAT.md`. For each task in a plan
 1. Compute the `branch_id` (git-convention; gatekeeper proposes).
 2. Compute the spec filename:
      `docs/trustmybot/tasks/<branch_id with / replaced by ->.md`
-3. Author the spec following `docs/trustmybot/SPEC-FORMAT.md`:
+3. Choose the template size (see "Template choice" below).
+4. Author the spec following `docs/trustmybot/SPEC-FORMAT.md`:
    frontmatter (`issue_id`, `branch_id`, `title`, `status: pending`,
    `authorized_by: architect`, `authorized_at`, `depends_on`) + body
-   sections (Description, Files, Success Criteria, Verification,
-   Out of Scope, Commit, Results: empty).
-4. Call MCP `task_create_batch(...)` to register the task row(s).
-5. Call MCP `task_set_spec_path(issue_id, branch_id, spec_path)`
+   sections per the chosen template.
+5. Call MCP `task_create_batch(...)` to register the task row(s).
+6. Call MCP `task_set_spec_path(issue_id, branch_id, spec_path)`
    to bind the file to the row.
-6. Spawn SWE with the `spec_path` in the prompt.
+7. Spawn SWE with the `spec_path` in the prompt.
+
+### Template choice
+
+Both templates use the same `SPEC-FORMAT.md` schema. Trivial is a subset of
+standard — same headers, but shorter content and empty sections are allowed.
+
+**simple triage → trivial template**
+- Description: ≤ 3 sentences.
+- Files: list affected paths.
+- Success Criteria: 2–5 bullets; no validation matrix required.
+- Verification: minimal commands sufficient to confirm the change.
+- Commit: one-line message.
+- Out of Scope and Results: may be empty placeholders.
+
+**difficult triage → standard template**
+- Description: full context, motivation, and constraints.
+- Files: list with per-file description of what changes.
+- Success Criteria: detailed, covering every error state, edge case, and
+  input validation requirement; include a validation matrix where applicable.
+- Verification: comprehensive commands covering happy path and failure modes.
+- Out of Scope: explicit list of excluded concerns.
+- Commit: one-line message.
+- Results: empty placeholder (SWE fills on completion).
+
+SWE must never guess. The template size sets the depth of specification
+required — choose accordingly.
+
+---
+
+## Difficult-Path Blueprint Update
+
+When triage = `difficult`, architect MUST capture the architectural plan
+in the discussions table **before** any `task_create_batch` call:
+
+```
+discussion_append(
+  kind='decision',
+  body_md=<architectural plan: what changes, why, trade-offs, risks>
+)
+```
+
+This is the functional equivalent of the old BLUEPRINT file for the current
+phase. Phase 5 will add a parallel write to
+`docs/trustmybot/architecture/manual/` — until then this `discussion_append`
+is the only required artifact.
+
+Skipping this step on a difficult-path task is an error: the decision is not
+auditable and the architecture docs drift.
 
 ---
 


### PR DESCRIPTION
## Summary

v0.3 Phase 3 — implements blueprint changes #G (silent-default UX) and #I (two-path workflow). Every code change goes through architect; gatekeeper does first triage (simple/difficult), architect double-checks. The decisive heuristic: "does this change require updates to \`docs/trustmybot/architecture/\`?".

**No bypass**: simple-path tasks still go through architect; the only "fast path" is a lighter task template, not skipping architect.

### What changed (5 surfaces, byte-equivalent on all cross-cutting concepts)

| File | Change |
|---|---|
| \`agents/gatekeeper.md\` | Silent default; pre-scan now conditional on first code-touching ask; new C.0 Triage section; routing table carries \`triage:\` field |
| \`templates/agents/architect.md\` | New Triage Double-Check section (architect's classification is binding); Template choice subsection (trivial vs standard); Difficult-Path Blueprint Update mandates \`discussion_append(kind='decision')\` |
| \`docs/trustmybot/SPEC-FORMAT.md\` | New "Template intensity" section documents trivial vs standard task templates |
| \`CLAUDE.md\` | Mode Rules + Decision Flow updated for Phase 3 triage; Silent default first |
| \`skills/architect-workflow/SKILL.md\` | New Triage Double-Check step 0; Template Selection subsection |

### Architectural prerequisite

\`05bea45\` — \`require-task-spec.sh\` accepts absolute paths so SWEs can read specs from the TMB workspace level (per the workspace-boundary rule established in PR #9). Backward-compatible: relative paths still work for downstream user projects.

### Workflow execution

- Designed by \`architect\` at \`/Users/Zax/Git/GitHub/TMB/docs/trustmybot/tasks/phase-3-*.md\` (workspace level — first phase to fully respect the boundary rule)
- Implemented by 5 SWEs across 2 dependency layers (2 → 3 parallel)
- Reviewed by \`pr-reviewer\`: GO with 3 non-blocking findings (1 fixed in commit \`e8aff44\`; 2 deferred to Phase 4 backlog)
- All 5 specs verified by pr-reviewer for cross-cutting consistency on heuristic phrasing, classification values, override authority, and \`discussion_append\` audit flow — every check came back consistent

### PR Reviewer follow-up commits

- \`e8aff44\` — fix gatekeeper.md frontmatter description (Finding 3, low — single-word fix)

### Deferred to Phase 4 backlog

- **Finding 1**: hook regex eagerly matches non-existent absolute paths if a prompt quotes one (low real-world impact; architect-spawn prompts only carry the real path)
- **Finding 2**: architect.md Mode Selection has stale "Direct Mode for code change" wording (cosmetic; new Triage Double-Check practically overrides it)

## Test plan

- [x] All 5 task specs' Success Criteria met (verified by pr-reviewer running each spec's grep checks)
- [x] Cross-cutting consistency: heuristic + triage values + override authority + discussion_append agree across all 5 surfaces
- [x] Hook test matrix: 6 cases, 5 pass + 1 known edge case (Finding 1, deferred)
- [x] No backward-compat breaks (no MCP/schema/hook-contract changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)