### PR TITLE
🚑 fix: v0.1.3 — ship usable MCP server (postinstall) + L0 install-smoke

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TMB multi-agent Claude Code plugin with SQLite trajectory MCP.",
   "author": {
     "name": "trustmybot",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   test:
+    name: lint + MCP unit + integration + hooks
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -34,3 +35,19 @@ jobs:
 
       - name: run full test suite
         run: bash tests/run-all.sh
+
+  install-smoke:
+    name: L0 install-smoke (cold-start Docker)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: build install-smoke image
+        # Strips local artifacts, runs `bun install`, asserts dist/index.js
+        # exists, spawns the MCP server, and verifies tools/list responds.
+        # This catches the v0.1.2 class of bug where the published artifact
+        # was unbootable because postinstall didn't fire.
+        run: docker build -f tests/docker/install-smoke.Dockerfile -t tmb-install-smoke .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
+## v0.1.3 — 2026-04-25
+
+**Critical install hotfix.** v0.1.2 shipped without prebuilt `dist/` for the MCP trajectory server, so a fresh marketplace install left the MCP server unbootable. First sessions silently failed to register any of the `mcp__plugin_tmb_trajectory-server__*` tools, breaking onboarding, planning, and every workflow that depends on MCP state. **Anyone on v0.1.2 should upgrade.**
+
+### Fixed
+
+- **Marketplace install now boots cleanly** — added a `postinstall` script to the workspace root `package.json` that runs `bun --filter='*' run build`, ensuring `dist/index.js` and `dist/schema.sql` exist after `bun install`. Restores the cold-start contract that v0.1.2 broke.
+- Synced workspace-root `package.json` version (was a stale `0.3.2`) to track the plugin version (now `0.1.3`).
+
+### Added — Layer 0 distribution test (so this can't ship again)
+
+Added a Docker-based **install-smoke test** at [`tests/docker/install-smoke.Dockerfile`](tests/docker/install-smoke.Dockerfile) and a local wrapper [`tests/docker/run-install-smoke.sh`](tests/docker/run-install-smoke.sh). The Dockerfile:
+
+1. Starts from a clean `node:20-slim` (no preexisting `dist/`, no `node_modules/`).
+2. Installs bun + sqlite, copies the plugin tree.
+3. Strips any local artifacts to force cold-start conditions.
+4. Runs `bun install --frozen-lockfile` and asserts `mcp/trajectory-server/dist/index.js` + `dist/schema.sql` exist after install.
+5. Spawns the MCP server, sends `tools/list`, asserts it responds with `identity_get`.
+6. Re-runs both lint scripts in the as-shipped tree.
+7. Verifies all hook scripts are executable + syntactically valid.
+8. Confirms `.mcp.json`'s server path resolves in the installed tree.
+
+Wired into `.github/workflows/test.yml` as a separate `install-smoke` CI job that runs on every PR + push to dev/main. Build success = a clean marketplace install would boot. Build failure = release blocker.
+
+This is **Layer 0** in the broader test-pyramid plan tracked in #76 follow-ups. v0.1.4 will add Layer 1 lint expansions + Layer 2 unit expansions + Layer 6 release-canary; v0.2.0 will add Layer 4 workflow-simulation harness.
+
+### Versioning
+
+Bumped `.claude-plugin/plugin.json`, `mcp/trajectory-server/package.json`, and root `package.json` to `0.1.3`. No schema migrations needed (still `schema_version=1`).
+
+---
+
 ## v0.1.2 — 2026-04-25
 
 **Docs + structural release.** No agent, hook, or MCP-server behavior change. Adds multi-platform structural placeholders following the [Superpowers](https://github.com/obra/superpowers) pattern, and refreshes contributor docs to match the bro-as-planner doctrine that landed in v0.1.0.

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.3.2",
+  "version": "0.1.3",
   "description": "TMB multi-agent Claude Code plugin — workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "build": "bun --filter='*' run build",
+    "postinstall": "bun --filter='*' run build",
     "test": "bash tests/run-all.sh"
   },
   "devDependencies": {

--- a/tests/docker/install-smoke.Dockerfile
+++ b/tests/docker/install-smoke.Dockerfile
@@ -1,0 +1,72 @@
+# Layer 0 — Distribution / cold-start install smoke
+#
+# Simulates what a marketplace install does: clone repo, `bun install`,
+# then immediately try to spawn the MCP server. v0.1.2 shipped without
+# a postinstall build step, so dist/index.js was missing and the server
+# silently failed. This Dockerfile catches that class of regression.
+#
+# Build:
+#   docker build -f tests/docker/install-smoke.Dockerfile -t tmb-install-smoke .
+#
+# Each `RUN test` line is a fail-fast assertion. Build success = release shippable.
+
+FROM node:20-slim
+
+# Install bun + sqlite (CC's plugin install runtime assumes bun for workspace handling)
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl unzip git ca-certificates sqlite3 \
+ && rm -rf /var/lib/apt/lists/* \
+ && curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+# Copy the plugin tree as it would be served from the marketplace
+WORKDIR /plugin
+COPY . /plugin
+
+# Strip any local build artifacts so we test cold-start, not "what was already built"
+RUN rm -rf node_modules \
+           mcp/trajectory-server/node_modules \
+           mcp/trajectory-server/dist \
+           monitors/node_modules
+
+# Simulate CC's plugin install: bun install at the workspace root.
+# postinstall (added in v0.1.3) MUST build the workspaces, otherwise the
+# next assertions fail.
+RUN bun install --frozen-lockfile
+
+# ---- Hard assertions — these would have failed on v0.1.2 ----
+
+# A1: dist/ exists and contains the entry point
+RUN test -f mcp/trajectory-server/dist/index.js \
+ || (echo "❌ FAIL: mcp/trajectory-server/dist/index.js missing after install — postinstall didn't run or build failed" && exit 1)
+
+# A2: schema.sql copied alongside (the build script does both)
+RUN test -f mcp/trajectory-server/dist/schema.sql \
+ || (echo "❌ FAIL: dist/schema.sql missing — build didn't copy schema" && exit 1)
+
+# A3: MCP server actually spawns and responds to tools/list
+RUN echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  | timeout 8 node mcp/trajectory-server/dist/index.js 2>/dev/null \
+  | grep -q '"name":"identity_get"' \
+ || (echo "❌ FAIL: MCP server did not respond with tools/list containing identity_get" && exit 1)
+
+# A4: every shipped agent template parses (frontmatter + body, ≤30 lines)
+RUN bash tests/lint/agent-line-budget.sh \
+ || (echo "❌ FAIL: agent-line-budget lint failed in clean install" && exit 1)
+
+# A5: onboarding skill contract still met in the as-shipped tree
+RUN bash tests/lint/onboarding-skill-contract.sh \
+ || (echo "❌ FAIL: onboarding-skill-contract lint failed in clean install" && exit 1)
+
+# A6: hook scripts are executable + syntactically valid
+RUN for h in scripts/hooks/*.sh; do \
+      test -x "$h" || (echo "❌ FAIL: $h not executable" && exit 1); \
+      bash -n "$h" || (echo "❌ FAIL: $h has syntax error" && exit 1); \
+    done
+
+# A7: .mcp.json points at a path that actually exists in the install
+RUN test -f "$(node -e 'const m=require("./.mcp.json");console.log(m.mcpServers["trajectory-server"].args[0].replace("${CLAUDE_PLUGIN_ROOT}", "/plugin"))')" \
+ || (echo "❌ FAIL: .mcp.json command path does not exist in installed tree" && exit 1)
+
+# Final marker so the build log shows we made it all the way
+RUN echo "✓ Layer 0 install-smoke: all assertions passed"

--- a/tests/docker/run-install-smoke.sh
+++ b/tests/docker/run-install-smoke.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Local convenience wrapper for the L0 install-smoke Docker test.
+#
+# Usage:
+#   bash tests/docker/run-install-smoke.sh
+#
+# Builds tests/docker/install-smoke.Dockerfile from the plugin root.
+# Build success = a fresh marketplace install would boot cleanly.
+# Build failure = release-blocker; a real user would hit it.
+
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$PLUGIN_ROOT"
+
+if ! command -v docker >/dev/null 2>&1; then
+  printf "❌ docker not found. Install Docker Desktop or run via CI.\n" >&2
+  exit 1
+fi
+
+IMAGE_TAG="tmb-install-smoke:$(jq -r '.version' .claude-plugin/plugin.json)"
+
+printf "Building %s from a clean tree (this strips dist/ + node_modules first)...\n\n" "$IMAGE_TAG"
+docker build \
+  -f tests/docker/install-smoke.Dockerfile \
+  -t "$IMAGE_TAG" \
+  --progress=plain \
+  .
+
+printf "\n✓ Layer 0 install-smoke passed. A fresh marketplace install would boot.\n"


### PR DESCRIPTION
## Why

v0.1.2 marketplace install was broken — `dist/index.js` was never compiled, so the MCP trajectory server silently failed to spawn. Bro lost access to all MCP tools on first session: onboarding broke, planning broke, push gate broke. Anyone on v0.1.2 should upgrade.

## What

**The fix (one-liner):** add `postinstall` to root `package.json` so `bun install` automatically builds the workspaces. Marketplace install now boots cleanly with no contributor knowledge required.

**The new test (so this can't ship again):** `tests/docker/install-smoke.Dockerfile` boots a clean `node:20-slim`, simulates a marketplace install, then asserts:

- `mcp/trajectory-server/dist/index.js` exists after `bun install`
- MCP server actually spawns and responds to `tools/list` with `identity_get`
- Both lint scripts still pass in the as-shipped tree
- All hook scripts are executable + syntactically valid
- `.mcp.json`'s server path resolves in the installed tree

Wired into `.github/workflows/test.yml` as a separate `install-smoke` CI job. **Build success = release shippable. Build failure = release blocker.**

## Verification

Local (without Docker daemon):
```
rm -rf mcp/trajectory-server/dist
bun install                                          # postinstall fires, dist/ rebuilt ✓
echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
  | node mcp/trajectory-server/dist/index.js \
  | grep -o '"name":"identity_get"'                  # ✓
```

CI: the new `install-smoke` job runs Docker build on every PR.

## What's coming next

This is **PR 1 of 3** in the test-coverage rebuild approved in [#74 follow-ups](https://github.com/trustmybot/plugin/issues/74) discussion:

- **v0.1.4 (next PR)** — L1 lint expansion + L2 unit expansion + L6 release-canary in release.sh
- **v0.2.0 (after that)** — L4 workflow-simulation harness; compress scenarios.md to L5 manual-only checklist

Closes the v0.1.2 install regression class. Tag v0.1.3 immediately after merge.