### PR TITLE
v0.3 Phase 6: release prep — bump to 0.3.0, CHANGELOG, PLUGIN_BUGS→Issues

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TMB multi-agent Claude Code plugin with SQLite trajectory MCP.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,83 @@
+# Changelog
+
+All notable changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
+
+## [0.3.0] — 2026-04-22
+
+Workflow redesign: SQLite is canonical state; files are generated snapshots; git is the organizing primitive; gatekeeper is silent by default, opinionated when needed.
+
+### Added
+
+- **Hybrid architecture-doc directory** (`docs/trustmybot/architecture/{auto,manual}/`): `auto/` regenerates from `file_registry` SQLite table via lazy git-log diff parse; `manual/` holds ADRs + narrative. Four auto-generated files: `codebase-tree.md`, `erd.md`, `module-graph.md`, `changelog.md`.
+- **`architecture_regen` MCP tool** (orchestrator): full + incremental scopes, target filtering, path-safety.
+- **`file_registry` MCP tools** (`upsert`, `list`, `delete`): track files, types, imports, exports, last_change.
+- **`regen_state` MCP tools** (`get`, `set`): track last-regen-per-target with SHA.
+- **`discussions` MCP tools** (`append`, `list`, `issue_get_with_discussions`): conversational intent captured in SQLite, replacing `GOALS.md` / `DISCUSSION.md` files.
+- **`issue_list` + `issue_snapshot_md` MCP tools**: enumerate issues, generate read-only markdown snapshots on demand.
+- **`task_set_spec_path` MCP tool**: link task rows to markdown spec files.
+- **`task_update_status` accepts `commit_sha`**: atomic close with commit linkage.
+- **Silent-default UX** for gatekeeper: pre-scan only on first code-touching ask of a session, not every greeting.
+- **Two-path workflow** (simple vs difficult): every code change routes through architect; heuristic = "does it require updates to `docs/trustmybot/architecture/`?"; architect has trivial vs standard task-template tiers.
+- **First-run onboarding**: gatekeeper detects fresh project, asks 2-3 questions (branching model, PR target, identity), persists via `config_set` + `identity_set`.
+- **Identity rename UX**: `identity_get` at session start; mid-session rename via natural language; `identity_set` persists.
+- **`tmb-reonboard` skill**: re-run onboarding to change branching model or reset identity later.
+- **`refresh-architecture` skill**: wraps `architecture_regen` with user-facing invocation.
+- **Gatekeeper lazy-regen**: runs `architecture_regen` at session start when new commits warrant it (≤25 silent; >25 nudge user).
+- **PR Reviewer auto-dir check**: flags manual edits to `architecture/auto/*.md` files.
+- **`git-guards.sh` config-driven**: reads `branching_model` / `pr_target` / `protected_branches` from `plugin_config` SQLite; supports trunk-based / gitflow / custom models.
+- **Branch-id format validation**: `task_create_batch` enforces `^(feat|fix|refactor|chore|docs|test|perf|build|ci|style|revert)/[a-z0-9][a-z0-9-]{0,62}$`.
+- **Template seeding** (`templates/docs-trustmybot/`): replaces `bro-template/`; includes `architecture/` subtree + `tasks/` + `snapshots/` + `SPEC-FORMAT.md`.
+- **Role-gated MCP writes**: `discussion_append`, `task_set_spec_path`, `issue_snapshot_md`, `file_registry_upsert`, `file_registry_delete`, `regen_state_set`, `architecture_regen` require appropriate agent roles.
+
+### Changed
+
+- **Task spec format**: XML envelope dropped. New specs are markdown at `docs/trustmybot/tasks/<branch_id_filename>.md` (canonical format in `docs/trustmybot/SPEC-FORMAT.md`).
+- **Workflow directory**: `bro/` → `docs/trustmybot/` everywhere (agents, skills, hooks, README, CLAUDE.md).
+- **Branch-id semantics**: accepts git-convention strings (`feat/user-login`, `fix/auth-crash`), not synthetic `1.2.3` numbering. Gatekeeper proposes branch names from intent.
+- **SWE agent prompt**: reads markdown specs (not XML); closes via `task_update_status(commit_sha=<sha>)`; never hand-edits spec files.
+- **Architect agent prompt**: writes markdown specs; captures intent via `issue_create` + `discussion_append`; two task-template tiers (trivial / standard).
+- **PR Reviewer agent prompt**: records verdicts via `validation_record` MCP call; no `Edit` tool needed; new No-Edit Discipline section.
+- **Gatekeeper agent prompt**: MCP-driven pre-scan; new Section C.0 Triage (simple/difficult); Section A.1 First-Run Onboarding; Section A.2 Identity; Section A.3 Lazy Architecture Regen.
+- **`CLAUDE.md` Workflow Files table**: reflects SQLite-canonical state model (files are snapshots).
+- **Schema v4**: added `discussions`, `file_registry`, `plugin_config`, `identity`, `regen_state` tables; added `tasks.task_spec_path` + `tasks.commit_sha` columns. Auto-migration from v3.
+- **`require-task-xml.sh` → `require-task-spec.sh`**: accepts `docs/trustmybot/tasks/*.{xml,md}` with format-dispatched authorization checks (also accepts absolute paths for workspace-level specs).
+- **`require-review-sign.sh` queries SQLite** (via `lib/query-task.sh` helper), with legacy XML fallback.
+
+### Removed
+
+- `bro-template/` (replaced by `templates/docs-trustmybot/`).
+- `bro/GOALS.md`, `bro/BLUEPRINT.md`, `bro/DISCUSSION.md` as required files (replaced by `issues` + `discussions` SQLite tables; snapshots generated on demand).
+- XML task spec envelope (replaced by markdown frontmatter + body).
+- Hardcoded `dev` / `main` in `git-guards.sh` (now config-driven).
+- `scripts/hooks/require-task-xml.sh` (renamed).
+
+### Known issues
+
+See the plugin's GitHub Issues for open items migrated from v0.2 dogfooding:
+
+- #13 require-review-sign blocks all pushes, not just dev/main
+- #14 subagent Bash may bypass host PreToolUse hooks (unconfirmed)
+- #16 withAgentScope middleware redactor param unused (hygiene)
+
+### Migration notes (0.2.x → 0.3.0)
+
+- SQLite schema auto-migrates v3 → v4 on first load.
+- Existing projects with `bro/` directories should rename to `docs/trustmybot/` (no data migration — paths only).
+- First activation on 0.3.0 triggers the onboarding flow; use `/tmb reonboard` to re-run.
+- XML task specs in `bro/tasks/` stop being recognized. New specs are markdown at `docs/trustmybot/tasks/`.
+
+## [0.2.0] — 2026-04-21
+
+Initial native Claude Code plugin format release. Migrated from `.claude/`-based scaffolding to proper plugin manifests + marketplace.
+
+### Added
+
+- Native plugin format (`.claude-plugin/plugin.json` + marketplace manifest).
+- Bundled SQLite MCP server at `mcp/trajectory-server/` (schema v3, 13 tables, 23 tools).
+- Two-tier agent roster: global (`gatekeeper`, `prompt-engineer`) + project placeholders (`ceo`, `cto`, `architect`, `swe`, `pr-reviewer`).
+- Agent-creator skill for on-demand domain agents.
+- Hook-enforced task-spec gate + review-sign gate.
+- Information-isolation via frontmatter (`isolation: worktree`, `disallowedTools`).
+
+[0.3.0]: https://github.com/trustmybot/plugin/releases/tag/v0.3.0
+[0.2.0]: https://github.com/trustmybot/plugin/releases/tag/v0.2.0


