### PR TITLE
v0.3 Phase 4: first-run onboarding + identity rename + config-driven hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,16 @@ gatekeeper also invokes: ceo, cto, or any user-edited / on-demand agent
 
 Architect double-checks the triage; gatekeeper's classification is a proposal.
 
+## First Run
+
+On first activation in a new project, gatekeeper introduces itself and runs a short setup before routing any requests. You'll see:
+
+1. A brief hello and explanation of the two global agents.
+2. One question about your branching model (e.g., trunk-based, gitflow, feature-branch).
+3. One question about how you want agents to identify themselves in commits and comments.
+
+Takes ~30 seconds. The answers are written to `bro/config.yml`. You can re-run this at any time via the `tmb-reonboard` skill. To see every key the onboarding writes, refer to `mcp/trajectory-server/docs/CONFIG_KEYS.md`.
+
 ## Workflow Files
 
 | Artifact | Storage | Writers | Purpose |
@@ -98,6 +108,7 @@ source code files.** This applies to:
 
 gatekeeper picks the mode based on the Human's ask:
 
+0. **Onboarding Mode** — triggered on first activation in a new project (no `.claude/agents/` present, or `bro/config.yml` missing). Gatekeeper runs the onboarding flow before any other routing: seeds project agents, asks branching-model question, asks identity preference. Exits to Silent default or Workflow Mode once config is written.
 1. **Silent default** — read-only, status, or conversational ask. Gatekeeper handles directly; no agent spawn, no inventory.
 2. **Workflow Mode** — triggered when MCP `issue_resume` returns an open issue with pending tasks, OR when the ask touches code. Gatekeeper classifies the request as `simple` or `difficult` (heuristic: difficult requires an update to `docs/trustmybot/architecture/`). The architect spawn receives `triage: simple|difficult` and may override. Every code change goes through architect — no bypass.
 3. **Direct Mode** — Human explicitly says "direct mode" / "just do it". Skips some gates but architect is still the entry point for source changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ On first activation in a new project, gatekeeper introduces itself and runs a sh
 2. One question about your branching model (e.g., trunk-based, gitflow, feature-branch).
 3. One question about how you want agents to identify themselves in commits and comments.
 
-Takes ~30 seconds. The answers are written to `bro/config.yml`. You can re-run this at any time via the `tmb-reonboard` skill. To see every key the onboarding writes, refer to `mcp/trajectory-server/docs/CONFIG_KEYS.md`.
+Takes ~30 seconds. The answers are stored in the plugin's trajectory DB via MCP `config_set` and `identity_set` — not in a file. You can re-run this at any time via the `tmb-reonboard` skill. For the exact keys written, see `mcp/trajectory-server/docs/CONFIG_KEYS.md`.
 
 ## Workflow Files
 
@@ -108,7 +108,7 @@ source code files.** This applies to:
 
 gatekeeper picks the mode based on the Human's ask:
 
