### PR TITLE
🐛 v0.3 followups: resolve #13 + #16, close #15, add #14 probe harness

### DIFF
--- a/mcp/trajectory-server/src/middleware/agent-scope.ts
+++ b/mcp/trajectory-server/src/middleware/agent-scope.ts
@@ -39,8 +39,6 @@ export interface ValidationAttempt {
   created_at: string;
 }
 
-export type Redactor<T> = (value: T, agent: AgentRole, args: Record<string, unknown>) => T;
-
 type Fn = (args: Record<string, unknown>) => Promise<CallToolResult>;
 
 export function requireRoles(toolName: string, allowedRoles: AgentRole[], handler: Fn): Fn {
@@ -105,24 +103,14 @@ export function redactValidationRow(
   return row;
 }
 
-export function withAgentScope<T>(
-  toolName: string,
-  handler: Fn,
-  redactor?: Redactor<T>,
-): Fn {
-  return async (args) => {
-    const agent = normalizeAgent(args['agent'] as string | undefined);
-    const result = await handler(args);
-
-    if (!redactor || result.isError) return result;
-
-    const first = result.content[0];
-    if (!first || first.type !== 'text') return result;
-
-    const parsed = JSON.parse(first.text) as T;
-    if (parsed === null) return result;
-
-    const redacted = redactor(parsed, agent, args);
-    return { ...result, content: [{ type: 'text' as const, text: JSON.stringify(redacted) }] };
-  };
+/**
+ * Pass-through wrapper around a handler. Kept as a seam for future
+ * cross-cutting concerns (tracing, metrics, etc.) that need to see every
+ * MCP tool call. Redaction is done INSIDE individual handlers against
+ * `redactIssue` / `redactValidationRow`; role enforcement is done via
+ * `requireRoles`. This function deliberately does not carry a redactor
+ * argument — callers that need redaction should apply it in-handler.
+ */
+export function withAgentScope(_toolName: string, handler: Fn): Fn {
+  return handler;
 }

--- a/scripts/hooks/diagnostic/README.md
+++ b/scripts/hooks/diagnostic/README.md
@@ -1,0 +1,45 @@
+# Hook diagnostic tools
+
+Opt-in scripts for debugging plugin hooks. **Not wired by default.**
+
+## `probe-bash.sh` — verify PreToolUse:Bash hook delivery
+
+Used to investigate [issue #14](https://github.com/trustmybot/plugin/issues/14): whether subagent Bash calls trigger host-level PreToolUse hooks.
+
+### Enable
+
+Add to `hooks/hooks.json` as the FIRST Bash matcher entry so it fires before any gating hook:
+
+```json
+{
+  "matcher": "Bash",
+  "hooks": [
+    { "type": "command", "command": "scripts/hooks/diagnostic/probe-bash.sh", "timeout": 5 },
+    { "type": "command", "command": "scripts/hooks/git-guards.sh", "timeout": 10 }
+  ]
+}
+```
+
+Restart Claude Code (plugin hook config is loaded at startup, not hot-reloaded).
+
+### Run the test
+
+```bash
+rm -f /tmp/tmb-hook-probe.log
+# ... inside a fresh Claude Code session ...
+# 1. Run a Bash tool call in your parent transcript (e.g., `pwd`)
+# 2. Spawn any subagent that runs a Bash tool call
+# 3. Check the log:
+cat /tmp/tmb-hook-probe.log
+```
+
+### Interpret
+
+Each line is `<epoch> PID=<shell_pid> CMD=<first 80 chars>`.
+
+- **If BOTH parent and subagent Bash calls log**: PreToolUse hooks fire for subagents. No bypass. Close #14.
+- **If ONLY parent calls log**: subagent Bash bypasses host hooks. Confirmed platform limitation; document in README and consider moving critical enforcement to `.git/hooks/pre-commit`.
+
+### Disable
+
+Remove the probe-bash.sh entry from `hooks/hooks.json` and restart Claude Code. Optionally `rm /tmp/tmb-hook-probe.log`.

--- a/scripts/hooks/diagnostic/probe-bash.sh
+++ b/scripts/hooks/diagnostic/probe-bash.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Diagnostic hook for issue #14 — logs every Bash PreToolUse fire.
+# Non-blocking: always exits 0. Writes to /tmp/tmb-hook-probe.log.
+set -euo pipefail
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+TS=$(date +%s)
+echo "$TS PID=$$ CMD=$(echo "$CMD" | head -c 80)" >> /tmp/tmb-hook-probe.log
+exit 0

--- a/scripts/hooks/require-review-sign.sh
+++ b/scripts/hooks/require-review-sign.sh
@@ -11,6 +11,26 @@ case "$CMD" in
   *) exit 0 ;;
 esac
 
+# Issue #13: feature/* pushes are always allowed (work-in-progress backups
+# don't require signoff). Enforcement applies only to pushes/merges targeting
+# protected branches (dev, main, master, or anything the user's branching
+# model declared as protected).
+if echo "$CMD" | grep -qE '\bgit push[[:space:]]+[^[:space:]]+[[:space:]]+(HEAD:)?feature/'; then
+  exit 0
+fi
+if echo "$CMD" | grep -qE '\bgit push[[:space:]]+[^[:space:]]+[[:space:]]+(HEAD:)?(fix|feat|refactor|chore|docs|test|perf|build|ci|style|revert)/'; then
+  exit 0
+fi
+# Bare `git push` with current branch being a feature/* shape — also allow.
+if ! echo "$CMD" | grep -qE '\bgit push[[:space:]]+[^[:space:]]+[[:space:]]+'; then
+  CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || true)
+  case "$CURRENT_BRANCH" in
+    feature/*|fix/*|feat/*|refactor/*|chore/*|docs/*|test/*|perf/*|build/*|ci/*|style/*|revert/*)
+      exit 0
+      ;;
+  esac
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/hooks/lib/query-task.sh
 . "$SCRIPT_DIR/lib/query-task.sh"


### PR DESCRIPTION
## Summary

Follow-up fixes for the 4 GitHub Issues filed at v0.3.0 release prep.

| Issue | Severity | Status |
|---|---|---|
| #13 require-review-sign blocks all pushes | Medium | **RESOLVED** — hook now exits 0 for pushes to conventional-commits-prefixed branches |
| #14 subagent Bash bypass suspicion | Medium (unconfirmed) | **Probe harness added** — fresh session required to run empirical test |
| #15 PR Reviewer read-only | Tracking | **CLOSED** — already resolved in v0.3 Phase 2 redesign |
| #16 withAgentScope redactor unused | Low | **RESOLVED** — param + dead branch removed, function kept as seam |

## Changes

- **`scripts/hooks/require-review-sign.sh`** — allows `git push origin <any>/<slug>` where the prefix matches `feature/fix/feat/refactor/chore/docs/test/perf/build/ci/style/revert`. Also checks bare `git push` against the current branch name.
- **`mcp/trajectory-server/src/middleware/agent-scope.ts`** — `withAgentScope` simplified to `(toolName, handler) => handler`; dropped unused `redactor?` arg + `Redactor<T>` type export.
- **`scripts/hooks/diagnostic/probe-bash.sh`** + **`scripts/hooks/diagnostic/README.md`** — opt-in diagnostic hook for #14. NOT wired by default.

## Test plan

- [x] `bun run build` clean
- [x] `node --test dist/test/*.test.js` → 237/237 pass
- [x] Hook smoke tests: feature/* pushes allowed, bare `git push` on a feature branch allowed, dev push gates normally
- [x] Probe hook runs correctly when invoked directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)