### PR DESCRIPTION
## Summary

Final v0.3 phase — release prep only. No functional plugin changes; the v0.3.0 release is ready once `dev` → `main` merge + tag is done by a human.

### What changed

- **`.claude-plugin/plugin.json` bumped 0.2.0 → 0.3.0**
- **`CHANGELOG.md` added** with full v0.3.0 changelog: all blueprint changes #A–#J documented under Added / Changed / Removed, known issues linked, migration notes for v0.2.x → v0.3.0

### What was done outside this PR

- **4 GitHub Issues filed** for plugin bugs migrated from TMB workspace's `bro/PLUGIN_BUGS.md`:
  - #13 require-review-sign blocks all pushes (medium, still open)
  - #14 subagent Bash bypass suspicion (medium, unconfirmed)
  - #15 PR Reviewer read-only — superseded by v0.3 redesign (tracking/closed)
  - #16 withAgentScope redactor unused (low, hygiene)

### What's NOT in this PR

- `git tag v0.3.0` — reserved for human per explicit instruction
- `gh release create` — reserved for human
- `main` branch update — reserved for human (currently at v0.2 scaffolding state)

### Blueprint coverage

All 10 v0.3 blueprint changes complete:

| Change | Phase | Status |
|---|---|---|
| #A bro/ → docs/trustmybot/ | Phase 1 | ✅ |
| #B Drop task XML envelope | Phase 2 | ✅ |
| #C PLUGIN_BUGS → GitHub Issues | Phase 6 | ✅ (this PR) |
| #D Gatekeeper identity rename | Phase 4 | ✅ |
| #E Drop GOALS/DISCUSSION/BLUEPRINT files | Phase 2 | ✅ |
| #F branch_id = git-convention names | Phase 1 | ✅ |
| #G Silent-default UX | Phase 3 | ✅ |
| #H First-run onboarding | Phase 4 | ✅ |
| #I Two-path workflow (simple/difficult) | Phase 3 | ✅ |
| #J Hybrid architecture/ dir | Phase 5 | ✅ |

## Test plan

- [x] `plugin.json` valid JSON, version=0.3.0
- [x] CHANGELOG.md renders correctly
- [x] 4 Issues filed on plugin repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)