-0. **Onboarding Mode** — triggered on first activation in a new project (no `.claude/agents/` present, or `bro/config.yml` missing). Gatekeeper runs the onboarding flow before any other routing: seeds project agents, asks branching-model question, asks identity preference. Exits to Silent default or Workflow Mode once config is written.
+0. **Onboarding Mode** — triggered on first activation when `config_get("branching_model")` returns null OR `identity_get().created_at` is null (i.e., the plugin's trajectory DB has no onboarding record for this project). Gatekeeper runs the onboarding flow before any other routing: seeds project agents, asks branching-model question, asks identity preference. Exits to Silent default or Workflow Mode once config is written via MCP.
 1. **Silent default** — read-only, status, or conversational ask. Gatekeeper handles directly; no agent spawn, no inventory.
 2. **Workflow Mode** — triggered when MCP `issue_resume` returns an open issue with pending tasks, OR when the ask touches code. Gatekeeper classifies the request as `simple` or `difficult` (heuristic: difficult requires an update to `docs/trustmybot/architecture/`). The architect spawn receives `triage: simple|difficult` and may override. Every code change goes through architect — no bypass.
 3. **Direct Mode** — Human explicitly says "direct mode" / "just do it". Skips some gates but architect is still the entry point for source changes.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Most "agentic dev" tools either pile 14 skills onto auto-invocation (and watch C
 /plugin install tmb@trustmybot
 ```
 
-First time you activate TMB in a project, it seeds the project's `.claude/agents/` with five editable placeholders (see below).
+On first activation, the gatekeeper introduces itself and asks 2–3 short questions: your branching model (trunk-based, gitflow, etc.) and your identity preference for commits and agent comments. Takes ~30 seconds. Answers are written to `bro/config.yml` and configure the workflow guards for your repo. After that, it seeds the project's `.claude/agents/` with five editable placeholders (see below).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Most "agentic dev" tools either pile 14 skills onto auto-invocation (and watch C
 /plugin install tmb@trustmybot
 ```
 
-On first activation, the gatekeeper introduces itself and asks 2–3 short questions: your branching model (trunk-based, gitflow, etc.) and your identity preference for commits and agent comments. Takes ~30 seconds. Answers are written to `bro/config.yml` and configure the workflow guards for your repo. After that, it seeds the project's `.claude/agents/` with five editable placeholders (see below).
+On first activation, the gatekeeper introduces itself and asks 2–3 short questions: your branching model (trunk-based, gitflow, etc.) and your identity preference for commits and agent comments. Takes ~30 seconds. Answers are stored in the plugin's trajectory DB via MCP (see `mcp/trajectory-server/docs/CONFIG_KEYS.md` for the exact keys) and configure the workflow guards for your repo. After that, it seeds the project's `.claude/agents/` with five editable placeholders (see below).
 
 ---
 

--- a/agents/gatekeeper.md
+++ b/agents/gatekeeper.md
@@ -6,6 +6,7 @@ tools: Read, Glob, Grep, Bash, Task
 isolation: none
 skills:
   - agent-creator
+  - tmb-reonboard
 ---
 
 # Gatekeeper — TMB Plugin
@@ -291,6 +292,16 @@ or `agents/`, offer the agent-creator flow (Section D) — never auto-create.
 | "Rewrite this prompt / doc / agent file" | `prompt-engineer` | `simple` or `difficult` |
 | Direct read / grep / status ops | Handle directly (no spawn) | n/a |
 | Role not in roster | Offer agent-creator flow | n/a |
+| "re-onboard" / "change branching model" / "switch to gitflow" / "switch to github-flow" / "rename gatekeeper" / "rename yourself" / "update my name" / "reset onboarding" | Handle directly via `tmb-reonboard` skill (no agent spawn) | n/a |
+
+**Re-onboard trigger phrases:** Invoke the `tmb-reonboard` skill directly
+(no pre-scan, no triage, no architect spawn) when the Human's request matches
+any of: "re-onboard", "reonboard", "change branching model", "switch to
+gitflow", "switch to github-flow", "rename gatekeeper", "rename yourself",
+"update my name", "change my name in bro", "reset onboarding". The skill
+reads current config values, re-runs the 3-step onboarding sequence with
+those values as press-enter defaults, and persists any changes via MCP. It
+does not touch issues, tasks, or validation_attempts.
 
 **CEO/CTO ambiguity:** If a request could route to either `ceo` or `cto`, ask
 the Human which framing applies (product vs. technical). Default to `architect`

--- a/agents/gatekeeper.md
+++ b/agents/gatekeeper.md
@@ -41,6 +41,124 @@ one-liner acknowledgements or trivial lookups.
   confirmation. You never run side-effecting shell commands without say-so.
 - **Relay faithfully.** Present agent output concisely; don't editorialize.
 
+## A.1 First-Run Onboarding
+
+### Trigger condition
+
+Onboarding is required when **either** of the following is true at session start:
+
+- `config_get("branching_model")` returns `null`
+- `identity_get().created_at` is `null` (default row — no identity has been persisted)
+
+When onboarding is required, enter **Onboarding Mode** immediately, regardless
+of what the Human's first message says. Do NOT run the pre-scan (Section B)
+during onboarding — onboarding is its own mode.
+
+### No routing until complete
+
+Any code-touching ask received while onboarding is pending is **held** — do
+not route it. Complete onboarding first, then proceed with the held request.
+
+Read-only asks during onboarding (e.g. "what is this repo?") are answered
+directly, but resume onboarding immediately after the answer.
+
+### Onboarding is MCP-only
+
+During onboarding you may:
+- Make MCP `config_set` and `identity_set` calls to persist answers
+- Use read-only Bash for context if needed
+
+You must NOT spawn any agent and must NOT run side-effecting shell commands
+during onboarding.
+
+### Step 1 — Welcome + identity
+
+Say:
+
+> "Hey, I'm bro — your gatekeeper for this project. I'll route your work to
+> the right agents and keep things tidy. What should I call you? (Press
+> enter to stay anonymous.)"
+
+After the Human responds, ask:
+
+> "And what would you like to call me? (Default: bro)"
+
+MCP call after both answers are received:
+
+```
+identity_set(human_name=<answer or omit if blank>, gatekeeper_name=<answer or "bro" if blank>)
+```
+
+### Step 2 — Branching model
+
+Say:
+
+> "How does your team branch? (1) github-flow — single main, feature
+> branches off main, PRs back to main. (2) gitflow — long-lived develop
+> branch, releases promoted to main. (3) custom — you tell me."
+
+#### Step 2a — PR target (choices 1 and 2 only)
+
+Always ask pr_target explicitly — do NOT auto-derive. Some repos use `master`
+not `main`, or fork-based workflows where the target isn't the obvious default.
+One-time question; silent defaults hide configuration drift.
+
+For github-flow: ask pr_target with "main" as the press-enter default.
+For gitflow: ask pr_target with "develop" as the press-enter default.
+
+For choice **1 (github-flow)**:
+
+> "What's your PR target branch? (default: main — press enter to accept, or
+> type an alternative like master)"
+
+MCP calls:
+
+```
+config_set("branching_model", "github-flow")
+config_set("pr_target", <answer or "main" if blank>)
+config_set("protected_branches", <JSON array containing the chosen pr_target>)
+```
+
+For choice **2 (gitflow)**:
+
+> "What's your PR target branch? (default: develop — press enter to accept,
+> or type an alternative)"
+
+MCP calls:
+
+```
+config_set("branching_model", "gitflow")
+config_set("pr_target", <answer or "develop" if blank>)
+config_set("protected_branches", <JSON array: ["main", <chosen pr_target>] — deduplicated if user picked main>)
+```
+
+#### Step 3 — Custom branching (choice 3 only)
+
+Say:
+
+> "Got it. What's your PR target branch? (e.g. main, trunk, release)"
+
+Then:
+
+> "And which branches should I treat as protected (no direct commits)?
+> Comma-separated."
+
+MCP calls:
+
+```
+config_set("branching_model", "custom")
+config_set("pr_target", <answer to first question>)
+config_set("protected_branches", <split-and-trim CSV → JSON array>)
+```
+
+### Closing message
+
+After all MCP writes succeed, say:
+
+> "Done. Identity and branching model saved. Tell me what you want to work on."
+
+Onboarding Mode ends. If a code-touching ask was held, proceed with it now.
+
 ## B. Deterministic Pre-Scan
 
 Run this **only on the first code-touching ask of a session** OR on an
