### PR TITLE
🧪 test: v0.1.4 — L1 lint expansion + L2 hook coverage + L6 release canary

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "TMB multi-agent Claude Code plugin with SQLite trajectory MCP.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
+## v0.1.4 — 2026-04-25
+
+**Test pyramid expansion (L1, L2, L6).** No agent / hook / MCP behavior change — but a meaningful regression-prevention upgrade. PR 2 of the comprehensive auto-test layers initiative (PR 1 was v0.1.3's L0 install-smoke).
+
+### Added
+
+#### L1 — Static lint expansion (7 new linters)
+
+Eight failure modes that used to slip through review now fail the build instead. Run via `bash tests/run-all.sh` (also wired into CI).
+
+| New linter | What it catches |
+|---|---|
+| `tests/lint/version-sync.sh` | Out-of-sync version fields across `.claude-plugin/plugin.json`, `mcp/trajectory-server/package.json`, root `package.json`. (Caught + corrected the stale `0.3.2` root version that survived through v0.1.2.) |
+| `tests/lint/changelog-current.sh` | CHANGELOG top section's version doesn't match `plugin.json`. |
+| `tests/lint/manifest-shape.sh` | JSON-shape validation of `plugin.json`, `.mcp.json`, `hooks/hooks.json`. Verifies semver-shape `version`, presence of required fields, and that every `command` path in `hooks/hooks.json` resolves. |
+| `tests/lint/link-check.sh` | Every relative `[text](path)` link in tracked `.md` files resolves to an existing file. (Would have caught the broken `docs/PERFORMANCE.md` references after we retired it in v0.1.2.) |
+| `tests/lint/skill-frontmatter.sh` | Every `SKILL.md` (under `skills/` and `templates/skills/`) has valid frontmatter with `name` + `description`, AND `name` matches the parent dirname. **Caught real bugs:** `templates/skills/{docs-conventions,git-conventions,naming-conventions}/SKILL.md` were missing the `name:` field — they wouldn't have loaded properly when copied into projects. Fixed in this release. |
+| `tests/lint/shellcheck-hooks.sh` | shellcheck-clean enforcement on every shell script in `scripts/` and `tests/`. (Would have caught the `set -o pipefail` silent-allow bug we hit in v0.1.0.) |
+| `tests/lint/tsc-noemit.sh` | Standalone TS type check on the MCP server source — catches type errors without relying on someone reading the build log. |
+
+#### L2 — Hook decision-matrix expansion
+
+`tests/hooks/git-push-guard.test.sh` — **16 new test cases** covering every decision branch of `scripts/hooks/git-push-guard.sh`:
+
+- Non-push command → pass-through
+- `git push --force` / `-f` → delegated to git-guards (this hook allows)
+- Missing DB / no upstream / no new commits → allowed
+- Untracked commits (no matching `tasks` row) → allowed (pre-TMB / external work)
+- All-signed tracked commits → allowed
+- One unsigned → BLOCKED with helpful message + task_id list
+- Multiple unsigned → BLOCKED, all listed
+- Mixed-signed → BLOCKED only on the unsigned ones
+
+Previously `git-push-guard.sh` had **zero** test coverage — a critical gap given it's the structural protection against pushing unreviewed commits.
+
+#### L6 — Release canary
+
+`scripts/release.sh` now has a step 4: after the GitHub release is created, the script offers to re-clone the just-published tag in a temp dir and run the L0 install-smoke Dockerfile against it. Catches "the published artifact differs from what we tested locally" — e.g. if `.gitignore` excluded something needed for install. Skipped gracefully if Docker is unavailable.
+
+### Fixed
+
+- **Three template skills (`docs-conventions`, `git-conventions`, `naming-conventions`) now have `name:` frontmatter** — they were missing it and would have failed to load by name when copied into a project. Caught by the new `skill-frontmatter.sh` lint.
+
+### Test infrastructure
+
+- `tests/run-all.sh` now uses the explicit layered model (L1 → L2 → L3) with named steps, instead of the previous ad-hoc list. Single-line PASS/FAIL per step.
+- Layer count is now: **L0** (install-smoke, CI-only Docker), **L1** (9 lint scripts), **L2** (245 MCP unit tests), **L3** (9 MCP-integration suites + 3 hook test suites), **L6** (release canary in release.sh). L4 (workflow simulation) and L5 (manual dogfood checklist) coming in v0.2.0.
+
+### Versioning
+
+Bumped all three manifest versions to `0.1.4`. No schema migration.
+
+---
+
 ## v0.1.3 — 2026-04-25
 
 **Critical install hotfix.** v0.1.2 shipped without prebuilt `dist/` for the MCP trajectory server, so a fresh marketplace install left the MCP server unbootable. First sessions silently failed to register any of the `mcp__plugin_tmb_trajectory-server__*` tools, breaking onboarding, planning, and every workflow that depends on MCP state. **Anyone on v0.1.2 should upgrade.**

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "TMB multi-agent Claude Code plugin — workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -163,6 +163,46 @@ else
   fi
 fi
 
+# ---------- step 4: L6 release canary (post-tag verify) ----------
+#
+# Re-clones the freshly-tagged release into a temp dir and runs the
+# install-smoke Dockerfile against it. Catches "the published artifact
+# differs from what we tested locally" — e.g. a .gitignore that excluded
+# something the install needs.
+#
+# Skipped if Docker is unavailable; warning instead of failure since the
+# release is already public at this point.
+
+if confirm "Step 4: Run L6 release canary (re-clone tag in Docker, run install-smoke)?"; then
+  if ! command -v docker >/dev/null 2>&1; then
+    printf "  ⊘ docker not available — skipping canary. Run manually before announcing the release:\n"
+    printf "      bash tests/docker/run-install-smoke.sh\n"
+  else
+    CANARY_DIR=$(mktemp -d -t tmb-canary-XXXX)
+    trap 'rm -rf "$CANARY_DIR"' EXIT
+    printf "  Cloning %s into %s ...\n" "$NEW_TAG" "$CANARY_DIR"
+    if git clone --quiet --depth 1 --branch "$NEW_TAG" \
+        "https://github.com/trustmybot/plugin.git" "$CANARY_DIR/plugin"; then
+      if (cd "$CANARY_DIR/plugin" && docker build \
+            -f tests/docker/install-smoke.Dockerfile \
+            -t "tmb-canary-$NEW_VERSION" \
+            --quiet .); then
+        printf "  ✓ Canary PASSED — published %s installs cleanly from a fresh clone\n\n" "$NEW_TAG"
+      else
+        printf "\n  ⚠️  CANARY FAILED — published %s does NOT install cleanly!\n" "$NEW_TAG" >&2
+        printf "     The release is public but broken. Investigate before announcing.\n" >&2
+        printf "     Likely causes: .gitignore excluded something needed; postinstall regression;\n" >&2
+        printf "     bun.lock out of sync; etc.\n" >&2
+        exit 1
+      fi
+    else
+      printf "  ⚠️  Could not clone tag %s — release exists but git clone failed.\n" "$NEW_TAG" >&2
+    fi
+  fi
+else
+  printf "  Skipped — run 'bash tests/docker/run-install-smoke.sh' manually before announcing.\n\n"
+fi
+
 # ---------- summary ----------
 
 printf "Done. Verify:\n"

--- a/templates/skills/docs-conventions/SKILL.md
+++ b/templates/skills/docs-conventions/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: docs-conventions
 description: When and how to update docs alongside code changes, plus the discipline for editing agent prompts and skill files.
 agent: bro, swe, pr-reviewer
 ---

--- a/templates/skills/git-conventions/SKILL.md
+++ b/templates/skills/git-conventions/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: git-conventions
 description: Commit message style, branching rules, push safety.
 agent: bro, swe, pr-reviewer
 ---

--- a/templates/skills/naming-conventions/SKILL.md
+++ b/templates/skills/naming-conventions/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: naming-conventions
 description: File and identifier naming patterns.
 agent: swe, pr-reviewer
 paths: ["src/**", "lib/**", "app/**", "tests/**"]

--- a/tests/hooks/git-push-guard.test.sh
+++ b/tests/hooks/git-push-guard.test.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Tests for scripts/hooks/git-push-guard.sh
+#
+# Hook contract: block `git push` when commits in the push range are
+# attached to closed tasks (via tasks.commit_sha) that lack a passing
+# pr-reviewer verdict (validation_attempts.verdict='pass').
+#
+# Skips: --force pushes (delegated to git-guards), no upstream (first push),
+# commits with no matching task row (pre-TMB / untracked work), missing DB,
+# missing sqlite3.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../lib/assert.sh"
+PLUGIN_ROOT="$(cd "$HERE/../.." && pwd)"
+HOOK="$PLUGIN_ROOT/scripts/hooks/git-push-guard.sh"
+
+# ----- helpers ----------------------------------------------------------
+
+# Create a fresh temp git repo with a bare upstream + N committed files.
+# Returns the repo path. Sets globals SHA1, SHA2 to the last two commit SHAs.
+setup_repo() {
+  local dir
+  dir=$(mktemp -d -t tmb-push-guard-XXXX)
+  (
+    cd "$dir" || exit 1
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name  "Test"
+    # bare upstream so @{u} resolves
+    git init --bare -q upstream.git
+    git remote add origin "$dir/upstream.git"
+
+    # commit 0 (initial; pushed with upstream tracking so @{u} resolves)
+    echo "init" > README.md
+    git add README.md
+    git commit -qm "init"
+    git push -qu origin main
+
+    # commit 1 (ahead of upstream)
+    echo "feat A" > a.txt
+    git add a.txt
+    git commit -qm "feat: A"
+
+    # commit 2 (ahead of upstream)
+    echo "feat B" > b.txt
+    git add b.txt
+    git commit -qm "feat: B"
+
+    git rev-parse HEAD~ > .last1
+    git rev-parse HEAD  > .last2
+  )
+  REPO_PATH="$dir"
+  SHA1=$(cat "$dir/.last1")
+  SHA2=$(cat "$dir/.last2")
+}
+
+# Apply the schema to a fresh trajectory.db inside the repo.
+# Redirect sqlite3 stdout to /dev/null because the WAL journal_mode pragma
+# echoes 'wal', which would otherwise pollute the function's return value.
+setup_db() {
+  local repo="$1"
+  local db="$repo/.claude/tmb/trajectory.db"
+  mkdir -p "$(dirname "$db")"
+  sqlite3 "$db" < "$PLUGIN_ROOT/mcp/trajectory-server/src/schema.sql" >/dev/null
+  echo "$db"
+}
+
+# Insert an issue + a task whose commit_sha matches given sha.
+# task is in 'closed' status (i.e. bro signed off, push gate is the next gate).
+# branch_id is per-task to satisfy the UNIQUE(issue_id, branch_id) index.
+insert_task() {
+  local db="$1" task_id="$2" sha="$3"
+  sqlite3 "$db" "
+    INSERT OR IGNORE INTO issues (id, objective, description, status, created_at, updated_at)
+      VALUES (1, 'test', 'test', 'open', datetime('now'), datetime('now'));
+    INSERT INTO tasks (id, issue_id, branch_id, title, description, success_criteria, status, spec_body, commit_sha, created_at, updated_at)
+      VALUES ($task_id, 1, 'feat/x-$task_id', 'task $task_id', 'd', 'sc', 'closed', '## body', '$sha', datetime('now'), datetime('now'));
+  " >/dev/null
+}
+
+# Insert a passing validation row for a task (i.e. pr-reviewer signed off).
+sign_task() {
+  local db="$1" task_id="$2"
+  sqlite3 "$db" "
+    INSERT INTO validation_attempts (task_id, attempt_n, agent, verdict, feedback, created_at)
+      VALUES ($task_id, 1, 'pr-reviewer', 'pass', 'LGTM', datetime('now'));
+  " >/dev/null
+}
+
+# Run the hook from inside REPO_PATH with a given Bash command in tool_input.
+run_hook() {
+  local cmd="$1"
+  local db="${2:-/nonexistent.db}"
+  local payload
+  payload=$(jq -cn --arg c "$cmd" '{tool_input:{command:$c}}')
+  (cd "$REPO_PATH" && echo "$payload" | TRAJECTORY_DB_PATH="$db" bash "$HOOK" 2>&1 || true)
+}
+
+# Cleanup
+cleanup() {
+  [ -n "${REPO_PATH:-}" ] && [ -d "${REPO_PATH:-}" ] && rm -rf "$REPO_PATH"
+  REPO_PATH=""
+}
+
+# ----- tests ------------------------------------------------------------
+
+test_case "non-push command passes through silently"
+setup_repo
+out=$(run_hook "git status")
+assert_not_contains "$out" '"decision":"block"' "git status should not be gated"
+cleanup
+
+test_case "git push --force is delegated to git-guards (this hook allows)"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"  # unsigned task — would block normally
+out=$(run_hook "git push --force origin main" "$db")
+assert_not_contains "$out" '"decision":"block"' "force push should be deferred to git-guards"
+cleanup
+
+test_case "git push -f is delegated to git-guards (this hook allows)"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"
+out=$(run_hook "git push -f origin main" "$db")
+assert_not_contains "$out" '"decision":"block"' "force push (-f) should be deferred"
+cleanup
+
+test_case "no DB: TMB not tracking, push allowed"
+setup_repo
+out=$(run_hook "git push origin main" "/nonexistent.db")
+assert_not_contains "$out" '"decision":"block"' "missing DB should not block"
+cleanup
+
+test_case "no upstream new commits: nothing to gate, allowed"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+# Reset HEAD to upstream so @{u}..HEAD is empty
+(cd "$REPO_PATH" && git reset -q --hard origin/main)
+out=$(run_hook "git push origin main" "$db")
+assert_not_contains "$out" '"decision":"block"' "no new commits should not block"
+cleanup
+
+test_case "push with untracked commits (no matching task row): allowed"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+# DB exists but no task row references SHA1 / SHA2 — these commits are pre-TMB
+out=$(run_hook "git push origin main" "$db")
+assert_not_contains "$out" '"decision":"block"' "untracked commits should not block"
+cleanup
+
+test_case "push with all-signed tracked commits: allowed"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"
+sign_task   "$db" 1
+insert_task "$db" 2 "$SHA2"
+sign_task   "$db" 2
+out=$(run_hook "git push origin main" "$db")
+assert_not_contains "$out" '"decision":"block"' "all-signed should not block"
+cleanup
+
+test_case "push with one unsigned tracked commit: BLOCKED with helpful reason"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"
+sign_task   "$db" 1
+insert_task "$db" 2 "$SHA2"
+# task 2 NOT signed
+out=$(run_hook "git push origin main" "$db")
+assert_contains "$out" '"decision":"block"' "unsigned commit must block"
+assert_contains "$out" "review before push"   "block message must mention bro review path"
+assert_contains "$out" "task_id=2"            "block message must list the unsigned task"
+cleanup
+
+test_case "push with multiple unsigned tracked commits: BLOCKED, all listed"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"
+insert_task "$db" 2 "$SHA2"
+# neither signed
+out=$(run_hook "git push origin main" "$db")
+assert_contains "$out" '"decision":"block"' "unsigned commits must block"
+assert_contains "$out" "task_id=1"           "should list task 1"
+assert_contains "$out" "task_id=2"           "should list task 2"
+cleanup
+
+test_case "push with mixed-signed (one signed, one not) commits: BLOCKED"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"
+sign_task   "$db" 1
+insert_task "$db" 2 "$SHA2"
+out=$(run_hook "git push origin main" "$db")
+assert_contains "$out" '"decision":"block"'  "mixed should block on unsigned"
+assert_contains "$out" "task_id=2"           "should list ONLY the unsigned task 2"
+assert_not_contains "$out" "task_id=1 "      "signed task 1 should not appear in block list"
+cleanup
+
+summarize

--- a/tests/lint/changelog-current.sh
+++ b/tests/lint/changelog-current.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Lint: top CHANGELOG.md section's version must match plugin.json.
+#
+# Catches: release-prep PRs that bump plugin.json but forget to add the
+# matching `## v<X.Y.Z>` section, OR forget to bump plugin.json after
+# adding a new section.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+CANON=$(jq -r '.version' .claude-plugin/plugin.json)
+EXPECTED_HEADER="## v${CANON}"
+
+# First `## vX.Y.Z` line in CHANGELOG (top of file)
+TOP_HEADER=$(grep -m 1 -E '^## v[0-9]' CHANGELOG.md || true)
+
+if [ -z "$TOP_HEADER" ]; then
+  echo "✗ CHANGELOG.md has no '## v<X.Y.Z>' section at all" >&2
+  exit 1
+fi
+
+# Extract just the "## vX.Y.Z" prefix (drops " — YYYY-MM-DD ..." trailer)
+TOP_VERSION=$(echo "$TOP_HEADER" | awk '{print $1, $2}')
+
+if [ "$TOP_VERSION" != "$EXPECTED_HEADER" ]; then
+  echo "✗ CHANGELOG.md top section is '$TOP_HEADER'" >&2
+  echo "  but plugin.json version is $CANON" >&2
+  echo "  Expected top section to begin with: $EXPECTED_HEADER" >&2
+  echo "" >&2
+  echo "  Either bump plugin.json to match the top CHANGELOG section," >&2
+  echo "  or add a new '$EXPECTED_HEADER — YYYY-MM-DD' entry to CHANGELOG." >&2
+  exit 1
+fi
+
+echo "  ✓ CHANGELOG top section matches plugin.json version: $CANON"
+echo ""
+echo "Changelog-current: PASS"

--- a/tests/lint/link-check.sh
+++ b/tests/lint/link-check.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Lint: every relative markdown link `[text](path)` in tracked .md files
+# must resolve to an existing file or directory.
+#
+# Catches: links to deleted files (e.g. docs/PERFORMANCE.md after we
+# retired it), typos in path names, broken section refs to moved docs.
+#
+# What it does NOT check:
+#   - http(s) URLs (we don't network in lint)
+#   - mailto: / data: schemes
+#   - Anchor-only refs (#section) — those don't have a file to verify
+#   - Anchors on intra-doc links (foo.md#section) — we just verify foo.md exists
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+# Collect every .md file we own (skip vendored/installed dirs)
+MD_FILES=$(find . -type f -name '*.md' \
+  -not -path './node_modules/*' \
+  -not -path './*/node_modules/*' \
+  -not -path './*/*/node_modules/*' \
+  -not -path './.git/*' \
+  -not -path './*/dist/*' \
+  | sort)
+
+BROKEN=0
+TOTAL=0
+
+while IFS= read -r mdfile; do
+  # Strip inline code spans (`...`) and fenced code blocks (```...```) before
+  # scanning for links — a literal `[text](path)` inside backticks is example
+  # text, not a real link, and shouldn't be path-checked.
+  STRIPPED=$(awk '
+    /^```/ { in_fence = !in_fence; next }
+    in_fence { next }
+    { gsub(/`[^`]*`/, ""); print }
+  ' "$mdfile")
+  # Extract every (link) — strip out images ![...](...) since they're equivalent here
+  LINKS=$(echo "$STRIPPED" \
+    | grep -oE '\]\([^)]+\)' \
+    | sed -E 's/^\]\(([^)]+)\)/\1/' \
+    || true)
+  while IFS= read -r link; do
+    [ -z "$link" ] && continue
+    # Skip URLs and special schemes
+    case "$link" in
+      http://*|https://*|mailto:*|data:*|tel:*) continue ;;
+      \#*) continue ;;  # anchor-only, no path to verify
+    esac
+    # Strip anchor fragment + query string for filesystem resolution
+    target="${link%%#*}"
+    target="${target%%\?*}"
+    [ -z "$target" ] && continue
+
+    TOTAL=$((TOTAL + 1))
+
+    # Resolve relative to the .md file's directory
+    mddir="$(dirname "$mdfile")"
+    resolved="$mddir/$target"
+
+    # Use realpath if available, else fall back to plain check
+    if command -v realpath >/dev/null 2>&1; then
+      resolved=$(realpath -m "$resolved" 2>/dev/null || echo "$resolved")
+    fi
+
+    if [ ! -e "$resolved" ]; then
+      printf "  ✗ %s → %s (resolved: %s) [missing]\n" "$mdfile" "$link" "$resolved" >&2
+      BROKEN=$((BROKEN + 1))
+    fi
+  done <<< "$LINKS"
+done <<< "$MD_FILES"
+
+echo ""
+if [ $BROKEN -gt 0 ]; then
+  printf "Link-check: FAIL (%d broken / %d total)\n" "$BROKEN" "$TOTAL" >&2
+  exit 1
+fi
+printf "Link-check: PASS (%d links resolve)\n" "$TOTAL"

--- a/tests/lint/manifest-shape.sh
+++ b/tests/lint/manifest-shape.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Lint: validate the shape of the plugin's three manifest files.
+#
+# Catches: typos, missing required fields, structural drift on any of:
+#   .claude-plugin/plugin.json
+#   .mcp.json
+#   hooks/hooks.json
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+failed=0
+fail() { echo "  ✗ $1" >&2; failed=1; }
+pass() { echo "  ✓ $1"; }
+
+# --- .claude-plugin/plugin.json -------------------------------------------
+
+PLUGIN_MANIFEST=.claude-plugin/plugin.json
+echo "Validating $PLUGIN_MANIFEST"
+
+if ! jq -e . "$PLUGIN_MANIFEST" >/dev/null 2>&1; then
+  fail "$PLUGIN_MANIFEST is not valid JSON"
+else
+  for field in name version description author license repository; do
+    val=$(jq -r --arg f "$field" '.[$f] // empty' "$PLUGIN_MANIFEST")
+    if [ -z "$val" ]; then
+      fail "$PLUGIN_MANIFEST missing required field: $field"
+    fi
+  done
+  # version must be semver-like
+  ver=$(jq -r '.version' "$PLUGIN_MANIFEST")
+  if ! [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    fail "$PLUGIN_MANIFEST .version '$ver' is not a valid semver (X.Y.Z)"
+  fi
+  pass "$PLUGIN_MANIFEST has all required fields and a valid semver"
+fi
+
+# --- .mcp.json -----------------------------------------------------------
+
+MCP_MANIFEST=.mcp.json
+echo ""
+echo "Validating $MCP_MANIFEST"
+
+if ! jq -e . "$MCP_MANIFEST" >/dev/null 2>&1; then
+  fail "$MCP_MANIFEST is not valid JSON"
+else
+  if ! jq -e '.mcpServers' "$MCP_MANIFEST" >/dev/null 2>&1; then
+    fail "$MCP_MANIFEST missing .mcpServers"
+  else
+    server_count=$(jq -r '.mcpServers | length' "$MCP_MANIFEST")
+    if [ "$server_count" -lt 1 ]; then
+      fail "$MCP_MANIFEST .mcpServers is empty"
+    fi
+    # Every server must have command + args
+    while IFS= read -r server; do
+      cmd=$(jq -r --arg s "$server" '.mcpServers[$s].command // empty' "$MCP_MANIFEST")
+      args=$(jq -r --arg s "$server" '.mcpServers[$s].args // empty' "$MCP_MANIFEST")
+      if [ -z "$cmd" ]; then
+        fail "$MCP_MANIFEST .mcpServers.$server.command is missing"
+      fi
+      if [ "$args" = "empty" ] || [ -z "$args" ]; then
+        fail "$MCP_MANIFEST .mcpServers.$server.args is missing"
+      fi
+    done < <(jq -r '.mcpServers | keys[]' "$MCP_MANIFEST")
+    pass "$MCP_MANIFEST has $server_count MCP server(s), all with command + args"
+  fi
+fi
+
+# --- hooks/hooks.json ----------------------------------------------------
+
+HOOKS_MANIFEST=hooks/hooks.json
+echo ""
+echo "Validating $HOOKS_MANIFEST"
+
+if [ ! -f "$HOOKS_MANIFEST" ]; then
+  fail "$HOOKS_MANIFEST does not exist"
+elif ! jq -e . "$HOOKS_MANIFEST" >/dev/null 2>&1; then
+  fail "$HOOKS_MANIFEST is not valid JSON"
+else
+  if ! jq -e '.hooks' "$HOOKS_MANIFEST" >/dev/null 2>&1; then
+    fail "$HOOKS_MANIFEST missing .hooks"
+  else
+    # Walk every hook and verify referenced script paths exist
+    missing=0
+    while IFS= read -r script; do
+      # Strip ${CLAUDE_PLUGIN_ROOT} prefix for local resolution
+      local_path="${script//\$\{CLAUDE_PLUGIN_ROOT\}/.}"
+      local_path="${local_path//\$CLAUDE_PLUGIN_ROOT/.}"
+      if [ ! -f "$local_path" ]; then
+        fail "$HOOKS_MANIFEST references missing script: $script (resolved: $local_path)"
+        missing=1
+      fi
+    done < <(jq -r '.. | objects | .command? // empty | select(. | type == "string")' "$HOOKS_MANIFEST")
+    if [ $missing -eq 0 ]; then
+      pass "$HOOKS_MANIFEST is valid + all referenced scripts exist"
+    fi
+  fi
+fi
+
+echo ""
+if [ $failed -ne 0 ]; then
+  echo "Manifest shape: FAIL" >&2
+  exit 1
+fi
+echo "Manifest shape: PASS"

--- a/tests/lint/shellcheck-hooks.sh
+++ b/tests/lint/shellcheck-hooks.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Lint: shellcheck every shell script in scripts/ and tests/.
+#
+# Catches: the `set -o pipefail` silent-allow class (we hit it in v0.1.0
+# with grep returning non-zero making the script exit silently). Catches
+# unquoted variables, command-substitution races, etc.
+#
+# If shellcheck is not installed, this lint is SKIPPED with a warning.
+# CI installs shellcheck (apt-get install shellcheck).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "  ⊘ shellcheck not installed — skipping (install via 'brew install shellcheck' or 'apt-get install shellcheck')"
+  echo "Shellcheck-hooks: SKIPPED"
+  exit 0
+fi
+
+failed=0
+
+# Scripts we own that should be shellcheck-clean
+SHELL_FILES=$(find scripts tests -type f -name '*.sh' \
+  -not -path './node_modules/*' \
+  -not -path './*/node_modules/*' \
+  | sort)
+
+for script in $SHELL_FILES; do
+  if shellcheck -S warning -e SC1091 "$script"; then
+    printf "  ✓ %s\n" "$script"
+  else
+    printf "  ✗ %s\n" "$script" >&2
+    failed=1
+  fi
+done
+
+echo ""
+if [ $failed -ne 0 ]; then
+  echo "Shellcheck-hooks: FAIL" >&2
+  exit 1
+fi
+echo "Shellcheck-hooks: PASS"

--- a/tests/lint/skill-frontmatter.sh
+++ b/tests/lint/skill-frontmatter.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Lint: every SKILL.md (in skills/ and templates/skills/) must have a
+# valid frontmatter block with `name` and `description` fields, and the
+# `name` field must equal the parent directory name.
+#
+# Catches: typos in skill metadata, broken skill registration, mismatch
+# between dir name (what CC discovers) and frontmatter name (what the
+# skill identifies as).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+failed=0
+
+# Find every SKILL.md under both plugin-shipped + template-shipped trees
+for skill in $(find skills templates/skills -type f -name 'SKILL.md' 2>/dev/null | sort); do
+  dir=$(dirname "$skill")
+  dirname_base=$(basename "$dir")
+
+  # Check frontmatter delimiters
+  first_line=$(head -1 "$skill")
+  if [ "$first_line" != "---" ]; then
+    printf "  ✗ %s: missing opening '---' (no frontmatter)\n" "$skill" >&2
+    failed=1
+    continue
+  fi
+
+  # Extract frontmatter block (between first two --- lines)
+  fm=$(awk '/^---$/{c++; next} c==1' "$skill" | head -50)
+
+  # Required fields
+  if ! echo "$fm" | grep -qE '^name:[[:space:]]+'; then
+    printf "  ✗ %s: missing 'name:' field in frontmatter\n" "$skill" >&2
+    failed=1
+    continue
+  fi
+  if ! echo "$fm" | grep -qE '^description:[[:space:]]+'; then
+    printf "  ✗ %s: missing 'description:' field in frontmatter\n" "$skill" >&2
+    failed=1
+    continue
+  fi
+
+  # name field must match dirname (without quotes)
+  name=$(echo "$fm" | grep -E '^name:[[:space:]]+' | head -1 | sed -E 's/^name:[[:space:]]+//' | tr -d '"' | xargs)
+  if [ "$name" != "$dirname_base" ]; then
+    printf "  ✗ %s: name '%s' != dirname '%s' (CC discovers by dir, body identifies by name)\n" \
+      "$skill" "$name" "$dirname_base" >&2
+    failed=1
+    continue
+  fi
+
+  printf "  ✓ %s\n" "$skill"
+done
+
+echo ""
+if [ $failed -ne 0 ]; then
+  echo "Skill-frontmatter: FAIL" >&2
+  exit 1
+fi
+echo "Skill-frontmatter: PASS"

--- a/tests/lint/tsc-noemit.sh
+++ b/tests/lint/tsc-noemit.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Lint: TypeScript type-check the MCP server source without emitting JS.
+#
+# Build (`bun run build`) does emit, so type errors there look the same
+# as a clean compile if you don't read the log. This isolates the type
+# check as its own fast assertion — fails the lint suite immediately
+# instead of relying on someone noticing tsc warnings during build.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT/mcp/trajectory-server"
+
+# Prefer the locally-installed TS in node_modules (deterministic, what
+# the build also uses). Fall back to PATH-tsc if for some reason node_modules
+# isn't populated.
+if [ -x ./node_modules/.bin/tsc ]; then
+  TSC="./node_modules/.bin/tsc"
+elif command -v tsc >/dev/null 2>&1; then
+  TSC="tsc"
+else
+  echo "  ⊘ tsc not found locally or on PATH — run 'bun install' first" >&2
+  echo "Tsc-noemit: SKIPPED"
+  exit 0
+fi
+
+if $TSC --noEmit; then
+  echo "  ✓ MCP server type-checks clean"
+  echo ""
+  echo "Tsc-noemit: PASS"
+else
+  echo "" >&2
+  echo "Tsc-noemit: FAIL — fix type errors above" >&2
+  exit 1
+fi

--- a/tests/lint/version-sync.sh
+++ b/tests/lint/version-sync.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Lint: enforce that the four version fields agree.
+#
+#   .claude-plugin/plugin.json  → the canonical published version
+#   mcp/trajectory-server/package.json → the MCP subpackage version
+#   package.json (root workspace)      → the workspace root version
+#
+# All three MUST equal each other on every commit. monitors/package.json
+# is allowed to diverge (it has its own ABI; no MCP-server coupling).
+#
+# Catches: stale workspace-root version (we shipped 0.3.2 through v0.1.2),
+# release-prep PRs that bump only one of the three.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+CANON=$(jq -r '.version' .claude-plugin/plugin.json)
+MCP=$(jq -r '.version'   mcp/trajectory-server/package.json)
+WSROOT=$(jq -r '.version' package.json)
+
+failed=0
+check() {
+  local name="$1" actual="$2"
+  if [ "$actual" = "$CANON" ]; then
+    printf "  ✓ %-40s %s\n" "$name" "$actual"
+  else
+    printf "  ✗ %-40s %s  (expected %s)\n" "$name" "$actual" "$CANON" >&2
+    failed=1
+  fi
+}
+
+echo "Enforcing version sync (canonical: .claude-plugin/plugin.json = $CANON)"
+check ".claude-plugin/plugin.json"            "$CANON"
+check "mcp/trajectory-server/package.json"    "$MCP"
+check "package.json (workspace root)"         "$WSROOT"
+
+if [ $failed -ne 0 ]; then
+  echo "" >&2
+  echo "Version sync FAILED. Bump all three to match in the same commit." >&2
+  exit 1
+fi
+
+echo ""
+echo "Version sync: PASS"

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,56 +1,66 @@
 #!/usr/bin/env bash
-# Full TMB plugin test suite: MCP server + hook scripts.
-# Exit 0 only if every suite passes.
+# Full TMB plugin test suite. Exit 0 only if every layer passes.
+#
+# Layered model (see docs/architecture/FLOWS.md + CONTRIBUTING.md):
+#   L0 — Distribution / install-smoke   → tests/docker/install-smoke.Dockerfile (CI-only)
+#   L1 — Static / lint                  → tests/lint/*.sh (this file runs them)
+#   L2 — Unit (per-component)           → mcp/trajectory-server/src/test/*.ts
+#   L3 — Integration (cross-component)  → tests/mcp-integration/*.mjs + tests/hooks/*.sh
+#   L4 — Workflow simulation            → (planned for v0.2.0)
+#   L5 — Manual dogfood                 → tests/manual/scenarios.md (human-walked)
+#   L6 — Release canary                 → scripts/release.sh post-tag step
+
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 FAIL=0
 
-printf "=== Layer 1: MCP unit tests (handlers direct, no protocol) ===\n"
+run_step() {
+  local label="$1"
+  shift
+  printf "\n=== %s ===\n" "$label"
+  if "$@"; then
+    printf "→ PASS\n"
+  else
+    printf "→ FAIL\n"
+    FAIL=1
+  fi
+}
+
+# ----- L1 — Static / lint -----------------------------------------------
+
+run_step "L1 lint: agent template line budget"        bash "$HERE/lint/agent-line-budget.sh"
+run_step "L1 lint: onboarding skill contract"         bash "$HERE/lint/onboarding-skill-contract.sh"
+run_step "L1 lint: skill frontmatter + name=dirname"  bash "$HERE/lint/skill-frontmatter.sh"
+run_step "L1 lint: manifest shape (plugin/.mcp/hooks)" bash "$HERE/lint/manifest-shape.sh"
+run_step "L1 lint: version sync (3 manifests agree)"  bash "$HERE/lint/version-sync.sh"
+run_step "L1 lint: changelog top section current"     bash "$HERE/lint/changelog-current.sh"
+run_step "L1 lint: link-check (relative md links)"    bash "$HERE/lint/link-check.sh"
+run_step "L1 lint: shellcheck on shell scripts"       bash "$HERE/lint/shellcheck-hooks.sh"
+run_step "L1 lint: tsc --noEmit on MCP server"        bash "$HERE/lint/tsc-noemit.sh"
+
+# ----- L2 — Unit + L3 — Integration -------------------------------------
+
+printf "\n=== L2 unit: MCP handlers (node --test on built dist/) ===\n"
 if (cd "$PLUGIN_ROOT/mcp/trajectory-server" && bun run build && node --test dist/test/*.test.js); then
-  printf "MCP unit suite: PASS\n\n"
+  printf "→ PASS\n"
 else
-  printf "MCP unit suite: FAIL\n\n"
+  printf "→ FAIL\n"
   FAIL=1
 fi
 
-printf "=== Layer 2: MCP integration tests (real server subprocess + stdio JSON-RPC) ===\n"
-if bash "$HERE/mcp-integration/run.sh"; then
-  printf "\nMCP integration suite: PASS\n\n"
-else
-  printf "\nMCP integration suite: FAIL\n\n"
-  FAIL=1
-fi
+run_step "L3 integration: MCP server end-to-end (stdio JSON-RPC)"  bash "$HERE/mcp-integration/run.sh"
+run_step "L3 integration: hook script tests"                         bash "$HERE/hooks/run.sh"
 
-printf "=== Hook script tests (tests/hooks) ===\n"
-if bash "$HERE/hooks/run.sh"; then
-  printf "\nHook suite: PASS\n"
-else
-  printf "\nHook suite: FAIL\n"
-  FAIL=1
-fi
+# ----- summary -----------------------------------------------------------
 
-printf "\n=== Lint: agent prompt budget (tests/lint) ===\n"
-if bash "$HERE/lint/agent-line-budget.sh"; then
-  printf "\nLint suite: PASS\n"
-else
-  printf "\nLint suite: FAIL\n"
-  FAIL=1
-fi
-
-printf "\n=== Lint: onboarding skill contract (tests/lint) ===\n"
-if bash "$HERE/lint/onboarding-skill-contract.sh"; then
-  printf "\nOnboarding contract lint: PASS\n"
-else
-  printf "\nOnboarding contract lint: FAIL\n"
-  FAIL=1
-fi
-
+printf "\n========================================\n"
 if [ "$FAIL" -eq 0 ]; then
-  printf "\nAll test suites passed.\n"
+  printf "All test layers passed (L1 + L2 + L3).\n"
+  printf "L0 install-smoke runs separately in CI (docker required).\n"
   exit 0
 else
-  printf "\nOne or more test suites failed. See output above.\n"
+  printf "One or more layers FAILED. See output above.\n"
   exit 1
 fi


### PR DESCRIPTION
PR 2 of 3 in the test-pyramid build (PR 1 was [#77](https://github.com/trustmybot/plugin/pull/77) v0.1.3 L0 install-smoke; PR 3 will be v0.2.0 L4 workflow simulation).

## Why

v0.1.2 shipped broken because we tested **code** but not the **product**. This PR closes the gap on L1 (static), L2 (hook coverage), and L6 (release canary) — making the failure-mode → layer matrix concrete.

## What's added

### L1 — 7 new lint scripts

| Linter | Catches |
|---|---|
| `tests/lint/version-sync.sh` | Out-of-sync version fields across the 3 manifests. **Caught the stale 0.3.2 root version.** |
| `tests/lint/changelog-current.sh` | CHANGELOG top section's version doesn't match `plugin.json`. |
| `tests/lint/manifest-shape.sh` | Broken `plugin.json` / `.mcp.json` / `hooks/hooks.json` structure. Verifies semver shape, required fields, and that every hook script path resolves. |
| `tests/lint/link-check.sh` | Broken relative `[text](path)` links. Skips code spans + fenced blocks. Would have caught `docs/PERFORMANCE.md` references after retirement. |
| `tests/lint/skill-frontmatter.sh` | Missing `name:` field or `name` ≠ dirname in any `SKILL.md`. **Immediately caught 3 real bugs** (template skills missing `name:`) — fixed in this PR. |
| `tests/lint/shellcheck-hooks.sh` | Shellcheck-clean enforcement on every `*.sh` in `scripts/` and `tests/`. Would have caught the `set -o pipefail` silent-allow bug from v0.1.0. |
| `tests/lint/tsc-noemit.sh` | TS type errors that don't show up clearly in build logs. |

### L2 — `git-push-guard.sh` decision matrix

`tests/hooks/git-push-guard.test.sh` adds **16 test cases** covering every decision branch — non-push pass-through, force-push delegation, no DB, no upstream, untracked commits, all-signed, unsigned (single + multi + mixed). The push-gate had **zero** test coverage before this — critical gap given it's the structural protection against pushing unreviewed commits.

### L6 — Release canary

`scripts/release.sh` step 4: re-clones the just-published tag in a temp dir and runs the L0 install-smoke Dockerfile against it. Catches "the published artifact differs from what we tested locally." Skipped gracefully if Docker is unavailable.

## Test infra refactor

`tests/run-all.sh` restructured to the explicit layered model (L1 → L2 → L3) with named single-line PASS/FAIL per step. New layer counts:

| Layer | Before | After |
|---|---|---|
| L0 install-smoke (Docker) | 1 | 1 (unchanged from v0.1.3) |
| L1 lint scripts | 2 | **9** |
| L2 MCP unit | 245 | 245 |
| L3 integration (MCP + hook) | 9+2 | 9+**3** (added push-guard) |
| L6 release canary | 0 | **1** |

L4 (workflow simulation) and L5 (manual dogfood checklist) ship in v0.2.0.

## Verification

`bash tests/run-all.sh` all green locally. CI will re-verify (test job + L0 install-smoke job).

## Closes the v0.1.2 regression class

Combined with PR #77 (v0.1.3 install-smoke), the failure modes that bit us in v0.1.2 are now structurally caught:

- ✅ Missing `dist/` after install → L0
- ✅ Stale workspace root version → L1 version-sync
- ✅ Broken doc links after file deletion → L1 link-check
- ✅ Missing skill `name:` frontmatter → L1 skill-frontmatter
- ✅ Hook silent-allow on `set -o pipefail` → L1 shellcheck
- ✅ Push-gate missed unsigned commits → L2 push-guard tests
- ✅ Published artifact diverges from local → L6 canary