### PR TITLE
✨ feat(mcp): per-project DB at <cwd>/.claude/tmb/trajectory.db (closes #29)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,10 +2,7 @@
   "servers": {
     "trajectory-server": {
       "command": "node",
-      "args": ["mcp/trajectory-server/dist/index.js"],
-      "env": {
-        "TRAJECTORY_DB_PATH": "${CLAUDE_PLUGIN_DATA}/trajectory.db"
-      }
+      "args": ["mcp/trajectory-server/dist/index.js"]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Takes ~30 seconds. The answers are stored in the plugin's trajectory DB via MCP 
 
 ## Persistence (bundled MCP)
 
-The plugin ships a Node MCP server at `plugin/mcp/trajectory-server/` registered via `plugin/.mcp.json`. It owns a SQLite database at `${CLAUDE_PLUGIN_DATA}/trajectory.db` (persistent across plugin updates). Agents call MCP tools (`issue_create`, `task_update_status`, `validation_record`, etc.) instead of writing raw state. `gatekeeper` calls `issue_resume()` on session start to detect and pick up unfinished work.
+The plugin ships a Node MCP server at `plugin/mcp/trajectory-server/` registered via `plugin/.mcp.json`. It owns a SQLite database at `<project-root>/.claude/tmb/trajectory.db` — project-local, per-user, gitignored (the plugin-root `.gitignore` excludes `.claude/`). Each project has its own DB; each developer has their own copy. Set `TRAJECTORY_DB_PATH` to override (e.g., `:memory:` for ephemeral CI runs). Agents call MCP tools (`issue_create`, `task_update_status`, `validation_record`, etc.) instead of writing raw state. `gatekeeper` calls `issue_resume()` on session start to detect and pick up unfinished work.
 
 ## Source Code Access Control
 

--- a/docs/architecture/ERD.md
+++ b/docs/architecture/ERD.md
@@ -85,9 +85,14 @@ erDiagram
         INT  issue_id FK
         TEXT branch_id
         TEXT parent_branch_id
+        TEXT title
+        TEXT description
+        TEXT tools_required "JSON array"
+        TEXT skills_required "JSON array"
+        TEXT success_criteria
         TEXT status
-        TEXT spec_body
         INT  attempts
+        TEXT spec_body
         TEXT commit_sha
     }
 
@@ -97,6 +102,7 @@ erDiagram
         INT  attempt_n
         TEXT agent
         TEXT verdict
+        TEXT feedback
     }
 
     ledger {
@@ -111,8 +117,11 @@ erDiagram
         INT  id PK
         INT  issue_id FK
         TEXT branch_id
+        TEXT from_node
         TEXT tool_name
+        TEXT tool_args "JSON"
         TEXT output
+        INT  round
     }
 
     discussions {
@@ -135,6 +144,7 @@ erDiagram
         INT  roundtable_id FK
         TEXT agent
         TEXT vote
+        TEXT rationale
     }
 ```
 
@@ -182,7 +192,7 @@ erDiagram
 - **gatekeeper** — reads `plugin_config`, `identity`, `issues(status='open')` on session start. Writes `discussions` when relaying human intent.
 - **architect** — `issue_create` → `discussion_append` → `task_create_batch(spec_body)` → `task_update_status` → `validation_record`. Also edits agent prompts, skill files, and workflow markdown when they drift (see `skills/docs-conventions` prompt-editing rules).
 - **swe** — `task_get(id)` for spec → `ledger_log` / `audit_log` during work → `task_update_status('completed')` on success.
-- **pr-reviewer** — `task_list(issue_id, status='completed')` → `validation_record(verdict)` per task.
+- **pr-reviewer** — `task_get(task_id)` to inspect the spec + status of the task passed in the spawn → `validation_record(task_id, attempt_n, verdict, feedback)` to sign off. Never writes to `tasks`; status flip to `closed` is the architect's call.
 - **monitors/tmb-trajectory-events.js** — read-only tail of `ledger` for status-line output.
 
 External writers are blocked by role-gating inside each `tools/*.ts` family (see `middleware/agent-scope.ts` for `requireRoles` + `AgentRole` type).

--- a/docs/architecture/ERD.md
+++ b/docs/architecture/ERD.md
@@ -1,6 +1,6 @@
 # Trajectory DB — Entity Relationship Diagram
 
-SQLite schema (`mcp/trajectory-server/src/schema.sql`, `schema_version = 1` baseline). Persistent at `${CLAUDE_PLUGIN_DATA}/trajectory.db` (see issue #29 for pending per-project scoping), owned by the bundled MCP server.
+SQLite schema (`mcp/trajectory-server/src/schema.sql`, `schema_version = 1` baseline). Persistent at `<cwd>/.claude/tmb/trajectory.db` — project-local, per-user, gitignored. Override with `TRAJECTORY_DB_PATH` for CI / ephemeral runs (`:memory:`, custom file).
 
 ## Overview
 

--- a/docs/architecture/FILES.md
+++ b/docs/architecture/FILES.md
@@ -167,7 +167,7 @@ plugin/
 ## Open issues touching file-map concerns
 
 - **#14** — subagent Bash may bypass PreToolUse hooks (diagnostic harness shipped at `scripts/hooks/diagnostic/`)
-- **#29** — DB location should scope per-project rather than one global file under `CLAUDE_PLUGIN_DATA`
+- (closed by this PR: #29 — DB now project-local at `<cwd>/.claude/tmb/trajectory.db`)
 
 ## Summary
 

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -75,10 +75,10 @@ On the first prompt in a fresh project, the `gatekeeper` should:
    - PR target + protected branches
    - Identity for commits and agent comments
 
-After the answers are captured, verify they persisted to SQLite:
+After the answers are captured, verify they persisted to SQLite. The DB is project-local at `<your-project>/.claude/tmb/trajectory.db`:
 
 ```bash
-sqlite3 ~/.config/claude-code/plugin-data/tmb/trajectory.db <<'SQL'
+sqlite3 .claude/tmb/trajectory.db <<'SQL'
   SELECT key, value_json FROM plugin_config;
   SELECT * FROM identity;
 SQL
@@ -118,11 +118,11 @@ Then `/reload-plugins`.
 # Inside Claude Code (if installed via marketplace):
 /plugin marketplace remove trustmybot
 
-# Outside CC — always reset the DB:
-rm ~/.config/claude-code/plugin-data/tmb/trajectory.db
+# Outside CC — always reset the project-local DB:
+rm -rf .claude/tmb/
 ```
 
-The DB persists across sessions and across plugin updates. Stale onboarding state is the #1 source of "why isn't first-run triggering" confusion — delete the DB whenever you want a truly fresh run.
+The DB persists across sessions but is scoped to the project directory you launch CC from. Switch projects → different DB. Delete `.claude/tmb/` whenever you want a truly fresh run. Stale onboarding state is the #1 source of "why isn't first-run triggering" confusion.
 
 ---
 
@@ -150,7 +150,7 @@ Any failure here is a bug a downstream user will hit identically — file an iss
 ## Common pitfalls
 
 - **"MCP server not connected"** — almost always a build failure. Run `cd plugin/mcp/trajectory-server && bun run build` and check for errors.
-- **"Onboarding didn't fire"** — stale DB. Delete `~/.config/claude-code/plugin-data/tmb/trajectory.db` and relaunch.
+- **"Onboarding didn't fire"** — stale DB. Delete `.claude/tmb/` in your project root and relaunch.
 - **"Agent changes didn't take effect"** — forgot `/reload-plugins`, or CC cached a previous install (Mode B). Try Mode A for cleaner iteration.
 - **"Hook didn't block"** — hook path mismatch. Check `plugin/hooks/hooks.json` points at the script you edited and that the script is executable (`chmod +x`).
 - **"git-guards blocked my legitimate commit"** — check `plugin_config.protected_branches` — you're on a configured protected branch. Override intentionally or switch to a feature branch.

--- a/mcp/trajectory-server/README.md
+++ b/mcp/trajectory-server/README.md
@@ -22,9 +22,9 @@ node --test dist/test/*.test.js
 
 | Variable | Default | Description |
 |---|---|---|
-| `TRAJECTORY_DB_PATH` | `.trajectory.db` in CWD | Absolute path to the SQLite database |
+| `TRAJECTORY_DB_PATH` | `<cwd>/.claude/tmb/trajectory.db` | Absolute path to the SQLite database, or `:memory:` for ephemeral runs |
 
-Set by Claude Code as `${CLAUDE_PLUGIN_DATA}/trajectory.db`. See issue #29 for pending per-project DB-path scoping.
+Default is project-local, per-user, gitignored (the plugin-root `.gitignore` excludes `.claude/`). Each project has its own DB; nothing crosses project boundaries; nothing committed. Set the env var to override for CI, isolated tests, or shared testbeds.
 
 ## Tool families
 

--- a/mcp/trajectory-server/src/db.ts
+++ b/mcp/trajectory-server/src/db.ts
@@ -4,6 +4,21 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 
+/**
+ * Resolve the trajectory DB path.
+ *
+ * 1. Explicit `TRAJECTORY_DB_PATH` env override wins. Power-user / CI use.
+ * 2. Default: `<cwd>/.claude/tmb/trajectory.db` — project-local, per-user,
+ *    auto-gitignored via the plugin-root `.gitignore` exclusion of `.claude/`.
+ */
+export function resolveDbPath(opts?: { env?: NodeJS.ProcessEnv; cwd?: string }): string {
+  const env = opts?.env ?? process.env;
+  const cwd = opts?.cwd ?? process.cwd();
+  const override = env['TRAJECTORY_DB_PATH'];
+  if (override && override.trim().length > 0) return override;
+  return join(cwd, '.claude', 'tmb', 'trajectory.db');
+}
+
 export class TrajectoryDB {
   private db: Database.Database;
 

--- a/mcp/trajectory-server/src/index.ts
+++ b/mcp/trajectory-server/src/index.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { mkdirSync } from 'node:fs';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
@@ -6,11 +7,12 @@ import {
   CallToolRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { toolDefinitions, toolHandlers, registerTools } from './tools/index.js';
-import { TrajectoryDB } from './db.js';
+import { TrajectoryDB, resolveDbPath } from './db.js';
 
-const dbPath =
-  process.env.TRAJECTORY_DB_PATH ??
-  path.join(process.cwd(), '.trajectory.db');
+const dbPath = resolveDbPath();
+if (dbPath !== ':memory:') {
+  mkdirSync(path.dirname(dbPath), { recursive: true });
+}
 
 const db = new TrajectoryDB(dbPath);
 

--- a/mcp/trajectory-server/src/test/db-path.test.ts
+++ b/mcp/trajectory-server/src/test/db-path.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { resolveDbPath } from '../db.js';
+
+describe('resolveDbPath', () => {
+  it('defaults to <cwd>/.claude/tmb/trajectory.db when no env override', () => {
+    const cwd = '/some/project';
+    const got = resolveDbPath({ env: {}, cwd });
+    assert.equal(got, join(cwd, '.claude', 'tmb', 'trajectory.db'));
+  });
+
+  it('honors TRAJECTORY_DB_PATH env override verbatim', () => {
+    const got = resolveDbPath({
+      env: { TRAJECTORY_DB_PATH: '/tmp/explicit/test.db' },
+      cwd: '/some/project',
+    });
+    assert.equal(got, '/tmp/explicit/test.db');
+  });
+
+  it('honors :memory: as a sentinel via the env override', () => {
+    const got = resolveDbPath({
+      env: { TRAJECTORY_DB_PATH: ':memory:' },
+      cwd: '/some/project',
+    });
+    assert.equal(got, ':memory:');
+  });
+
+  it('treats empty TRAJECTORY_DB_PATH as unset (falls back to default)', () => {
+    const cwd = '/some/project';
+    const got = resolveDbPath({ env: { TRAJECTORY_DB_PATH: '' }, cwd });
+    assert.equal(got, join(cwd, '.claude', 'tmb', 'trajectory.db'));
+  });
+
+  it('treats whitespace-only TRAJECTORY_DB_PATH as unset', () => {
+    const cwd = '/some/project';
+    const got = resolveDbPath({ env: { TRAJECTORY_DB_PATH: '   ' }, cwd });
+    assert.equal(got, join(cwd, '.claude', 'tmb', 'trajectory.db'));
+  });
+});

--- a/monitors/tmb-trajectory-events.js
+++ b/monitors/tmb-trajectory-events.js
@@ -4,13 +4,18 @@
 const fs = require('fs');
 const path = require('path');
 
-const dataDir = process.env.CLAUDE_PLUGIN_DATA;
-if (!dataDir) process.exit(0);
+// Resolve DB path the same way the MCP server does:
+//   1. TRAJECTORY_DB_PATH env override wins.
+//   2. Otherwise default to <cwd>/.claude/tmb/trajectory.db.
+const override = process.env.TRAJECTORY_DB_PATH;
+const dbDir = override
+  ? path.dirname(override)
+  : path.join(process.cwd(), '.claude', 'tmb');
+const dbPath = override || path.join(dbDir, 'trajectory.db');
 
-const dbPath = path.join(dataDir, 'trajectory.db');
 if (!fs.existsSync(dbPath)) process.exit(0);
 
-const cursorPath = path.join(dataDir, 'monitor-cursor.json');
+const cursorPath = path.join(dbDir, 'monitor-cursor.json');
 
 let Database;
 try {

--- a/scripts/hooks/lib/query-task.sh
+++ b/scripts/hooks/lib/query-task.sh
@@ -3,8 +3,18 @@
 # Sourced (not exec'd) by other hook scripts.
 set -euo pipefail
 
+# tmb_db_path
+# Resolve the trajectory DB path the same way the MCP server does:
+#   1. TRAJECTORY_DB_PATH env override wins
+#   2. Otherwise default to <cwd>/.claude/tmb/trajectory.db
+# Prints the path only if the file exists.
 tmb_db_path() {
-  local p="${CLAUDE_PLUGIN_DATA:-$HOME/.claude/plugins/data/tmb}/trajectory.db"
+  local p
+  if [ -n "${TRAJECTORY_DB_PATH:-}" ]; then
+    p="$TRAJECTORY_DB_PATH"
+  else
+    p="$(pwd)/.claude/tmb/trajectory.db"
+  fi
   [ -f "$p" ] && echo "$p"
 }
 

--- a/tests/hooks/git-guards.test.sh
+++ b/tests/hooks/git-guards.test.sh
@@ -11,7 +11,7 @@ PLUGIN_ROOT="$(cd "$HERE/../.." && pwd)"
 HOOK="$PLUGIN_ROOT/scripts/hooks/git-guards.sh"
 
 run_hook() {
-  (cd "$PLUGIN_ROOT" && echo "$1" | CLAUDE_PLUGIN_DATA=/nonexistent bash "$HOOK" 2>&1 || true)
+  (cd "$PLUGIN_ROOT" && echo "$1" | TRAJECTORY_DB_PATH=/nonexistent.db bash "$HOOK" 2>&1 || true)
 }
 
 test_case "no config (fresh install) is non-blocking for commits"

--- a/tests/hooks/require-review-sign.test.sh
+++ b/tests/hooks/require-review-sign.test.sh
@@ -11,7 +11,7 @@ PLUGIN_ROOT="$(cd "$HERE/../.." && pwd)"
 HOOK="$PLUGIN_ROOT/scripts/hooks/require-review-sign.sh"
 
 run_hook() {
-  (cd "$PLUGIN_ROOT" && echo "$1" | CLAUDE_PLUGIN_DATA=/nonexistent bash "$HOOK" 2>&1 || true)
+  (cd "$PLUGIN_ROOT" && echo "$1" | TRAJECTORY_DB_PATH=/nonexistent.db bash "$HOOK" 2>&1 || true)
 }
 
 test_case "non-push/merge command passes silently"

--- a/tests/hooks/require-task-spec.test.sh
+++ b/tests/hooks/require-task-spec.test.sh
@@ -10,11 +10,11 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$HERE/../.." && pwd)"
 HOOK="$PLUGIN_ROOT/scripts/hooks/require-task-spec.sh"
 
-# Fixture: isolated CLAUDE_PLUGIN_DATA + a tasks table with known rows
+# Fixture: isolated TRAJECTORY_DB_PATH + a tasks table with known rows
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 DB="$TMPDIR/trajectory.db"
-export CLAUDE_PLUGIN_DATA="$TMPDIR"
+export TRAJECTORY_DB_PATH="$DB"
 
 sqlite3 "$DB" "
   CREATE TABLE tasks (
@@ -88,7 +88,7 @@ out=$(run_hook "$(swe_input 'task_id=1 and also task_id=4')")
 assert_eq "" "$out" "first token is valid -> passes"
 
 test_case "missing trajectory.db is blocked with clear reason"
-out=$(run_hook_env "$(swe_input 'task_id=1')" "CLAUDE_PLUGIN_DATA" "$TMPDIR/nonexistent")
+out=$(run_hook_env "$(swe_input 'task_id=1')" "TRAJECTORY_DB_PATH" "$TMPDIR/nonexistent.db")
 assert_contains "$out" '"decision":"block"' "block decision"
 assert_contains "$out" "trajectory.db not found" "reason cites missing DB"
 


### PR DESCRIPTION
## Summary

Default trajectory DB is now project-local (`<cwd>/.claude/tmb/trajectory.db`) instead of one global file under `\${CLAUDE_PLUGIN_DATA}`. Each project gets its own DB; each developer has their own copy; nothing crosses project boundaries; nothing committed.

`TRAJECTORY_DB_PATH` env var stays as a power-user / CI override (e.g., `:memory:` for ephemeral runs).

Closes #29.

## Why this is correct

- **Trajectory is per-developer execution state** — which task ran, which validations happened. Like shell history. Sharing it across a team produces noise + conflicts; team coordination already happens through commits, PRs, and (future, see #32) GitHub Issues mirroring.
- **Multi-project usage finally works**: pre-fix, project A's open issues bled into project B's session via `issue_resume`. Now isolated.
- **Branch switching, pull, reset don't touch the DB** — workflow state is orthogonal to git refs (a task may span several commits/branches).

## Path resolution

```
1. TRAJECTORY_DB_PATH env override wins
2. Default: <cwd>/.claude/tmb/trajectory.db
```

The plugin-root `.gitignore` already excludes `.claude/`, so the DB is auto-excluded from commits — no new gitignore rules needed.

## Files changed (14)

**MCP server**
- `src/db.ts` — new exported `resolveDbPath()` with injectable `env`/`cwd` for unit-testability
- `src/index.ts` — uses `resolveDbPath`; `mkdirSync` the parent dir on startup
- `src/test/db-path.test.ts` — new; covers env override, default fallback, `:memory:`, empty/whitespace handling

**Plugin glue**
- `.mcp.json` — drop `TRAJECTORY_DB_PATH=\${CLAUDE_PLUGIN_DATA}/...` default; env var is now opt-in
- `scripts/hooks/lib/query-task.sh` — `tmb_db_path()` mirrors MCP server resolver
- `monitors/tmb-trajectory-events.js` — same; falls back to `cwd` when env unset

**Tests**
- `tests/hooks/{git-guards,require-review-sign,require-task-spec}.test.sh` — switch fixture from `CLAUDE_PLUGIN_DATA` env injection to `TRAJECTORY_DB_PATH` override

**Docs**
- `CLAUDE.md`, `README.md`, `docs/architecture/ERD.md`, `docs/local-testing.md`, `mcp/trajectory-server/README.md` — prose updated; reset instructions now `rm -rf .claude/tmb/`
- `docs/architecture/FILES.md` — #29 marked closed

## Follow-up filed: #32

Commit a small `.claude/tmb/config.json` for team-shared project config (`branching_model`, `pr_target`, `protected_branches`) so each new dev's onboarding pre-fills from the team convention instead of asking the same questions per dev. Out of scope for this PR; needs its own design decisions.

## Test plan

- [x] `bash tests/run-all.sh` — 240 MCP + 16 hook tests pass
- [x] New unit tests cover all 5 path-resolution branches
- [ ] Reviewer skim: confirm no other site reads the DB outside of the three resolvers (MCP server, hook lib, monitor)
- [ ] Reviewer skim: gitignore on `.claude/` already in place, no new gitignore needed
- [ ] **Manual**: in a fresh scratch dir, `claude --plugin-dir ...` and verify `.claude/tmb/trajectory.db` lands there, not `~/.config/claude-code/plugin-data/`

## Migration note for TMB-internal dev

Your current dev DB at `~/.config/claude-code/plugin-data/tmb/trajectory.db` is now orphaned. After merging this PR, running CC in `plugin/` will create a fresh `plugin/.claude/tmb/trajectory.db`. Pre-release, fine to lose. If you want to keep accumulated state:

```bash
mkdir -p /Users/Zax/Git/GitHub/TMB/plugin/.claude/tmb
cp ~/.config/claude-code/plugin-data/tmb/trajectory.db /Users/Zax/Git/GitHub/TMB/plugin/.claude/tmb/trajectory.db
```

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)