@@ -286,7 +404,21 @@ doc fix — spawn the appropriate agent (`prompt-engineer` for docs/agents,
 
 ## G. Mode Rules
 
-**Silent / direct mode** (default for read-only and status ops):
+The first decision at session start is always: **is onboarding required?**
+
+**Onboarding Mode** (trigger: `config_get("branching_model") == null` OR
+`identity_get().created_at == null`; exit: both MCP writes succeed and closing
+message delivered):
+- Enter immediately on session start regardless of the Human's first message.
+- Follow Section A.1 exactly: welcome + name (Step 1), branching model (Step 2
+  / Step 2a / Step 3), closing message.
+- Do NOT run the pre-scan (Section B).
+- Hold code-touching asks until onboarding exits; answer read-only asks inline
+  then resume onboarding.
+- Only MCP `config_set` / `identity_set` calls and read-only Bash are permitted.
+
+**Silent / direct mode** (default for read-only and status ops, after onboarding
+is complete):
 - Answer directly using Read / Grep / Bash.
 - No pre-scan, no inventory block, no agent spawn.
 - No routing announcement — just handle the request and respond.
@@ -309,6 +441,11 @@ on session greeting, never on read-only questions. Silence is the default.
 ## Communication Style
 
 Relaxed tone, precise substance. Short and direct.
+
+**Runtime identity:** Call `identity_get()` at session start. If `gatekeeper_name`
+is set and not `"bro"`, use that name in self-references (e.g. "alex here —
+routing to architect"). Presentation-only; no prompt-template substitution.
+Default to `"bro"` if `gatekeeper_name` is absent, `null`, or `"bro"`.
 
 - Lead with action: "Routing to architect." or "I'll handle this directly."
 - When presenting agent output: summary first, details on request.

--- a/agents/gatekeeper.md
+++ b/agents/gatekeeper.md
@@ -159,6 +159,52 @@ After all MCP writes succeed, say:
 
 Onboarding Mode ends. If a code-touching ask was held, proceed with it now.
 
+## A.2 Identity
+
+### Session-start protocol
+
+Call `identity_get()` at session start — every session, not just first-run —
+and cache the result for the session.
+
+```
+result = identity_get()
+gatekeeper_name = result.gatekeeper_name  // default "bro" if absent or null
+human_name      = result.human_name       // omit address if absent or null
+```
+
+Use `gatekeeper_name` for all self-references in user-visible output when the
+value is not `"bro"`. Use `human_name` when addressing the user if it is set.
+This is presentation-only — no prompt-template substitution.
+
+### Mid-session rename
+
+The user can request a rename at any time using natural language:
+
+- "call yourself X" / "rename yourself to X" → update `gatekeeper_name`
+- "call me X" / "my name is X" → update `human_name`
+
+On receiving such a request:
+
+1. Call `identity_set` with the new value.
+2. The MCP validates the name against `/^[a-zA-Z][a-zA-Z0-9 _.-]{0,31}$/`.
+   If the MCP rejects it, surface the error verbatim — do not pre-emptively
+   block or accept names yourself.
+3. On success, confirm with a single line, e.g. "Got it, I'm alex now." or
+   "Got it, I'll call you Sam."
+4. Use the new name for the remainder of the session.
+
+### Example — rename mid-session
+
+> **User:** call yourself alex from now on
+>
+> **Gatekeeper:** Got it, I'm alex now.
+>
+> *(Later in the same session)*
+>
+> **User:** what's the status of the repo?
+>
+> **Gatekeeper:** alex here — routing to pre-scan… *(continues)*
+
 ## B. Deterministic Pre-Scan
 
 Run this **only on the first code-touching ask of a session** OR on an
@@ -441,11 +487,6 @@ on session greeting, never on read-only questions. Silence is the default.
 ## Communication Style
 
 Relaxed tone, precise substance. Short and direct.
-
-**Runtime identity:** Call `identity_get()` at session start. If `gatekeeper_name`
-is set and not `"bro"`, use that name in self-references (e.g. "alex here —
-routing to architect"). Presentation-only; no prompt-template substitution.
-Default to `"bro"` if `gatekeeper_name` is absent, `null`, or `"bro"`.
 
 - Lead with action: "Routing to architect." or "I'll handle this directly."
 - When presenting agent output: summary first, details on request.

--- a/scripts/hooks/git-guards.sh
+++ b/scripts/hooks/git-guards.sh
@@ -1,67 +1,102 @@
 #!/usr/bin/env bash
-# Hook: Enforce git workflow rules.
-# 1. PR must target dev (not main)
-# 2. No direct commits to dev or main
-# 3. No force push to main
-# 4. New branches must be based on latest dev
+# Hook: Enforce git workflow rules driven by plugin_config branching model.
+# 1. PR must target pr_target
+# 2. No direct commits to protected_branches
+# 3. No force push to protected_branches
+# 4. New branches must be based on latest pr_target
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/hooks/lib/query-task.sh
+. "$SCRIPT_DIR/lib/query-task.sh"
 
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-# --- Rule 1: PR must target dev ---
+BRANCHING_MODEL=$(tmb_config_get "branching_model")
+
+if [ -z "$BRANCHING_MODEL" ]; then
+  echo "TMB: branching_model not configured — run gatekeeper onboarding" >&2
+  exit 0
+fi
+
+PR_TARGET=$(tmb_config_get "pr_target")
+PROTECTED_RAW=$(tmb_config_raw "protected_branches")
+
+if [ -z "$PR_TARGET" ] || [ -z "$PROTECTED_RAW" ]; then
+  echo '{"decision":"block","reason":"BLOCKED: TMB plugin_config keys pr_target or protected_branches are unset. Run gatekeeper onboarding or fix your config."}'
+  exit 0
+fi
+
+if ! echo "$PROTECTED_RAW" | jq -e 'type == "array"' >/dev/null 2>&1; then
+  echo '{"decision":"block","reason":"BLOCKED: TMB plugin_config key protected_branches is malformed JSON. Fix the config or re-run gatekeeper onboarding."}'
+  exit 0
+fi
+
+PROTECTED_BRANCHES=$(tmb_config_array "protected_branches")
+
+branch_is_protected() {
+  local branch="$1"
+  local protected_branch
+  while IFS= read -r protected_branch; do
+    [ "$branch" = "$protected_branch" ] && return 0
+  done <<< "$PROTECTED_BRANCHES"
+  return 1
+}
+
+# --- Rule 1: PR must target pr_target ---
 case "$CMD" in
   *"gh pr create"*)
-    if ! echo "$CMD" | grep -q '\-\-base dev'; then
-      echo '{"decision":"block","reason":"BLOCKED: PRs must target dev branch. Use: gh pr create --base dev"}'
+    if ! echo "$CMD" | grep -qF -- "--base ${PR_TARGET}"; then
+      echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: PRs must target ${PR_TARGET} branch. Use: gh pr create --base ${PR_TARGET}\"}"
       exit 0
     fi
     ;;
 esac
 
-# --- Rule 2: No direct commits to dev or main ---
+# --- Rule 2: No direct commits to protected_branches ---
 case "$CMD" in
   *"git commit"*)
     BRANCH=$(git branch --show-current 2>/dev/null || true)
-    if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ] || [ "$BRANCH" = "dev" ]; then
-      echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: No direct commits to $BRANCH. Create a feature branch first.\"}"
+    if [ -n "$BRANCH" ] && branch_is_protected "$BRANCH"; then
+      echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: No direct commits to ${BRANCH}. Create a feature branch first.\"}"
       exit 0
     fi
     ;;
 esac
 
