### PR TITLE
🔖 release: dev → main for v0.1.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TMB multi-agent Claude Code plugin with SQLite trajectory MCP.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
+## v0.1.1 — 2026-04-25
+
+**Patch release.** Single fix to `scripts/hooks/git-guards.sh` that affects projects using a dual-tier `dev`/`main` branching model.
+
+### Fixed
+
+- **`gh pr create --base main --head dev` no longer blocked when `pr_target=dev`** ([#70](https://github.com/trustmybot/plugin/pull/70)). The previous rule treated all non-`pr_target` bases as forbidden, which blocked the legitimate `dev → main` release-merge PR. The hook now permits this exact case (release exception) while still blocking `feature → main` PRs.
+- **Silent-allow bug under `set -o pipefail`** in the `--head` extraction. `grep -oE` returned non-zero when `--head` was absent (the common case), causing the script to exit silently and fall through to allow. Added `|| true` to the extraction pipeline.
+
+### Test coverage
+
+The commit message includes a 7-case synthetic-DB harness covering all explicit + implicit-head combinations. All pass.
+
+### Who's affected
+
+- **Projects using github-flow** (`pr_target=main`, the most common): no behavior change. The dual-tier exception code path doesn't activate.
+- **Projects using dual-tier `dev/main`** (e.g. trustmybot/plugin itself): the dev → main release-merge PR now goes through the hook cleanly without manual workarounds.
+
+---
+
 ## v0.1.0 — 2026-04-25
 
 **First actionable release.** Supersedes the placeholder v0.2.0 tag (revoked) — that earlier tag predated the multi-agent decision-chain doctrine and didn't represent a working end-to-end workflow. This release does.

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/hooks/git-guards.sh
+++ b/scripts/hooks/git-guards.sh
@@ -44,11 +44,35 @@ branch_is_protected() {
   return 1
 }
 
-# --- Rule 1: PR must target pr_target ---
+# --- Rule 1: PR must target pr_target, with the dev → main release-merge exception ---
+#
+# Default: feature/* branches must PR to PR_TARGET (typically `dev` for the
+# dual-tier dev/main model, or `main` for single-tier github-flow).
+#
+# Exception: when PR_TARGET == "dev" (dual-tier model), `dev → main` is the
+# release-merge path and is allowed. The head MUST be `dev` (either
+# explicit `--head dev` or the current branch is `dev` and `--head` is
+# omitted). Any other head targeting main is blocked — feature branches do
+# not PR directly to main.
 case "$CMD" in
   *"gh pr create"*)
-    if ! echo "$CMD" | grep -qF -- "--base ${PR_TARGET}"; then
-      echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: PRs must target ${PR_TARGET} branch. Use: gh pr create --base ${PR_TARGET}\"}"
+    if echo "$CMD" | grep -qF -- "--base ${PR_TARGET}"; then
+      :  # OK — feature → pr_target (the standard path)
+    elif [ "$PR_TARGET" = "dev" ] && echo "$CMD" | grep -qF -- "--base main"; then
+      # Dual-tier exception: dev → main release merge.
+      # `set -o pipefail` makes the assignment fail when grep finds no
+      # `--head` (which is the common case — gh defaults head to the
+      # current branch). The `|| true` keeps the pipeline succeeding.
+      HEAD_BRANCH=$(echo "$CMD" | grep -oE -- '--head[= ][^[:space:]]+' | head -1 | sed -E 's/--head[= ]+//' | tr -d "'\"" || true)
+      if [ -z "$HEAD_BRANCH" ]; then
+        HEAD_BRANCH=$(git branch --show-current 2>/dev/null || true)
+      fi
+      if [ "$HEAD_BRANCH" != "dev" ]; then
+        echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: only 'dev → main' is permitted as a release merge. Feature branches must PR to ${PR_TARGET}: gh pr create --base ${PR_TARGET} --head <branch>. Got --head=${HEAD_BRANCH}.\"}"
+        exit 0
+      fi
+    else
+      echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: PRs must target ${PR_TARGET} branch. Use: gh pr create --base ${PR_TARGET} --head <branch>. (Dev → main release merges are allowed when PR_TARGET=dev.)\"}"
       exit 0
     fi
     ;;


### PR DESCRIPTION
Patch release: ships the `git-guards.sh` fix (#70) that allows dev → main release-merge PRs while still blocking feature → main.

3 commits since v0.1.0:

- #70 git-guards hook fix
- #71 v0.1.1 version bump + CHANGELOG entry

After merge: tag v0.1.1 + release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)