### PR TITLE
📝 docs: local-testing setup guide (closes #27)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Every code change should add or update tests.
 
 - **MCP server changes** → `mcp/trajectory-server/src/test/<name>.test.ts`. See `tests/README.md` for the helper API.
 - **Hook changes** → `tests/hooks/<name>.test.sh`. See the same README.
-- **Agent prompts / skills / docs** — no automated tests yet (gap). Run the manual dogfood checklist in `tests/README.md` before PR.
+- **Agent prompts / skills / docs** — no automated tests yet (gap). Walk the manual dogfood checklist in [`docs/local-testing.md`](docs/local-testing.md) before PR.
 
 ## Pre-PR checklist
 

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -1,0 +1,161 @@
+# Local Testing — Setup Guide
+
+How to stand up a scratch project and exercise the TMB plugin end-to-end. This is the canonical manual-testing path for contributors and dogfooders. For automated test suites, see [`tests/README.md`](../tests/README.md).
+
+## Prerequisites
+
+- **Claude Code** — `claude --version` should work. [Install instructions](https://claude.com/claude-code).
+- **Node 20+** — the bundled MCP server runs on Node.
+- **bun** — used to build the MCP server. `curl -fsSL https://bun.sh/install | bash`.
+- **sqlite3** — for inspecting the trajectory DB. Usually preinstalled; `brew install sqlite3` if not.
+
+Verify the MCP server builds cleanly before doing anything else:
+
+```bash
+cd plugin/mcp/trajectory-server
+bun install
+bun run build
+```
+
+If that fails, fix it first — the plugin won't load a broken MCP server.
+
+---
+
+## Two install modes
+
+Pick one. Mode A is tighter for iteration; Mode B matches the release path end users experience.
+
+### Mode A — dev mode with hot reload (recommended for contributor iteration)
+
+Launch Claude Code against the plugin source directly:
+
+```bash
+mkdir -p /Users/Zax/Git/GitHub/TMB/test_plugin  # or anywhere disposable
+cd /Users/Zax/Git/GitHub/TMB/test_plugin
+git init && git commit --allow-empty -m "init"
+
+claude --plugin-dir /Users/Zax/Git/GitHub/TMB/plugin
+```
+
+Edits to agent prompts, skills, or hook scripts are picked up after `/reload-plugins` inside the session. TypeScript edits under `mcp/trajectory-server/src/` require a rebuild (`bun run build`) then `/reload-plugins`.
+
+No install, no cache, no marketplace.
+
+### Mode B — marketplace install (matches end-user flow)
+
+```bash
+mkdir -p /tmp/tmb-smoke && cd /tmp/tmb-smoke
+git init && git commit --allow-empty -m "init"
+
+claude                                   # launch CC
+```
+
+Inside the session:
+
+```
+/plugin marketplace add /Users/Zax/Git/GitHub/TMB/plugin
+/plugin install tmb@trustmybot
+```
+
+This is what downstream users do with `trustmybot/plugin` as the marketplace path. Useful for verifying the install UX, not for rapid iteration.
+
+---
+
+## First-run expectations
+
+On the first prompt in a fresh project, the `gatekeeper` should:
+
+1. Introduce itself in one short paragraph.
+2. Seed the project's domain-role templates at `./.claude/agents/ceo.md` + `cto.md`.
+3. Ask 2–3 onboarding questions:
+   - Branching model (trunk / gitflow / feature-branch)
+   - PR target + protected branches
+   - Identity for commits and agent comments
+
+After the answers are captured, verify they persisted to SQLite:
+
+```bash
+sqlite3 ~/.config/claude-code/plugin-data/tmb/trajectory.db <<'SQL'
+  SELECT key, value_json FROM plugin_config;
+  SELECT * FROM identity;
+SQL
+```
+
+Expected rows: `branching_model`, `pr_target`, `protected_branches`, and an `identity` row with `gatekeeper_name` + `human_name`.
+
+If nothing is written, the MCP server didn't connect — check `claude --plugin-dir` output for MCP errors.
+
+---
+
+## Hot reload within a session
+
+```
+/reload-plugins
+```
+
+Picks up edits to:
+- Agent prompts (`plugin/agents/*.md`)
+- Skills (`plugin/skills/**/SKILL.md`)
+- Hook scripts (`plugin/scripts/hooks/*.sh`)
+- Template content (`plugin/templates/**/*`)
+
+Does **not** pick up TypeScript edits in the MCP server. Rebuild first:
+
+```bash
+cd plugin/mcp/trajectory-server && bun run build
+```
+
+Then `/reload-plugins`.
+
+---
+
+## Reset between tests
+
+```bash
+# Inside Claude Code (if installed via marketplace):
+/plugin marketplace remove trustmybot
+
+# Outside CC — always reset the DB:
+rm ~/.config/claude-code/plugin-data/tmb/trajectory.db
+```
+
+The DB persists across sessions and across plugin updates. Stale onboarding state is the #1 source of "why isn't first-run triggering" confusion — delete the DB whenever you want a truly fresh run.
+
+---
+
+## End-to-end dogfood checklist
+
+Manual scenarios to walk before shipping a change. Tick each after running.
+
+| # | Scenario | Expected |
+|---|---|---|
+| 1 | Fresh install in empty project | Gatekeeper introduces itself; onboarding triggers |
+| 2 | Read-only question (`list files in src/`) | Gatekeeper answers inline; no agent spawn |
+| 3 | Simple code change | Gatekeeper triages `simple` → architect double-checks → task row created via `task_create_batch(spec_body_md=...)` → SWE in worktree reads via `task_get` |
+| 4 | Architecture-affecting change | Gatekeeper triages `difficult` → architect updates `architecture/manual/` ADR → task row (standard template) |
+| 5 | `/tmb reonboard` phrase | Skill re-prompts branching + identity |
+| 6 | Identity rename (`call yourself alex`) | `identity_set` persists; subsequent responses use new name |
+| 7 | Architecture regen (`refresh architecture docs`) | 4 files regenerated at `docs/trustmybot/architecture/auto/` with generated-header |
+| 8 | Commit on protected branch | `git-guards.sh` blocks |
+| 9 | Push to `feature/*` branch | Always allowed (issue #13) |
+| 10 | Push to dev/main with unsigned completed tasks | `require-review-sign.sh` blocks until pr-reviewer records `validation_record(verdict='pass')` |
+
+Any failure here is a bug a downstream user will hit identically — file an issue.
+
+---
+
+## Common pitfalls
+
+- **"MCP server not connected"** — almost always a build failure. Run `cd plugin/mcp/trajectory-server && bun run build` and check for errors.
+- **"Onboarding didn't fire"** — stale DB. Delete `~/.config/claude-code/plugin-data/tmb/trajectory.db` and relaunch.
+- **"Agent changes didn't take effect"** — forgot `/reload-plugins`, or CC cached a previous install (Mode B). Try Mode A for cleaner iteration.
+- **"Hook didn't block"** — hook path mismatch. Check `plugin/hooks/hooks.json` points at the script you edited and that the script is executable (`chmod +x`).
+- **"git-guards blocked my legitimate commit"** — check `plugin_config.protected_branches` — you're on a configured protected branch. Override intentionally or switch to a feature branch.
+
+---
+
+## Related
+
+- [`tests/README.md`](../tests/README.md) — automated MCP + hook test suites (`bash tests/run-all.sh`)
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — branch workflow, pre-PR checklist, design principles
+- [`mcp/trajectory-server/docs/CONFIG_KEYS.md`](../mcp/trajectory-server/docs/CONFIG_KEYS.md) — every `plugin_config` key the plugin reads or writes

--- a/tests/README.md
+++ b/tests/README.md
@@ -64,70 +64,7 @@ Assertion helpers in `tests/lib/assert.sh`:
 
 ## Local dogfood testing (end-to-end)
 
-The real correctness check is running the plugin against a project and watching for workflow friction. Every bug hit here is a bug downstream users will hit identically.
-
-### Fastest smoke test (~5 min, disposable scratch dir)
-
-```bash
-mkdir -p /tmp/tmb-test && cd /tmp/tmb-test
-git init && git commit --allow-empty -m "init"
-
-claude                                # launch Claude Code here
-```
-
-Inside the session:
-
-```
-/plugin marketplace add /Users/Zax/Git/GitHub/TMB/plugin
-/plugin install tmb@trustmybot
-```
-
-**Expected:** gatekeeper greets you, first-run onboarding asks branching model + PR target + identity. Verify answers persisted:
-
-```bash
-sqlite3 ~/.config/claude-code/plugin-data/tmb/trajectory.db \
-  "SELECT * FROM plugin_config; SELECT * FROM identity;"
-```
-
-### Hot-reload during a session
-
-```
-/reload-plugins
-```
-
-Or for tight dev iteration, launch with `--plugin-dir` (skips install/caching):
-
-```bash
-claude --plugin-dir /Users/Zax/Git/GitHub/TMB/plugin
-```
-
-Edits picked up by `/reload-plugins`.
-
-### Reset between tests
-
-```bash
-# Inside Claude Code:
-/plugin marketplace remove trustmybot
-# Outside:
-rm ~/.config/claude-code/plugin-data/tmb/trajectory.db
-```
-
-## End-to-end dogfood checklist
-
-Manual checks before shipping. Tick each after a change:
-
-| # | Scenario | Expected |
-|---|---|---|
-| 1 | Fresh install in empty project | Gatekeeper introduces itself; onboarding triggers |
-| 2 | Read-only question ("list files in src/") | Gatekeeper answers inline; no agent spawn |
-| 3 | Simple code change | Gatekeeper triages `simple` → architect double-checks → task row created via `task_create_batch(spec_body_md=...)` → SWE in worktree reads via `task_get` |
-| 4 | Architecture-affecting change | Gatekeeper triages `difficult` → architect updates `architecture/manual/` ADR → task row (standard template) |
-| 5 | `/tmb reonboard` phrase | Skill re-prompts branching + identity |
-| 6 | Identity rename ("call yourself alex") | `identity_set` persists; subsequent responses use new name |
-| 7 | Architecture regen ("refresh architecture docs") | 4 files regenerated at `docs/trustmybot/architecture/auto/` with generated-header |
-| 8 | Commit on protected branch | `git-guards.sh` blocks |
-| 9 | Push to `feature/*` branch | Always allowed (issue #13) |
-| 10 | Push to dev/main with unsigned completed tasks | `require-review-sign.sh` blocks until pr-reviewer records `validation_record(verdict='pass')` |
+For setting up a scratch project and exercising the plugin end-to-end — install modes, first-run expectations, DB verification, hot reload, reset, the 10-scenario dogfood checklist, and common pitfalls — see [`docs/local-testing.md`](../docs/local-testing.md).
 
 ## Gaps not covered by this suite (worth filing)
 


### PR DESCRIPTION
## Summary

Adds `plugin/docs/local-testing.md` as the canonical contributor guide for exercising the plugin end-to-end. Moves (not duplicates) the dogfood content out of `tests/README.md`, leaving that file focused on automated test suites.

## Changes

- **New:** `docs/local-testing.md` — prerequisites, two install modes (`--plugin-dir` for hot-reload iteration, `/plugin marketplace add` for release-like), scratch-project setup, first-run expectations, DB verification via `sqlite3`, hot-reload rules, reset procedure, 10-scenario dogfood checklist, common pitfalls.
- **Trimmed:** `tests/README.md` — the "Local dogfood testing" and "End-to-end dogfood checklist" sections replaced with a one-line pointer. Reduces duplication and keeps that file focused on automated suites.
- **Link added:** `CONTRIBUTING.md` — "Writing tests" section now points at the new doc.

## Test plan

- [x] Docs only — no code changes
- [ ] Reviewer follows the guide in a fresh scratch dir to confirm steps work top-to-bottom
- [ ] Reviewer confirms `tests/README.md` pointer lands correctly

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)