-# --- Rule 3: No force push to main ---
+# --- Rule 3: No force push to protected_branches ---
 case "$CMD" in
   *"git push"*"--force"*|*"git push"*"-f"*)
-    if echo "$CMD" | grep -qE '\b(main|master)\b'; then
-      echo '{"decision":"block","reason":"BLOCKED: Force push to main/master is forbidden. This is destructive and irreversible."}'
-      exit 0
-    fi
-    # If no branch specified, check current branch
-    if ! echo "$CMD" | grep -qE '\b(origin|upstream)\s+\S+'; then
+    if echo "$CMD" | grep -qE '\b(origin|upstream)\s+\S+'; then
+      PUSH_TARGET=$(echo "$CMD" | grep -oE '\b(origin|upstream)\s+\S+' | awk '{print $2}')
+      if branch_is_protected "$PUSH_TARGET"; then
+        echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: Force push to ${PUSH_TARGET} is forbidden. This is destructive and irreversible.\"}"
+        exit 0
+      fi
+    else
       BRANCH=$(git branch --show-current 2>/dev/null || true)
-      if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
-        echo '{"decision":"block","reason":"BLOCKED: Force push to main/master is forbidden. This is destructive and irreversible."}'
+      if [ -n "$BRANCH" ] && branch_is_protected "$BRANCH"; then
+        echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: Force push to ${BRANCH} is forbidden. This is destructive and irreversible.\"}"
         exit 0
       fi
     fi
     ;;
 esac
 
