### PR TITLE
🔒 fix(release): refuse to re-tag a published release + lint to enforce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ The 5 flows that **can't** be tested at L4 (onboarding, agent-creator, skill-cre
 
 10 numbered items, ~30 minutes to walk. **Required before tagging any release ≥ v0.2.0.**
 
+#### Release-script anti-retag guard
+
+`scripts/release.sh` now **refuses to re-tag a published release**. If `git ls-remote --tags origin refs/tags/v<X.Y.Z>` returns a SHA, the script exits with a clear error explaining the doctrinal alternative (bump the version, ship a new tag). Force-pushing tags is the antipattern that breaks consumer pinning, corrupts marketplace caches, and destroys audit trails — the script now prevents the accidental case while still allowing safe local-only retags (e.g. you tagged but haven't pushed yet).
+
+`tests/lint/release-script-safety.sh` (new lint) protects this guard against accidental removal during refactors. 5 grep-based assertions cover the remote-check, refusal message, exit-code, doctrinal alternative text, and the local-only path's correctness.
+
 #### L5 release gate
 
 `scripts/release.sh` now refuses to tag unless `MANUAL_DOGFOOD_PASSED=v<X.Y.Z>` matches the version being tagged. Sign-off after walking `tests/manual/scenarios.md`:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -127,12 +127,35 @@ if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
   if [ "$EXISTING_TAG_TARGET" = "$LOCAL_HEAD" ]; then
     printf "  Step 1: %s already points at HEAD — skipping retag.\n\n" "$NEW_TAG"
   else
-    printf "  ⚠️  %s exists but points at %s, not main HEAD %s.\n" "$NEW_TAG" "${EXISTING_TAG_TARGET:0:8}" "${LOCAL_HEAD:0:8}"
+    # The local tag exists but points elsewhere. Before offering to move it,
+    # check whether it's already published to the remote. If yes — REFUSE.
+    # Re-tagging a published release is the antipattern that breaks every
+    # downstream consumer's pinning + the marketplace cache. The discipline
+    # is "bump the version and ship a new tag" (e.g. v0.2.0 broken → v0.2.1).
+    REMOTE_TAG_SHA="$(git ls-remote --tags origin "refs/tags/$NEW_TAG" 2>/dev/null | awk '{print $1}')"
+    if [ -n "$REMOTE_TAG_SHA" ]; then
+      printf "❌ Refusing to re-tag a PUBLISHED release.\n" >&2
+      printf "\n" >&2
+      printf "  %s is already on origin (sha=%s).\n" "$NEW_TAG" "${REMOTE_TAG_SHA:0:8}" >&2
+      printf "  Re-tagging breaks every consumer that pinned to this version,\n" >&2
+      printf "  silently corrupts marketplace caches, and destroys the audit trail.\n" >&2
+      printf "\n" >&2
+      printf "  If you found a bug in %s, ship a NEW version with the fix:\n" "$NEW_TAG" >&2
+      printf "    1. Bump plugin.json + mcp pkg.json + root pkg.json to v%s.<next-patch>\n" "${NEW_VERSION%.*}" >&2
+      printf "    2. Add a CHANGELOG section for the new version\n" >&2
+      printf "    3. PR through dev → main → bash scripts/release.sh\n" >&2
+      printf "\n" >&2
+      printf "  Optionally annotate the broken release on GitHub:\n" >&2
+      printf "    gh release edit %s --notes \"⚠️  Known bug: <describe>. Upgrade to v...\"\n" "$NEW_TAG" >&2
+      exit 1
+    fi
+    printf "  ⚠️  Local-only %s exists at %s but points at %s, not main HEAD %s.\n" \
+      "$NEW_TAG" "${EXISTING_TAG_TARGET:0:8}" "${EXISTING_TAG_TARGET:0:8}" "${LOCAL_HEAD:0:8}"
+    printf "      (Not on origin yet — local-only retag is safe.)\n"
     if confirm "  Move $NEW_TAG to current main HEAD?"; then
       git tag -d "$NEW_TAG"
-      git push origin ":refs/tags/$NEW_TAG" 2>/dev/null || true
       git tag -a "$NEW_TAG" -m "$NEW_TAG"
-      printf "  ✓ %s re-tagged on %s\n\n" "$NEW_TAG" "${LOCAL_HEAD:0:8}"
+      printf "  ✓ %s re-tagged locally on %s\n\n" "$NEW_TAG" "${LOCAL_HEAD:0:8}"
     else
       printf "  Skipped — %s left where it is.\n\n" "$NEW_TAG"
     fi

--- a/tests/lint/release-script-safety.sh
+++ b/tests/lint/release-script-safety.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Lint: structural safety checks on scripts/release.sh.
+#
+# Protects against the "force-push a published tag" antipattern: the
+# release script must contain the explicit "Refusing to re-tag a PUBLISHED
+# release" guard. This test catches accidental removal of that guard
+# during refactors.
+#
+# This is a lint, not a behavior test, because driving release.sh
+# end-to-end requires a real repo + real remote. The behavior is small
+# enough that grep'ing for the guard text + the underlying mechanism
+# (`git ls-remote --tags origin`) is sufficient evidence.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/release.sh"
+
+failed=0
+fail() { echo "  ✗ $1" >&2; failed=1; }
+pass() { echo "  ✓ $1"; }
+
+if [ ! -f "$SCRIPT" ]; then
+  fail "scripts/release.sh missing"
+  echo "Release-script-safety: FAIL" >&2
+  exit 1
+fi
+
+# G1: must check the remote before considering retag
+if grep -q 'git ls-remote --tags origin "refs/tags/\$NEW_TAG"' "$SCRIPT"; then
+  pass "checks remote for the tag before allowing any retag"
+else
+  fail "missing remote-tag check (git ls-remote --tags origin refs/tags/\$NEW_TAG)"
+fi
+
+# G2: must contain the explicit refusal message
+if grep -q 'Refusing to re-tag a PUBLISHED release' "$SCRIPT"; then
+  pass "contains explicit refusal message for published-tag retag"
+else
+  fail "missing 'Refusing to re-tag a PUBLISHED release' guard"
+fi
+
+# G3: must exit non-zero on the published-retag path (so it actually blocks).
+# Look for `exit 1` (any indentation) within ~30 lines after the refusal message.
+if awk '
+  /Refusing to re-tag a PUBLISHED release/ { found=1; line=NR }
+  found && /^[[:space:]]*exit 1[[:space:]]*$/ && NR-line<=30 { print "ok"; exit }
+' "$SCRIPT" | grep -q ok; then
+  pass "exits non-zero on published-retag refusal path"
+else
+  fail "no 'exit 1' within 30 lines of the refusal message — guard would be advisory only"
+fi
+
+# G4: must mention the doctrinal alternative (bump version, ship new tag)
+if grep -q "ship a NEW version with the fix" "$SCRIPT"; then
+  pass "documents the doctrinal alternative (bump version)"
+else
+  fail "missing doctrinal alternative — refusal should explain what to do instead"
+fi
+
+# G5: must NOT push to origin a deleted tag in the local-only retag path
+# (an earlier version did `git push origin :refs/tags/$NEW_TAG` even for
+# local-only tags, which would silently delete the remote tag if it existed)
+if awk '/Local-only/{found=1} found && /git push.*:refs\/tags/ {print "BAD"; exit}' "$SCRIPT" | grep -q BAD; then
+  fail "local-only retag path still tries to push tag deletion to origin (would corrupt remote)"
+else
+  pass "local-only retag path doesn't push tag deletion to origin"
+fi
+
+echo ""
+if [ $failed -ne 0 ]; then
+  echo "Release-script-safety: FAIL" >&2
+  exit 1
+fi
+echo "Release-script-safety: PASS"

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -39,6 +39,7 @@ run_step "L1 lint: changelog top section current"     bash "$HERE/lint/changelog
 run_step "L1 lint: link-check (relative md links)"    bash "$HERE/lint/link-check.sh"
 run_step "L1 lint: shellcheck on shell scripts"       bash "$HERE/lint/shellcheck-hooks.sh"
 run_step "L1 lint: tsc --noEmit on MCP server"        bash "$HERE/lint/tsc-noemit.sh"
+run_step "L1 lint: release script safety guards"      bash "$HERE/lint/release-script-safety.sh"
 
 # ----- L2 — Unit + L3 — Integration -------------------------------------
 


### PR DESCRIPTION
Per the discussion: prevent the \"force-push a published tag\" antipattern at the script level + lock the guard in with a lint.

## Fix

`scripts/release.sh` now does a `git ls-remote --tags origin refs/tags/$NEW_TAG` check before any retag is offered:

- **Tag on remote** → REFUSE with a clear error explaining the doctrinal alternative (bump version, ship new tag) plus the exact 3-step recipe.
- **Local-only tag** (e.g. half-finished release): allow with the existing y/N prompt; doesn't try to push the tag deletion to origin.

## Lint to keep the guard

`tests/lint/release-script-safety.sh` enforces 5 invariants on the script structure:
- G1: remote-check via `git ls-remote --tags origin refs/tags/\$NEW_TAG`
- G2: explicit refusal message present
- G3: `exit 1` (not just a warning) within 30 lines of the message
- G4: doctrinal alternative documented in the error text
- G5: local-only retag path doesn't push tag deletion to origin

If a future refactor removes any of these, the lint fails in CI.

## Folded into v0.2.0

v0.2.0 is still in dev (untagged), so this lands under the existing v0.2.0 CHANGELOG entry rather than cutting a v0.2.1 just for one guard.

## Verification

`bash tests/run-all.sh` all green locally (10 lints now, including the new release-script-safety).