### PR TITLE
🔖 fix: bump marketplace.json version to 0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     {
       "name": "tmb",
       "source": ".",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "description": "TMB multi-agent Claude Code plugin with SQLite trajectory MCP."
     }
   ]


### PR DESCRIPTION
Phase 6 bumped plugin.json but missed marketplace.json mirror field. One-line fix before anyone installs via marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)