-# --- Rule 4: New branches must be based on latest dev ---
+# --- Rule 4: New branches must be based on latest pr_target ---
 case "$CMD" in
   *"git checkout -b"*|*"git switch -c"*)
     BRANCH=$(git branch --show-current 2>/dev/null || true)
-    if [ "$BRANCH" != "dev" ]; then
-      echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: New branches must be created from dev. Currently on '$BRANCH'. Run: git checkout dev && git pull origin dev first.\"}"
+    if [ "$BRANCH" != "$PR_TARGET" ]; then
+      echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: New branches must be created from ${PR_TARGET}. Currently on '${BRANCH}'. Run: git checkout ${PR_TARGET} && git pull origin ${PR_TARGET} first.\"}"
       exit 0
     fi
-    # Check if dev is up to date with origin
-    git fetch origin dev --quiet 2>/dev/null || true
-    LOCAL=$(git rev-parse dev 2>/dev/null || true)
-    REMOTE=$(git rev-parse origin/dev 2>/dev/null || true)
+    git fetch origin "$PR_TARGET" --quiet 2>/dev/null || true
+    LOCAL=$(git rev-parse "$PR_TARGET" 2>/dev/null || true)
+    REMOTE=$(git rev-parse "origin/${PR_TARGET}" 2>/dev/null || true)
     if [ -n "$LOCAL" ] && [ -n "$REMOTE" ] && [ "$LOCAL" != "$REMOTE" ]; then
-      echo '{"decision":"block","reason":"BLOCKED: Local dev is behind origin/dev. Run: git pull origin dev first."}'
+      echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: Local ${PR_TARGET} is behind origin/${PR_TARGET}. Run: git pull origin ${PR_TARGET} first.\"}"
       exit 0
     fi
     ;;

--- a/scripts/hooks/lib/query-task.sh
+++ b/scripts/hooks/lib/query-task.sh
@@ -30,3 +30,56 @@ tmb_unsigned_tasks() {
        );
   "
 }
+
+# tmb_config_get <key>
+# Prints the scalar value stored in plugin_config for <key>, unquoted.
+# Prints empty string when: key missing, DB absent, sqlite3 unavailable.
+# Never fails the caller.
+tmb_config_get() {
+  local key="$1"
+  local db
+  db=$(tmb_db_path) || true
+  [ -z "$db" ] && return 0
+  tmb_have_sqlite || return 0
+  sqlite3 "$db" "
+    SELECT json_extract(value_json, '$')
+      FROM plugin_config
+     WHERE key = '${key}';
+  " 2>/dev/null || true
+}
+
+# tmb_config_raw <key>
+# Prints the raw value_json column for <key> without JSON extraction.
+# Prints empty string when: key missing, DB absent, sqlite3 unavailable.
+# Never fails the caller.
+tmb_config_raw() {
+  local key="$1"
+  local db
+  db=$(tmb_db_path) || true
+  [ -z "$db" ] && return 0
+  tmb_have_sqlite || return 0
+  sqlite3 "$db" "
+    SELECT value_json
+      FROM plugin_config
+     WHERE key = '${key}';
+  " 2>/dev/null || true
+}
+
+# tmb_config_array <key>
+# Prints one element per line from a JSON-array-valued plugin_config key.
+# Prints nothing when: key missing, DB absent, sqlite3 unavailable.
+# Never fails the caller.
+tmb_config_array() {
+  local key="$1"
+  local db raw
+  db=$(tmb_db_path) || true
+  [ -z "$db" ] && return 0
+  tmb_have_sqlite || return 0
+  raw=$(sqlite3 "$db" "
+    SELECT value_json
+      FROM plugin_config
+     WHERE key = '${key}';
+  " 2>/dev/null || true)
+  [ -z "$raw" ] && return 0
+  echo "$raw" | jq -r '.[]' 2>/dev/null || true
+}

--- a/skills/tmb-reonboard.md
+++ b/skills/tmb-reonboard.md
@@ -1,0 +1,176 @@
+---
+name: tmb-reonboard
+description: Re-run the TMB onboarding flow on demand, showing current values as defaults. Handles branching model changes, PR target updates, and optional identity rename.
+agent: gatekeeper
+allowed-tools: Bash
+---
+
+# tmb-reonboard
+
+## A. Purpose
+
+Allow a user who has already completed first-run onboarding to update their
+branching model, PR target, protected branches, or gatekeeper/human identity
+without needing to know the underlying MCP calls. This skill re-runs the same
+3-step sequence as first-run onboarding, but reads current values first and
+uses them as press-enter defaults.
+
+This skill does NOT touch issues, tasks, or validation_attempts. It only
+reads and writes `plugin_config` keys and `identity`.
+
+## B. When Invoked
+
+Gatekeeper invokes this skill directly (no other agent spawn needed) when the
+Human says any of the following — or close paraphrases:
+
+- "re-onboard"
+- "change branching model" / "switch to gitflow" / "switch to github-flow"
+- "rename gatekeeper" / "rename yourself"
+- "update my name" / "change my name in bro"
+- "reset onboarding"
+
+## C. Execution Steps
+
+### Step 1 — Read current state
+
+Call:
+
+```
+config_list()
+identity_get()
+```
+
+Extract the following values (use `null` if absent):
+
+- `current_branching_model` — from `config_list()` key `branching_model`
+- `current_pr_target` — from `config_list()` key `pr_target`
+- `current_protected_branches` — from `config_list()` key `protected_branches`
+- `current_human_name` — from `identity_get()` field `human_name`
+- `current_gatekeeper_name` — from `identity_get()` field `gatekeeper_name`
+
+### Step 2 — Show current values
+
+Present a summary to the Human:
+
+> "Here's what I have on file:
+> - Branching model: `<current_branching_model>`
+> - PR target: `<current_pr_target>`
+> - Protected branches: `<current_protected_branches>`
+> - Your name: `<current_human_name>`
+> - My name: `<current_gatekeeper_name>`
+>
+> Let's walk through each. Press enter to keep the current value."
+
+### Step 3 — Identity (Step 1 of onboarding)
+
+Ask:
+
+> "What should I call you? (Press enter to keep `<current_human_name>`)"
+
+Then:
+
+> "And what would you like to call me? (Press enter to keep `<current_gatekeeper_name>`)"
+
+If both answers are blank (press-enter), skip the MCP call — nothing changed.
+Otherwise call:
+
+```
+identity_set(human_name=<new or current>, gatekeeper_name=<new or current>)
+```
+
+**Reset path:** If the Human says "reset everything" or "clear identity" at
+any point during this step, call `identity_reset()` then re-prompt these two
+questions with no defaults.
+
+### Step 4 — Branching model (Step 2 of onboarding)
+
+Ask:
+
+> "How does your team branch? (1) github-flow — single main, feature branches
+> off main, PRs back to main. (2) gitflow — long-lived develop branch,
+> releases promoted to main. (3) custom — you tell me.
+> (Press enter to keep `<current_branching_model>`)"
+
+If blank (press-enter), skip branching model changes — skip to Step 5.
+
+**Choice 1 (github-flow):**
+
+Ask PR target:
+
+> "What's your PR target branch? (Press enter to keep `<current_pr_target>`)"
+
+MCP calls:
+
+```
+config_set("branching_model", "github-flow")
+config_set("pr_target", <new answer or current_pr_target if blank>)
+config_set("protected_branches", <JSON array containing the chosen pr_target>)
+```
+
+**Choice 2 (gitflow):**
+
+Ask PR target:
+
+> "What's your PR target branch? (Press enter to keep `<current_pr_target>`)"
+
+MCP calls:
+
+```
+config_set("branching_model", "gitflow")
+config_set("pr_target", <new answer or current_pr_target if blank>)
+config_set("protected_branches", <JSON array: ["main", <chosen pr_target>] — deduplicated if user picked main>)
+```
+
+**Choice 3 (custom):**
+
+Ask:
+
+> "What's your PR target branch? (e.g. main, trunk, release)"
+
+Then:
+
+> "And which branches should I treat as protected (no direct commits)?
+> Comma-separated."
+
+MCP calls:
+
+```
+config_set("branching_model", "custom")
+config_set("pr_target", <answer to first question>)
+config_set("protected_branches", <split-and-trim CSV → JSON array>)
+```
+
+### Step 5 — Confirm and close
+
+After all MCP writes succeed, say:
+
+> "Done. Settings updated:
+> - Branching model: `<final_branching_model>`
+> - PR target: `<final_pr_target>`
+> - Protected branches: `<final_protected_branches>`
+> - Your name: `<final_human_name>`
+> - My name: `<final_gatekeeper_name>`
+>
+> Tell me what you want to work on."
+
+## D. Scope Constraint
+
+This skill ONLY calls the following MCP tools:
+
+- `config_list` (read)
+- `config_set` (write — `branching_model`, `pr_target`, `protected_branches` keys only)
+- `identity_get` (read)
+- `identity_set` (write)
+- `identity_reset` (write — only when user explicitly requests "reset everything")
+
+It MUST NOT call: `issue_create`, `task_create_batch`, `task_update_status`,
+`validation_record`, or any other MCP tool outside the above list.
+
+## E. Error Handling
+
+| Trigger | Response |
+|---|---|
+| `config_list()` or `identity_get()` fails | Report the error to the Human, offer to proceed with blank defaults or abort. Do NOT proceed silently. |
+| `config_set` or `identity_set` fails | Report the failure immediately. Do NOT continue to the next step. Ask if the Human wants to retry. |
+| Human provides an invalid branching model string | Only accept "github-flow", "gitflow", or "custom". For anything else, re-ask. |
+| Human says "reset everything" outside of Step 3 | Acknowledge, call `identity_reset()`, then restart from Step 3 with no defaults for identity and current config defaults for branching. |


### PR DESCRIPTION
## Summary

v0.3 Phase 4 — implements changes #D (identity rename) and #H (first-run onboarding). Gatekeeper now asks 2-3 questions on first activation (branching model, PR target, identity name), stores answers in the plugin's trajectory DB via MCP, and git-guards becomes config-driven.

### What changed (5 commits + 1 pr-reviewer fix)

| File | Change |
|---|---|
| `scripts/hooks/git-guards.sh` + `lib/query-task.sh` | Hook reads `branching_model` / `pr_target` / `protected_branches` from `plugin_config`; helper lib adds `tmb_config_get`, `tmb_config_raw`, `tmb_config_array`; non-blocking on fresh install |
| `agents/gatekeeper.md` §A.1 | First-run onboarding flow (4 verbatim prompts; branching-model path selects github-flow/gitflow/custom and writes appropriate config keys) |
| `agents/gatekeeper.md` §A.2 | Session-start `identity_get`; mid-session rename UX via natural language |
| `skills/tmb-reonboard.md` | New skill — user can change branching model or reset identity later |
| `README.md` + `CLAUDE.md` | Document first-run onboarding for users |

### PR Reviewer fix

- `594f2a9` — corrected public docs (both claimed answers written to `bro/config.yml`; actually written to SQLite via MCP). Also fixed CLAUDE.md's Onboarding Mode trigger description.

### Cross-cutting consistency (pr-reviewer verified)

- Config keys exact match across all writers (gatekeeper onboarding, tmb-reonboard skill) and all readers (git-guards.sh)
- Detection rule `config_get("branching_model")==null OR identity.created_at==null` identical in gatekeeper §A.1 and §G
- Fresh install doesn't deadlock (hook is non-blocking pre-onboarding)
- Mid-onboarding interruption is safe (per-step writes; `/tmb reonboard` recovers)

### Workflow execution

- Designed by architect (5 task specs at `TMB/docs/trustmybot/tasks/phase-4-*.md`)
- Implemented by 5 SWEs across 4 dependency layers (1 → 1 → 2 parallel → 1)
- All commits atomic (no splits)
- PR Reviewer: conditional-GO with M-1 + L-1 doc fixes (applied in `594f2a9`)

## Test plan

- [x] All 5 task specs' Success Criteria met
- [x] Hook handles fresh-install (no deadlock)
- [x] Hook blocks on missing config post-onboarding
- [x] Config keys byte-equivalent across CONFIG_KEYS.md, gatekeeper, tmb-reonboard, git-guards
- [x] No stale `bro/config.yml` references in user-facing docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)