### PR TITLE
🚀 release: v0.2.0 — install-smoke + test pyramid + dogfood gate

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "TMB multi-agent Claude Code plugin with SQLite trajectory MCP.",
   "author": {
     "name": "trustmybot",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TMB multi-agent Claude Code plugin with SQLite trajectory MCP.",
   "author": {
     "name": "trustmybot",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "TMB multi-agent Claude Code plugin with SQLite trajectory MCP.",
   "author": {
     "name": "trustmybot",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   test:
+    name: lint + MCP unit + integration + hooks
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -34,3 +35,19 @@ jobs:
 
       - name: run full test suite
         run: bash tests/run-all.sh
+
+  install-smoke:
+    name: L0 install-smoke (cold-start Docker)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: build install-smoke image
+        # Strips local artifacts, runs `bun install`, asserts dist/index.js
+        # exists, spawns the MCP server, and verifies tools/list responds.
+        # This catches the v0.1.2 class of bug where the published artifact
+        # was unbootable because postinstall didn't fire.
+        run: docker build -f tests/docker/install-smoke.Dockerfile -t tmb-install-smoke .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ The 5 flows that **can't** be tested at L4 (onboarding, agent-creator, skill-cre
 
 10 numbered items, ~30 minutes to walk. **Required before tagging any release ≥ v0.2.0.**
 
+#### Release-script anti-retag guard
+
+`scripts/release.sh` now **refuses to re-tag a published release**. If `git ls-remote --tags origin refs/tags/v<X.Y.Z>` returns a SHA, the script exits with a clear error explaining the doctrinal alternative (bump the version, ship a new tag). Force-pushing tags is the antipattern that breaks consumer pinning, corrupts marketplace caches, and destroys audit trails — the script now prevents the accidental case while still allowing safe local-only retags (e.g. you tagged but haven't pushed yet).
+
+`tests/lint/release-script-safety.sh` (new lint) protects this guard against accidental removal during refactors. 5 grep-based assertions cover the remote-check, refusal message, exit-code, doctrinal alternative text, and the local-only path's correctness.
+
 #### L5 release gate
 
 `scripts/release.sh` now refuses to tag unless `MANUAL_DOGFOOD_PASSED=v<X.Y.Z>` matches the version being tagged. Sign-off after walking `tests/manual/scenarios.md`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
+## v0.1.4 — 2026-04-25
+
+**Test pyramid expansion (L1, L2, L6).** No agent / hook / MCP behavior change — but a meaningful regression-prevention upgrade. PR 2 of the comprehensive auto-test layers initiative (PR 1 was v0.1.3's L0 install-smoke).
+
+### Added
+
+#### L1 — Static lint expansion (7 new linters)
+
+Eight failure modes that used to slip through review now fail the build instead. Run via `bash tests/run-all.sh` (also wired into CI).
+
+| New linter | What it catches |
+|---|---|
+| `tests/lint/version-sync.sh` | Out-of-sync version fields across `.claude-plugin/plugin.json`, `mcp/trajectory-server/package.json`, root `package.json`. (Caught + corrected the stale `0.3.2` root version that survived through v0.1.2.) |
+| `tests/lint/changelog-current.sh` | CHANGELOG top section's version doesn't match `plugin.json`. |
+| `tests/lint/manifest-shape.sh` | JSON-shape validation of `plugin.json`, `.mcp.json`, `hooks/hooks.json`. Verifies semver-shape `version`, presence of required fields, and that every `command` path in `hooks/hooks.json` resolves. |
+| `tests/lint/link-check.sh` | Every relative `[text](path)` link in tracked `.md` files resolves to an existing file. (Would have caught the broken `docs/PERFORMANCE.md` references after we retired it in v0.1.2.) |
+| `tests/lint/skill-frontmatter.sh` | Every `SKILL.md` (under `skills/` and `templates/skills/`) has valid frontmatter with `name` + `description`, AND `name` matches the parent dirname. **Caught real bugs:** `templates/skills/{docs-conventions,git-conventions,naming-conventions}/SKILL.md` were missing the `name:` field — they wouldn't have loaded properly when copied into projects. Fixed in this release. |
+| `tests/lint/shellcheck-hooks.sh` | shellcheck-clean enforcement on every shell script in `scripts/` and `tests/`. (Would have caught the `set -o pipefail` silent-allow bug we hit in v0.1.0.) |
+| `tests/lint/tsc-noemit.sh` | Standalone TS type check on the MCP server source — catches type errors without relying on someone reading the build log. |
+
+#### L2 — Hook decision-matrix expansion
+
+`tests/hooks/git-push-guard.test.sh` — **16 new test cases** covering every decision branch of `scripts/hooks/git-push-guard.sh`:
+
+- Non-push command → pass-through
+- `git push --force` / `-f` → delegated to git-guards (this hook allows)
+- Missing DB / no upstream / no new commits → allowed
+- Untracked commits (no matching `tasks` row) → allowed (pre-TMB / external work)
+- All-signed tracked commits → allowed
+- One unsigned → BLOCKED with helpful message + task_id list
+- Multiple unsigned → BLOCKED, all listed
+- Mixed-signed → BLOCKED only on the unsigned ones
+
+Previously `git-push-guard.sh` had **zero** test coverage — a critical gap given it's the structural protection against pushing unreviewed commits.
+
+#### L6 — Release canary
+
+`scripts/release.sh` now has a step 4: after the GitHub release is created, the script offers to re-clone the just-published tag in a temp dir and run the L0 install-smoke Dockerfile against it. Catches "the published artifact differs from what we tested locally" — e.g. if `.gitignore` excluded something needed for install. Skipped gracefully if Docker is unavailable.
+
+### Fixed
+
+- **Three template skills (`docs-conventions`, `git-conventions`, `naming-conventions`) now have `name:` frontmatter** — they were missing it and would have failed to load by name when copied into a project. Caught by the new `skill-frontmatter.sh` lint.
+
+### Test infrastructure
+
+- `tests/run-all.sh` now uses the explicit layered model (L1 → L2 → L3) with named steps, instead of the previous ad-hoc list. Single-line PASS/FAIL per step.
+- Layer count is now: **L0** (install-smoke, CI-only Docker), **L1** (9 lint scripts), **L2** (245 MCP unit tests), **L3** (9 MCP-integration suites + 3 hook test suites), **L6** (release canary in release.sh). L4 (workflow simulation) and L5 (manual dogfood checklist) coming in v0.2.0.
+
+### Versioning
+
+Bumped all three manifest versions to `0.1.4`. No schema migration.
+
+---
+
 ## v0.1.3 — 2026-04-25
 
 **Critical install hotfix.** v0.1.2 shipped without prebuilt `dist/` for the MCP trajectory server, so a fresh marketplace install left the MCP server unbootable. First sessions silently failed to register any of the `mcp__plugin_tmb_trajectory-server__*` tools, breaking onboarding, planning, and every workflow that depends on MCP state. **Anyone on v0.1.2 should upgrade.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,78 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
+## v0.2.0 — 2026-04-25
+
+**Workflow simulation harness + manual dogfood gate.** Final PR in the test-pyramid build. The full layered model is now in place: every failure mode that doesn't require Claude Code in the loop has an automated test owner.
+
+### Added
+
+#### L4 — Workflow simulation harness
+
+New directory `tests/workflow-sim/` holds **5 trajectory tests**, one per FLOWS.md flow that has an MCP-side contract worth asserting. Each test spawns the real MCP server and walks the flow as a scripted sequence of tool calls — no Claude required. Asserts state transitions, ledger events, role enforcement, and discussion-thread shape.
+
+| Flow | Test file | Asserts |
+|---|---|---|
+| 2 — Simple task | `flow-02-simple-task.test.mjs` | bro plans → swe completes → bro closes; **no per-task pr-reviewer** (push gate is amortized); planning_complete event lands in ledger |
+| 3 — Difficult task | `flow-03-difficult-task.test.mjs` | Q+A discussion sequence satisfies scope gate without `waive_scope_gate`; decision row queryable for ADR generation; positive + negative cases |
+| 6 — Push gate | `flow-06-push-gate.test.mjs` | bro forbidden from `validation_record` (only pr-reviewer); fail-then-pass attempt sequence preserved in `validation_history` |
+| 7 — Architecture regen | `flow-07-architecture-regen.test.mjs` | regen_state cursor lifecycle; swe forbidden from `architecture_regen` and `regen_state_set` |
+| 8 — SWE retry | `flow-08-swe-retry.test.mjs` | 3-attempt sequence preserved; UNIQUE(task_id, attempt_n) yields upsert (latest verdict wins); `'escalated'` is a valid terminal status |
+| D — Direct Mode | `flow-D-direct-mode.test.mjs` | `direct_mode_used` ledger event; no task / validation rows created |
+
+The 5 flows that **can't** be tested at L4 (onboarding, agent-creator, skill-creator) are filesystem-only or Claude-side; they live in L5.
+
+`tests/mcp-integration/run.sh` was extended to run both L3 (existing 9 suites) and L4 (new 5 suites) in one Node process — total **43 tests, ~3.1s**.
+
+#### L5 — Compressed manual dogfood checklist
+
+`tests/manual/scenarios.md` shrunk **from 785 lines → ~140 lines** of checklist focused on Claude-side behaviors that have no MCP surface to test: trigger word activation, AskUserQuestion radio rendering, silent template copy, subagent prompt precedence, worktree isolation, bro task-gate verification visible in conversation, push-gate flow with lazy pr-reviewer copy, Direct Mode timing, resume after kill, tone discipline.
+
+10 numbered items, ~30 minutes to walk. **Required before tagging any release ≥ v0.2.0.**
+
+#### L5 release gate
+
+`scripts/release.sh` now refuses to tag unless `MANUAL_DOGFOOD_PASSED=v<X.Y.Z>` matches the version being tagged. Sign-off after walking `tests/manual/scenarios.md`:
+
+```bash
+export MANUAL_DOGFOOD_PASSED=v0.2.0
+bash scripts/release.sh
+```
+
+Bypass for hotfixes that don't change Claude-side behavior:
+
+```bash
+BYPASS_DOGFOOD=1 bash scripts/release.sh   # justify in commit message
+```
+
+### Doctrine — the full pyramid is now in place
+
+```
+L0 — Distribution / install-smoke   (Docker — CI on every PR)
+L1 — Static / lint                  (9 scripts — CI on every PR)
+L2 — Unit (per-component)           (245 MCP unit + 16 hook unit — CI on every PR)
+L3 — Integration (cross-component)  (9 MCP-integration suites — CI on every PR)
+L4 — Workflow simulation            (5 trajectory suites — CI on every PR)
+L5 — Manual dogfood (Claude-side)   (10-item checklist — required before tag)
+L6 — Release canary                 (Docker re-clone of tag — in release.sh)
+```
+
+| Failure-mode class | Owner |
+|---|---|
+| MCP server fails to boot after install | L0 |
+| Stale version, broken link, missing skill name, shellcheck regression | L1 |
+| Per-tool / per-hook contract regression | L2 |
+| Cross-component (MCP+hook+DB) regression | L3 |
+| Workflow contract change without test update | L4 |
+| Trigger word, AskUserQuestion, agent isolation, tone, resume | L5 |
+| Published artifact ≠ tested artifact | L6 |
+
+### Versioning
+
+Bumped all three manifest versions to `0.2.0`. Minor bump (not patch) reflects the structural test infrastructure addition — no doctrine or behavior change for users.
+
+---
+
 ## v0.1.4 — 2026-04-25
 
 **Test pyramid expansion (L1, L2, L6).** No agent / hook / MCP behavior change — but a meaningful regression-prevention upgrade. PR 2 of the comprehensive auto-test layers initiative (PR 1 was v0.1.3's L0 install-smoke).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
+## v0.1.3 — 2026-04-25
+
+**Critical install hotfix.** v0.1.2 shipped without prebuilt `dist/` for the MCP trajectory server, so a fresh marketplace install left the MCP server unbootable. First sessions silently failed to register any of the `mcp__plugin_tmb_trajectory-server__*` tools, breaking onboarding, planning, and every workflow that depends on MCP state. **Anyone on v0.1.2 should upgrade.**
+
+### Fixed
+
+- **Marketplace install now boots cleanly** — added a `postinstall` script to the workspace root `package.json` that runs `bun --filter='*' run build`, ensuring `dist/index.js` and `dist/schema.sql` exist after `bun install`. Restores the cold-start contract that v0.1.2 broke.
+- Synced workspace-root `package.json` version (was a stale `0.3.2`) to track the plugin version (now `0.1.3`).
+
+### Added — Layer 0 distribution test (so this can't ship again)
+
+Added a Docker-based **install-smoke test** at [`tests/docker/install-smoke.Dockerfile`](tests/docker/install-smoke.Dockerfile) and a local wrapper [`tests/docker/run-install-smoke.sh`](tests/docker/run-install-smoke.sh). The Dockerfile:
+
+1. Starts from a clean `node:20-slim` (no preexisting `dist/`, no `node_modules/`).
+2. Installs bun + sqlite, copies the plugin tree.
+3. Strips any local artifacts to force cold-start conditions.
+4. Runs `bun install --frozen-lockfile` and asserts `mcp/trajectory-server/dist/index.js` + `dist/schema.sql` exist after install.
+5. Spawns the MCP server, sends `tools/list`, asserts it responds with `identity_get`.
+6. Re-runs both lint scripts in the as-shipped tree.
+7. Verifies all hook scripts are executable + syntactically valid.
+8. Confirms `.mcp.json`'s server path resolves in the installed tree.
+
+Wired into `.github/workflows/test.yml` as a separate `install-smoke` CI job that runs on every PR + push to dev/main. Build success = a clean marketplace install would boot. Build failure = release blocker.
+
+This is **Layer 0** in the broader test-pyramid plan tracked in #76 follow-ups. v0.1.4 will add Layer 1 lint expansions + Layer 2 unit expansions + Layer 6 release-canary; v0.2.0 will add Layer 4 workflow-simulation harness.
+
+### Versioning
+
+Bumped `.claude-plugin/plugin.json`, `mcp/trajectory-server/package.json`, and root `package.json` to `0.1.3`. No schema migrations needed (still `schema_version=1`).
+
+---
+
 ## v0.1.2 — 2026-04-25
 
 **Docs + structural release.** No agent, hook, or MCP-server behavior change. Adds multi-platform structural placeholders following the [Superpowers](https://github.com/obra/superpowers) pattern, and refreshes contributor docs to match the bro-as-planner doctrine that landed in v0.1.0.

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "TMB multi-agent Claude Code plugin — workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "TMB multi-agent Claude Code plugin — workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.3.2",
+  "version": "0.1.3",
   "description": "TMB multi-agent Claude Code plugin — workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "build": "bun --filter='*' run build",
+    "postinstall": "bun --filter='*' run build",
     "test": "bash tests/run-all.sh"
   },
   "devDependencies": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -77,6 +77,34 @@ if ! grep -q "^## ${NEW_TAG} " CHANGELOG.md; then
   exit 1
 fi
 
+# L5 manual dogfood gate. The release script refuses to tag without an
+# explicit signed-off env var matching this exact version. See
+# tests/manual/scenarios.md for the checklist that produces this sign-off.
+#
+# Bypass for hotfix releases that don't change Claude-side behavior:
+# set BYPASS_DOGFOOD=1 with a justification in the commit log.
+if [ "${BYPASS_DOGFOOD:-0}" = "1" ]; then
+  printf "⚠️  L5 manual dogfood gate BYPASSED (BYPASS_DOGFOOD=1).\n"
+  printf "    This is acceptable for hotfix releases that don't touch Claude-side\n"
+  printf "    behavior (agents/skills/CLAUDE.md). Document the bypass reason in the\n"
+  printf "    release commit message.\n\n"
+elif [ "${MANUAL_DOGFOOD_PASSED:-}" = "$NEW_TAG" ]; then
+  printf "✓ L5 manual dogfood passed for %s (MANUAL_DOGFOOD_PASSED matches).\n\n" "$NEW_TAG"
+else
+  printf "❌ Refusing to tag. L5 manual dogfood not signed off for %s.\n" "$NEW_TAG" >&2
+  printf "\n" >&2
+  printf "   Walk through the checklist at tests/manual/scenarios.md, then re-run with:\n" >&2
+  printf "     export MANUAL_DOGFOOD_PASSED=%s && bash scripts/release.sh\n" "$NEW_TAG" >&2
+  printf "\n" >&2
+  printf "   For hotfix releases that don't change Claude-side behavior:\n" >&2
+  printf "     BYPASS_DOGFOOD=1 bash scripts/release.sh    # justify in commit message\n" >&2
+  if [ -n "${MANUAL_DOGFOOD_PASSED:-}" ]; then
+    printf "\n   (MANUAL_DOGFOOD_PASSED is set to '%s' but plugin version is '%s' — version drift.)\n" \
+      "$MANUAL_DOGFOOD_PASSED" "$NEW_TAG" >&2
+  fi
+  exit 1
+fi
+
 confirm() {
   printf "%s [y/N] " "$1"
   read -r answer

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -127,12 +127,35 @@ if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
   if [ "$EXISTING_TAG_TARGET" = "$LOCAL_HEAD" ]; then
     printf "  Step 1: %s already points at HEAD — skipping retag.\n\n" "$NEW_TAG"
   else
-    printf "  ⚠️  %s exists but points at %s, not main HEAD %s.\n" "$NEW_TAG" "${EXISTING_TAG_TARGET:0:8}" "${LOCAL_HEAD:0:8}"
+    # The local tag exists but points elsewhere. Before offering to move it,
+    # check whether it's already published to the remote. If yes — REFUSE.
+    # Re-tagging a published release is the antipattern that breaks every
+    # downstream consumer's pinning + the marketplace cache. The discipline
+    # is "bump the version and ship a new tag" (e.g. v0.2.0 broken → v0.2.1).
+    REMOTE_TAG_SHA="$(git ls-remote --tags origin "refs/tags/$NEW_TAG" 2>/dev/null | awk '{print $1}')"
+    if [ -n "$REMOTE_TAG_SHA" ]; then
+      printf "❌ Refusing to re-tag a PUBLISHED release.\n" >&2
+      printf "\n" >&2
+      printf "  %s is already on origin (sha=%s).\n" "$NEW_TAG" "${REMOTE_TAG_SHA:0:8}" >&2
+      printf "  Re-tagging breaks every consumer that pinned to this version,\n" >&2
+      printf "  silently corrupts marketplace caches, and destroys the audit trail.\n" >&2
+      printf "\n" >&2
+      printf "  If you found a bug in %s, ship a NEW version with the fix:\n" "$NEW_TAG" >&2
+      printf "    1. Bump plugin.json + mcp pkg.json + root pkg.json to v%s.<next-patch>\n" "${NEW_VERSION%.*}" >&2
+      printf "    2. Add a CHANGELOG section for the new version\n" >&2
+      printf "    3. PR through dev → main → bash scripts/release.sh\n" >&2
+      printf "\n" >&2
+      printf "  Optionally annotate the broken release on GitHub:\n" >&2
+      printf "    gh release edit %s --notes \"⚠️  Known bug: <describe>. Upgrade to v...\"\n" "$NEW_TAG" >&2
+      exit 1
+    fi
+    printf "  ⚠️  Local-only %s exists at %s but points at %s, not main HEAD %s.\n" \
+      "$NEW_TAG" "${EXISTING_TAG_TARGET:0:8}" "${EXISTING_TAG_TARGET:0:8}" "${LOCAL_HEAD:0:8}"
+    printf "      (Not on origin yet — local-only retag is safe.)\n"
     if confirm "  Move $NEW_TAG to current main HEAD?"; then
       git tag -d "$NEW_TAG"
-      git push origin ":refs/tags/$NEW_TAG" 2>/dev/null || true
       git tag -a "$NEW_TAG" -m "$NEW_TAG"
-      printf "  ✓ %s re-tagged on %s\n\n" "$NEW_TAG" "${LOCAL_HEAD:0:8}"
+      printf "  ✓ %s re-tagged locally on %s\n\n" "$NEW_TAG" "${LOCAL_HEAD:0:8}"
     else
       printf "  Skipped — %s left where it is.\n\n" "$NEW_TAG"
     fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -163,6 +163,46 @@ else
   fi
 fi
 
+# ---------- step 4: L6 release canary (post-tag verify) ----------
+#
+# Re-clones the freshly-tagged release into a temp dir and runs the
+# install-smoke Dockerfile against it. Catches "the published artifact
+# differs from what we tested locally" — e.g. a .gitignore that excluded
+# something the install needs.
+#
+# Skipped if Docker is unavailable; warning instead of failure since the
+# release is already public at this point.
+
+if confirm "Step 4: Run L6 release canary (re-clone tag in Docker, run install-smoke)?"; then
+  if ! command -v docker >/dev/null 2>&1; then
+    printf "  ⊘ docker not available — skipping canary. Run manually before announcing the release:\n"
+    printf "      bash tests/docker/run-install-smoke.sh\n"
+  else
+    CANARY_DIR=$(mktemp -d -t tmb-canary-XXXX)
+    trap 'rm -rf "$CANARY_DIR"' EXIT
+    printf "  Cloning %s into %s ...\n" "$NEW_TAG" "$CANARY_DIR"
+    if git clone --quiet --depth 1 --branch "$NEW_TAG" \
+        "https://github.com/trustmybot/plugin.git" "$CANARY_DIR/plugin"; then
+      if (cd "$CANARY_DIR/plugin" && docker build \
+            -f tests/docker/install-smoke.Dockerfile \
+            -t "tmb-canary-$NEW_VERSION" \
+            --quiet .); then
+        printf "  ✓ Canary PASSED — published %s installs cleanly from a fresh clone\n\n" "$NEW_TAG"
+      else
+        printf "\n  ⚠️  CANARY FAILED — published %s does NOT install cleanly!\n" "$NEW_TAG" >&2
+        printf "     The release is public but broken. Investigate before announcing.\n" >&2
+        printf "     Likely causes: .gitignore excluded something needed; postinstall regression;\n" >&2
+        printf "     bun.lock out of sync; etc.\n" >&2
+        exit 1
+      fi
+    else
+      printf "  ⚠️  Could not clone tag %s — release exists but git clone failed.\n" "$NEW_TAG" >&2
+    fi
+  fi
+else
+  printf "  Skipped — run 'bash tests/docker/run-install-smoke.sh' manually before announcing.\n\n"
+fi
+
 # ---------- summary ----------
 
 printf "Done. Verify:\n"

--- a/templates/skills/docs-conventions/SKILL.md
+++ b/templates/skills/docs-conventions/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: docs-conventions
 description: When and how to update docs alongside code changes, plus the discipline for editing agent prompts and skill files.
 agent: bro, swe, pr-reviewer
 ---

--- a/templates/skills/git-conventions/SKILL.md
+++ b/templates/skills/git-conventions/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: git-conventions
 description: Commit message style, branching rules, push safety.
 agent: bro, swe, pr-reviewer
 ---

--- a/templates/skills/naming-conventions/SKILL.md
+++ b/templates/skills/naming-conventions/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: naming-conventions
 description: File and identifier naming patterns.
 agent: swe, pr-reviewer
 paths: ["src/**", "lib/**", "app/**", "tests/**"]

--- a/tests/docker/install-smoke.Dockerfile
+++ b/tests/docker/install-smoke.Dockerfile
@@ -1,0 +1,72 @@
+# Layer 0 — Distribution / cold-start install smoke
+#
+# Simulates what a marketplace install does: clone repo, `bun install`,
+# then immediately try to spawn the MCP server. v0.1.2 shipped without
+# a postinstall build step, so dist/index.js was missing and the server
+# silently failed. This Dockerfile catches that class of regression.
+#
+# Build:
+#   docker build -f tests/docker/install-smoke.Dockerfile -t tmb-install-smoke .
+#
+# Each `RUN test` line is a fail-fast assertion. Build success = release shippable.
+
+FROM node:20-slim
+
+# Install bun + sqlite (CC's plugin install runtime assumes bun for workspace handling)
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl unzip git ca-certificates sqlite3 \
+ && rm -rf /var/lib/apt/lists/* \
+ && curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+# Copy the plugin tree as it would be served from the marketplace
+WORKDIR /plugin
+COPY . /plugin
+
+# Strip any local build artifacts so we test cold-start, not "what was already built"
+RUN rm -rf node_modules \
+           mcp/trajectory-server/node_modules \
+           mcp/trajectory-server/dist \
+           monitors/node_modules
+
+# Simulate CC's plugin install: bun install at the workspace root.
+# postinstall (added in v0.1.3) MUST build the workspaces, otherwise the
+# next assertions fail.
+RUN bun install --frozen-lockfile
+
+# ---- Hard assertions — these would have failed on v0.1.2 ----
+
+# A1: dist/ exists and contains the entry point
+RUN test -f mcp/trajectory-server/dist/index.js \
+ || (echo "❌ FAIL: mcp/trajectory-server/dist/index.js missing after install — postinstall didn't run or build failed" && exit 1)
+
+# A2: schema.sql copied alongside (the build script does both)
+RUN test -f mcp/trajectory-server/dist/schema.sql \
+ || (echo "❌ FAIL: dist/schema.sql missing — build didn't copy schema" && exit 1)
+
+# A3: MCP server actually spawns and responds to tools/list
+RUN echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  | timeout 8 node mcp/trajectory-server/dist/index.js 2>/dev/null \
+  | grep -q '"name":"identity_get"' \
+ || (echo "❌ FAIL: MCP server did not respond with tools/list containing identity_get" && exit 1)
+
+# A4: every shipped agent template parses (frontmatter + body, ≤30 lines)
+RUN bash tests/lint/agent-line-budget.sh \
+ || (echo "❌ FAIL: agent-line-budget lint failed in clean install" && exit 1)
+
+# A5: onboarding skill contract still met in the as-shipped tree
+RUN bash tests/lint/onboarding-skill-contract.sh \
+ || (echo "❌ FAIL: onboarding-skill-contract lint failed in clean install" && exit 1)
+
+# A6: hook scripts are executable + syntactically valid
+RUN for h in scripts/hooks/*.sh; do \
+      test -x "$h" || (echo "❌ FAIL: $h not executable" && exit 1); \
+      bash -n "$h" || (echo "❌ FAIL: $h has syntax error" && exit 1); \
+    done
+
+# A7: .mcp.json points at a path that actually exists in the install
+RUN test -f "$(node -e 'const m=require("./.mcp.json");console.log(m.mcpServers["trajectory-server"].args[0].replace("${CLAUDE_PLUGIN_ROOT}", "/plugin"))')" \
+ || (echo "❌ FAIL: .mcp.json command path does not exist in installed tree" && exit 1)
+
+# Final marker so the build log shows we made it all the way
+RUN echo "✓ Layer 0 install-smoke: all assertions passed"

--- a/tests/docker/run-install-smoke.sh
+++ b/tests/docker/run-install-smoke.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Local convenience wrapper for the L0 install-smoke Docker test.
+#
+# Usage:
+#   bash tests/docker/run-install-smoke.sh
+#
+# Builds tests/docker/install-smoke.Dockerfile from the plugin root.
+# Build success = a fresh marketplace install would boot cleanly.
+# Build failure = release-blocker; a real user would hit it.
+
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$PLUGIN_ROOT"
+
+if ! command -v docker >/dev/null 2>&1; then
+  printf "❌ docker not found. Install Docker Desktop or run via CI.\n" >&2
+  exit 1
+fi
+
+IMAGE_TAG="tmb-install-smoke:$(jq -r '.version' .claude-plugin/plugin.json)"
+
+printf "Building %s from a clean tree (this strips dist/ + node_modules first)...\n\n" "$IMAGE_TAG"
+docker build \
+  -f tests/docker/install-smoke.Dockerfile \
+  -t "$IMAGE_TAG" \
+  --progress=plain \
+  .
+
+printf "\n✓ Layer 0 install-smoke passed. A fresh marketplace install would boot.\n"

--- a/tests/hooks/git-push-guard.test.sh
+++ b/tests/hooks/git-push-guard.test.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Tests for scripts/hooks/git-push-guard.sh
+#
+# Hook contract: block `git push` when commits in the push range are
+# attached to closed tasks (via tasks.commit_sha) that lack a passing
+# pr-reviewer verdict (validation_attempts.verdict='pass').
+#
+# Skips: --force pushes (delegated to git-guards), no upstream (first push),
+# commits with no matching task row (pre-TMB / untracked work), missing DB,
+# missing sqlite3.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../lib/assert.sh"
+PLUGIN_ROOT="$(cd "$HERE/../.." && pwd)"
+HOOK="$PLUGIN_ROOT/scripts/hooks/git-push-guard.sh"
+
+# ----- helpers ----------------------------------------------------------
+
+# Create a fresh temp git repo with a bare upstream + N committed files.
+# Returns the repo path. Sets globals SHA1, SHA2 to the last two commit SHAs.
+setup_repo() {
+  local dir
+  dir=$(mktemp -d -t tmb-push-guard-XXXX)
+  (
+    cd "$dir" || exit 1
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name  "Test"
+    # bare upstream so @{u} resolves
+    git init --bare -q upstream.git
+    git remote add origin "$dir/upstream.git"
+
+    # commit 0 (initial; pushed with upstream tracking so @{u} resolves)
+    echo "init" > README.md
+    git add README.md
+    git commit -qm "init"
+    git push -qu origin main
+
+    # commit 1 (ahead of upstream)
+    echo "feat A" > a.txt
+    git add a.txt
+    git commit -qm "feat: A"
+
+    # commit 2 (ahead of upstream)
+    echo "feat B" > b.txt
+    git add b.txt
+    git commit -qm "feat: B"
+
+    git rev-parse HEAD~ > .last1
+    git rev-parse HEAD  > .last2
+  )
+  REPO_PATH="$dir"
+  SHA1=$(cat "$dir/.last1")
+  SHA2=$(cat "$dir/.last2")
+}
+
+# Apply the schema to a fresh trajectory.db inside the repo.
+# Redirect sqlite3 stdout to /dev/null because the WAL journal_mode pragma
+# echoes 'wal', which would otherwise pollute the function's return value.
+setup_db() {
+  local repo="$1"
+  local db="$repo/.claude/tmb/trajectory.db"
+  mkdir -p "$(dirname "$db")"
+  sqlite3 "$db" < "$PLUGIN_ROOT/mcp/trajectory-server/src/schema.sql" >/dev/null
+  echo "$db"
+}
+
+# Insert an issue + a task whose commit_sha matches given sha.
+# task is in 'closed' status (i.e. bro signed off, push gate is the next gate).
+# branch_id is per-task to satisfy the UNIQUE(issue_id, branch_id) index.
+insert_task() {
+  local db="$1" task_id="$2" sha="$3"
+  sqlite3 "$db" "
+    INSERT OR IGNORE INTO issues (id, objective, description, status, created_at, updated_at)
+      VALUES (1, 'test', 'test', 'open', datetime('now'), datetime('now'));
+    INSERT INTO tasks (id, issue_id, branch_id, title, description, success_criteria, status, spec_body, commit_sha, created_at, updated_at)
+      VALUES ($task_id, 1, 'feat/x-$task_id', 'task $task_id', 'd', 'sc', 'closed', '## body', '$sha', datetime('now'), datetime('now'));
+  " >/dev/null
+}
+
+# Insert a passing validation row for a task (i.e. pr-reviewer signed off).
+sign_task() {
+  local db="$1" task_id="$2"
+  sqlite3 "$db" "
+    INSERT INTO validation_attempts (task_id, attempt_n, agent, verdict, feedback, created_at)
+      VALUES ($task_id, 1, 'pr-reviewer', 'pass', 'LGTM', datetime('now'));
+  " >/dev/null
+}
+
+# Run the hook from inside REPO_PATH with a given Bash command in tool_input.
+run_hook() {
+  local cmd="$1"
+  local db="${2:-/nonexistent.db}"
+  local payload
+  payload=$(jq -cn --arg c "$cmd" '{tool_input:{command:$c}}')
+  (cd "$REPO_PATH" && echo "$payload" | TRAJECTORY_DB_PATH="$db" bash "$HOOK" 2>&1 || true)
+}
+
+# Cleanup
+cleanup() {
+  [ -n "${REPO_PATH:-}" ] && [ -d "${REPO_PATH:-}" ] && rm -rf "$REPO_PATH"
+  REPO_PATH=""
+}
+
+# ----- tests ------------------------------------------------------------
+
+test_case "non-push command passes through silently"
+setup_repo
+out=$(run_hook "git status")
+assert_not_contains "$out" '"decision":"block"' "git status should not be gated"
+cleanup
+
+test_case "git push --force is delegated to git-guards (this hook allows)"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"  # unsigned task — would block normally
+out=$(run_hook "git push --force origin main" "$db")
+assert_not_contains "$out" '"decision":"block"' "force push should be deferred to git-guards"
+cleanup
+
+test_case "git push -f is delegated to git-guards (this hook allows)"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"
+out=$(run_hook "git push -f origin main" "$db")
+assert_not_contains "$out" '"decision":"block"' "force push (-f) should be deferred"
+cleanup
+
+test_case "no DB: TMB not tracking, push allowed"
+setup_repo
+out=$(run_hook "git push origin main" "/nonexistent.db")
+assert_not_contains "$out" '"decision":"block"' "missing DB should not block"
+cleanup
+
+test_case "no upstream new commits: nothing to gate, allowed"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+# Reset HEAD to upstream so @{u}..HEAD is empty
+(cd "$REPO_PATH" && git reset -q --hard origin/main)
+out=$(run_hook "git push origin main" "$db")
+assert_not_contains "$out" '"decision":"block"' "no new commits should not block"
+cleanup
+
+test_case "push with untracked commits (no matching task row): allowed"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+# DB exists but no task row references SHA1 / SHA2 — these commits are pre-TMB
+out=$(run_hook "git push origin main" "$db")
+assert_not_contains "$out" '"decision":"block"' "untracked commits should not block"
+cleanup
+
+test_case "push with all-signed tracked commits: allowed"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"
+sign_task   "$db" 1
+insert_task "$db" 2 "$SHA2"
+sign_task   "$db" 2
+out=$(run_hook "git push origin main" "$db")
+assert_not_contains "$out" '"decision":"block"' "all-signed should not block"
+cleanup
+
+test_case "push with one unsigned tracked commit: BLOCKED with helpful reason"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"
+sign_task   "$db" 1
+insert_task "$db" 2 "$SHA2"
+# task 2 NOT signed
+out=$(run_hook "git push origin main" "$db")
+assert_contains "$out" '"decision":"block"' "unsigned commit must block"
+assert_contains "$out" "review before push"   "block message must mention bro review path"
+assert_contains "$out" "task_id=2"            "block message must list the unsigned task"
+cleanup
+
+test_case "push with multiple unsigned tracked commits: BLOCKED, all listed"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"
+insert_task "$db" 2 "$SHA2"
+# neither signed
+out=$(run_hook "git push origin main" "$db")
+assert_contains "$out" '"decision":"block"' "unsigned commits must block"
+assert_contains "$out" "task_id=1"           "should list task 1"
+assert_contains "$out" "task_id=2"           "should list task 2"
+cleanup
+
+test_case "push with mixed-signed (one signed, one not) commits: BLOCKED"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"
+sign_task   "$db" 1
+insert_task "$db" 2 "$SHA2"
+out=$(run_hook "git push origin main" "$db")
+assert_contains "$out" '"decision":"block"'  "mixed should block on unsigned"
+assert_contains "$out" "task_id=2"           "should list ONLY the unsigned task 2"
+assert_not_contains "$out" "task_id=1 "      "signed task 1 should not appear in block list"
+cleanup
+
+summarize

--- a/tests/lint/changelog-current.sh
+++ b/tests/lint/changelog-current.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Lint: top CHANGELOG.md section's version must match plugin.json.
+#
+# Catches: release-prep PRs that bump plugin.json but forget to add the
+# matching `## v<X.Y.Z>` section, OR forget to bump plugin.json after
+# adding a new section.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+CANON=$(jq -r '.version' .claude-plugin/plugin.json)
+EXPECTED_HEADER="## v${CANON}"
+
+# First `## vX.Y.Z` line in CHANGELOG (top of file)
+TOP_HEADER=$(grep -m 1 -E '^## v[0-9]' CHANGELOG.md || true)
+
+if [ -z "$TOP_HEADER" ]; then
+  echo "✗ CHANGELOG.md has no '## v<X.Y.Z>' section at all" >&2
+  exit 1
+fi
+
+# Extract just the "## vX.Y.Z" prefix (drops " — YYYY-MM-DD ..." trailer)
+TOP_VERSION=$(echo "$TOP_HEADER" | awk '{print $1, $2}')
+
+if [ "$TOP_VERSION" != "$EXPECTED_HEADER" ]; then
+  echo "✗ CHANGELOG.md top section is '$TOP_HEADER'" >&2
+  echo "  but plugin.json version is $CANON" >&2
+  echo "  Expected top section to begin with: $EXPECTED_HEADER" >&2
+  echo "" >&2
+  echo "  Either bump plugin.json to match the top CHANGELOG section," >&2
+  echo "  or add a new '$EXPECTED_HEADER — YYYY-MM-DD' entry to CHANGELOG." >&2
+  exit 1
+fi
+
+echo "  ✓ CHANGELOG top section matches plugin.json version: $CANON"
+echo ""
+echo "Changelog-current: PASS"

--- a/tests/lint/link-check.sh
+++ b/tests/lint/link-check.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Lint: every relative markdown link `[text](path)` in tracked .md files
+# must resolve to an existing file or directory.
+#
+# Catches: links to deleted files (e.g. docs/PERFORMANCE.md after we
+# retired it), typos in path names, broken section refs to moved docs.
+#
+# What it does NOT check:
+#   - http(s) URLs (we don't network in lint)
+#   - mailto: / data: schemes
+#   - Anchor-only refs (#section) — those don't have a file to verify
+#   - Anchors on intra-doc links (foo.md#section) — we just verify foo.md exists
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+# Collect every .md file we own (skip vendored/installed dirs)
+MD_FILES=$(find . -type f -name '*.md' \
+  -not -path './node_modules/*' \
+  -not -path './*/node_modules/*' \
+  -not -path './*/*/node_modules/*' \
+  -not -path './.git/*' \
+  -not -path './*/dist/*' \
+  | sort)
+
+BROKEN=0
+TOTAL=0
+
+while IFS= read -r mdfile; do
+  # Strip inline code spans (`...`) and fenced code blocks (```...```) before
+  # scanning for links — a literal `[text](path)` inside backticks is example
+  # text, not a real link, and shouldn't be path-checked.
+  STRIPPED=$(awk '
+    /^```/ { in_fence = !in_fence; next }
+    in_fence { next }
+    { gsub(/`[^`]*`/, ""); print }
+  ' "$mdfile")
+  # Extract every (link) — strip out images ![...](...) since they're equivalent here
+  LINKS=$(echo "$STRIPPED" \
+    | grep -oE '\]\([^)]+\)' \
+    | sed -E 's/^\]\(([^)]+)\)/\1/' \
+    || true)
+  while IFS= read -r link; do
+    [ -z "$link" ] && continue
+    # Skip URLs and special schemes
+    case "$link" in
+      http://*|https://*|mailto:*|data:*|tel:*) continue ;;
+      \#*) continue ;;  # anchor-only, no path to verify
+    esac
+    # Strip anchor fragment + query string for filesystem resolution
+    target="${link%%#*}"
+    target="${target%%\?*}"
+    [ -z "$target" ] && continue
+
+    TOTAL=$((TOTAL + 1))
+
+    # Resolve relative to the .md file's directory
+    mddir="$(dirname "$mdfile")"
+    resolved="$mddir/$target"
+
+    # Use realpath if available, else fall back to plain check
+    if command -v realpath >/dev/null 2>&1; then
+      resolved=$(realpath -m "$resolved" 2>/dev/null || echo "$resolved")
+    fi
+
+    if [ ! -e "$resolved" ]; then
+      printf "  ✗ %s → %s (resolved: %s) [missing]\n" "$mdfile" "$link" "$resolved" >&2
+      BROKEN=$((BROKEN + 1))
+    fi
+  done <<< "$LINKS"
+done <<< "$MD_FILES"
+
+echo ""
+if [ $BROKEN -gt 0 ]; then
+  printf "Link-check: FAIL (%d broken / %d total)\n" "$BROKEN" "$TOTAL" >&2
+  exit 1
+fi
+printf "Link-check: PASS (%d links resolve)\n" "$TOTAL"

--- a/tests/lint/manifest-shape.sh
+++ b/tests/lint/manifest-shape.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Lint: validate the shape of the plugin's three manifest files.
+#
+# Catches: typos, missing required fields, structural drift on any of:
+#   .claude-plugin/plugin.json
+#   .mcp.json
+#   hooks/hooks.json
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+failed=0
+fail() { echo "  ✗ $1" >&2; failed=1; }
+pass() { echo "  ✓ $1"; }
+
+# --- .claude-plugin/plugin.json -------------------------------------------
+
+PLUGIN_MANIFEST=.claude-plugin/plugin.json
+echo "Validating $PLUGIN_MANIFEST"
+
+if ! jq -e . "$PLUGIN_MANIFEST" >/dev/null 2>&1; then
+  fail "$PLUGIN_MANIFEST is not valid JSON"
+else
+  for field in name version description author license repository; do
+    val=$(jq -r --arg f "$field" '.[$f] // empty' "$PLUGIN_MANIFEST")
+    if [ -z "$val" ]; then
+      fail "$PLUGIN_MANIFEST missing required field: $field"
+    fi
+  done
+  # version must be semver-like
+  ver=$(jq -r '.version' "$PLUGIN_MANIFEST")
+  if ! [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    fail "$PLUGIN_MANIFEST .version '$ver' is not a valid semver (X.Y.Z)"
+  fi
+  pass "$PLUGIN_MANIFEST has all required fields and a valid semver"
+fi
+
+# --- .mcp.json -----------------------------------------------------------
+
+MCP_MANIFEST=.mcp.json
+echo ""
+echo "Validating $MCP_MANIFEST"
+
+if ! jq -e . "$MCP_MANIFEST" >/dev/null 2>&1; then
+  fail "$MCP_MANIFEST is not valid JSON"
+else
+  if ! jq -e '.mcpServers' "$MCP_MANIFEST" >/dev/null 2>&1; then
+    fail "$MCP_MANIFEST missing .mcpServers"
+  else
+    server_count=$(jq -r '.mcpServers | length' "$MCP_MANIFEST")
+    if [ "$server_count" -lt 1 ]; then
+      fail "$MCP_MANIFEST .mcpServers is empty"
+    fi
+    # Every server must have command + args
+    while IFS= read -r server; do
+      cmd=$(jq -r --arg s "$server" '.mcpServers[$s].command // empty' "$MCP_MANIFEST")
+      args=$(jq -r --arg s "$server" '.mcpServers[$s].args // empty' "$MCP_MANIFEST")
+      if [ -z "$cmd" ]; then
+        fail "$MCP_MANIFEST .mcpServers.$server.command is missing"
+      fi
+      if [ "$args" = "empty" ] || [ -z "$args" ]; then
+        fail "$MCP_MANIFEST .mcpServers.$server.args is missing"
+      fi
+    done < <(jq -r '.mcpServers | keys[]' "$MCP_MANIFEST")
+    pass "$MCP_MANIFEST has $server_count MCP server(s), all with command + args"
+  fi
+fi
+
+# --- hooks/hooks.json ----------------------------------------------------
+
+HOOKS_MANIFEST=hooks/hooks.json
+echo ""
+echo "Validating $HOOKS_MANIFEST"
+
+if [ ! -f "$HOOKS_MANIFEST" ]; then
+  fail "$HOOKS_MANIFEST does not exist"
+elif ! jq -e . "$HOOKS_MANIFEST" >/dev/null 2>&1; then
+  fail "$HOOKS_MANIFEST is not valid JSON"
+else
+  if ! jq -e '.hooks' "$HOOKS_MANIFEST" >/dev/null 2>&1; then
+    fail "$HOOKS_MANIFEST missing .hooks"
+  else
+    # Walk every hook and verify referenced script paths exist
+    missing=0
+    while IFS= read -r script; do
+      # Strip ${CLAUDE_PLUGIN_ROOT} prefix for local resolution
+      local_path="${script//\$\{CLAUDE_PLUGIN_ROOT\}/.}"
+      local_path="${local_path//\$CLAUDE_PLUGIN_ROOT/.}"
+      if [ ! -f "$local_path" ]; then
+        fail "$HOOKS_MANIFEST references missing script: $script (resolved: $local_path)"
+        missing=1
+      fi
+    done < <(jq -r '.. | objects | .command? // empty | select(. | type == "string")' "$HOOKS_MANIFEST")
+    if [ $missing -eq 0 ]; then
+      pass "$HOOKS_MANIFEST is valid + all referenced scripts exist"
+    fi
+  fi
+fi
+
+echo ""
+if [ $failed -ne 0 ]; then
+  echo "Manifest shape: FAIL" >&2
+  exit 1
+fi
+echo "Manifest shape: PASS"

--- a/tests/lint/release-script-safety.sh
+++ b/tests/lint/release-script-safety.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Lint: structural safety checks on scripts/release.sh.
+#
+# Protects against the "force-push a published tag" antipattern: the
+# release script must contain the explicit "Refusing to re-tag a PUBLISHED
+# release" guard. This test catches accidental removal of that guard
+# during refactors.
+#
+# This is a lint, not a behavior test, because driving release.sh
+# end-to-end requires a real repo + real remote. The behavior is small
+# enough that grep'ing for the guard text + the underlying mechanism
+# (`git ls-remote --tags origin`) is sufficient evidence.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/release.sh"
+
+failed=0
+fail() { echo "  ✗ $1" >&2; failed=1; }
+pass() { echo "  ✓ $1"; }
+
+if [ ! -f "$SCRIPT" ]; then
+  fail "scripts/release.sh missing"
+  echo "Release-script-safety: FAIL" >&2
+  exit 1
+fi
+
+# G1: must check the remote before considering retag
+if grep -q 'git ls-remote --tags origin "refs/tags/\$NEW_TAG"' "$SCRIPT"; then
+  pass "checks remote for the tag before allowing any retag"
+else
+  fail "missing remote-tag check (git ls-remote --tags origin refs/tags/\$NEW_TAG)"
+fi
+
+# G2: must contain the explicit refusal message
+if grep -q 'Refusing to re-tag a PUBLISHED release' "$SCRIPT"; then
+  pass "contains explicit refusal message for published-tag retag"
+else
+  fail "missing 'Refusing to re-tag a PUBLISHED release' guard"
+fi
+
+# G3: must exit non-zero on the published-retag path (so it actually blocks).
+# Look for `exit 1` (any indentation) within ~30 lines after the refusal message.
+if awk '
+  /Refusing to re-tag a PUBLISHED release/ { found=1; line=NR }
+  found && /^[[:space:]]*exit 1[[:space:]]*$/ && NR-line<=30 { print "ok"; exit }
+' "$SCRIPT" | grep -q ok; then
+  pass "exits non-zero on published-retag refusal path"
+else
+  fail "no 'exit 1' within 30 lines of the refusal message — guard would be advisory only"
+fi
+
+# G4: must mention the doctrinal alternative (bump version, ship new tag)
+if grep -q "ship a NEW version with the fix" "$SCRIPT"; then
+  pass "documents the doctrinal alternative (bump version)"
+else
+  fail "missing doctrinal alternative — refusal should explain what to do instead"
+fi
+
+# G5: must NOT push to origin a deleted tag in the local-only retag path
+# (an earlier version did `git push origin :refs/tags/$NEW_TAG` even for
+# local-only tags, which would silently delete the remote tag if it existed)
+if awk '/Local-only/{found=1} found && /git push.*:refs\/tags/ {print "BAD"; exit}' "$SCRIPT" | grep -q BAD; then
+  fail "local-only retag path still tries to push tag deletion to origin (would corrupt remote)"
+else
+  pass "local-only retag path doesn't push tag deletion to origin"
+fi
+
+echo ""
+if [ $failed -ne 0 ]; then
+  echo "Release-script-safety: FAIL" >&2
+  exit 1
+fi
+echo "Release-script-safety: PASS"

--- a/tests/lint/shellcheck-hooks.sh
+++ b/tests/lint/shellcheck-hooks.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Lint: shellcheck every shell script in scripts/ and tests/.
+#
+# Catches: the `set -o pipefail` silent-allow class (we hit it in v0.1.0
+# with grep returning non-zero making the script exit silently). Catches
+# unquoted variables, command-substitution races, etc.
+#
+# If shellcheck is not installed, this lint is SKIPPED with a warning.
+# CI installs shellcheck (apt-get install shellcheck).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "  ⊘ shellcheck not installed — skipping (install via 'brew install shellcheck' or 'apt-get install shellcheck')"
+  echo "Shellcheck-hooks: SKIPPED"
+  exit 0
+fi
+
+failed=0
+
+# Scripts we own that should be shellcheck-clean
+SHELL_FILES=$(find scripts tests -type f -name '*.sh' \
+  -not -path './node_modules/*' \
+  -not -path './*/node_modules/*' \
+  | sort)
+
+for script in $SHELL_FILES; do
+  if shellcheck -S warning -e SC1091 "$script"; then
+    printf "  ✓ %s\n" "$script"
+  else
+    printf "  ✗ %s\n" "$script" >&2
+    failed=1
+  fi
+done
+
+echo ""
+if [ $failed -ne 0 ]; then
+  echo "Shellcheck-hooks: FAIL" >&2
+  exit 1
+fi
+echo "Shellcheck-hooks: PASS"

--- a/tests/lint/skill-frontmatter.sh
+++ b/tests/lint/skill-frontmatter.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Lint: every SKILL.md (in skills/ and templates/skills/) must have a
+# valid frontmatter block with `name` and `description` fields, and the
+# `name` field must equal the parent directory name.
+#
+# Catches: typos in skill metadata, broken skill registration, mismatch
+# between dir name (what CC discovers) and frontmatter name (what the
+# skill identifies as).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+failed=0
+
+# Find every SKILL.md under both plugin-shipped + template-shipped trees
+for skill in $(find skills templates/skills -type f -name 'SKILL.md' 2>/dev/null | sort); do
+  dir=$(dirname "$skill")
+  dirname_base=$(basename "$dir")
+
+  # Check frontmatter delimiters
+  first_line=$(head -1 "$skill")
+  if [ "$first_line" != "---" ]; then
+    printf "  ✗ %s: missing opening '---' (no frontmatter)\n" "$skill" >&2
+    failed=1
+    continue
+  fi
+
+  # Extract frontmatter block (between first two --- lines)
+  fm=$(awk '/^---$/{c++; next} c==1' "$skill" | head -50)
+
+  # Required fields
+  if ! echo "$fm" | grep -qE '^name:[[:space:]]+'; then
+    printf "  ✗ %s: missing 'name:' field in frontmatter\n" "$skill" >&2
+    failed=1
+    continue
+  fi
+  if ! echo "$fm" | grep -qE '^description:[[:space:]]+'; then
+    printf "  ✗ %s: missing 'description:' field in frontmatter\n" "$skill" >&2
+    failed=1
+    continue
+  fi
+
+  # name field must match dirname (without quotes)
+  name=$(echo "$fm" | grep -E '^name:[[:space:]]+' | head -1 | sed -E 's/^name:[[:space:]]+//' | tr -d '"' | xargs)
+  if [ "$name" != "$dirname_base" ]; then
+    printf "  ✗ %s: name '%s' != dirname '%s' (CC discovers by dir, body identifies by name)\n" \
+      "$skill" "$name" "$dirname_base" >&2
+    failed=1
+    continue
+  fi
+
+  printf "  ✓ %s\n" "$skill"
+done
+
+echo ""
+if [ $failed -ne 0 ]; then
+  echo "Skill-frontmatter: FAIL" >&2
+  exit 1
+fi
+echo "Skill-frontmatter: PASS"

--- a/tests/lint/tsc-noemit.sh
+++ b/tests/lint/tsc-noemit.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Lint: TypeScript type-check the MCP server source without emitting JS.
+#
+# Build (`bun run build`) does emit, so type errors there look the same
+# as a clean compile if you don't read the log. This isolates the type
+# check as its own fast assertion — fails the lint suite immediately
+# instead of relying on someone noticing tsc warnings during build.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT/mcp/trajectory-server"
+
+# Prefer the locally-installed TS in node_modules (deterministic, what
+# the build also uses). Fall back to PATH-tsc if for some reason node_modules
+# isn't populated.
+if [ -x ./node_modules/.bin/tsc ]; then
+  TSC="./node_modules/.bin/tsc"
+elif command -v tsc >/dev/null 2>&1; then
+  TSC="tsc"
+else
+  echo "  ⊘ tsc not found locally or on PATH — run 'bun install' first" >&2
+  echo "Tsc-noemit: SKIPPED"
+  exit 0
+fi
+
+if $TSC --noEmit; then
+  echo "  ✓ MCP server type-checks clean"
+  echo ""
+  echo "Tsc-noemit: PASS"
+else
+  echo "" >&2
+  echo "Tsc-noemit: FAIL — fix type errors above" >&2
+  exit 1
+fi

--- a/tests/lint/version-sync.sh
+++ b/tests/lint/version-sync.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Lint: enforce that the four version fields agree.
+#
+#   .claude-plugin/plugin.json  → the canonical published version
+#   mcp/trajectory-server/package.json → the MCP subpackage version
+#   package.json (root workspace)      → the workspace root version
+#
+# All three MUST equal each other on every commit. monitors/package.json
+# is allowed to diverge (it has its own ABI; no MCP-server coupling).
+#
+# Catches: stale workspace-root version (we shipped 0.3.2 through v0.1.2),
+# release-prep PRs that bump only one of the three.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+CANON=$(jq -r '.version' .claude-plugin/plugin.json)
+MCP=$(jq -r '.version'   mcp/trajectory-server/package.json)
+WSROOT=$(jq -r '.version' package.json)
+
+failed=0
+check() {
+  local name="$1" actual="$2"
+  if [ "$actual" = "$CANON" ]; then
+    printf "  ✓ %-40s %s\n" "$name" "$actual"
+  else
+    printf "  ✗ %-40s %s  (expected %s)\n" "$name" "$actual" "$CANON" >&2
+    failed=1
+  fi
+}
+
+echo "Enforcing version sync (canonical: .claude-plugin/plugin.json = $CANON)"
+check ".claude-plugin/plugin.json"            "$CANON"
+check "mcp/trajectory-server/package.json"    "$MCP"
+check "package.json (workspace root)"         "$WSROOT"
+
+if [ $failed -ne 0 ]; then
+  echo "" >&2
+  echo "Version sync FAILED. Bump all three to match in the same commit." >&2
+  exit 1
+fi
+
+echo ""
+echo "Version sync: PASS"

--- a/tests/manual/scenarios.md
+++ b/tests/manual/scenarios.md
@@ -1,787 +1,181 @@
-# Dogfood Test Scenarios
+# Layer 5 — Manual Dogfood Checklist
 
-> **Active rewrite — bro-as-planner chain (tracked in [#51](https://github.com/trustmybot/plugin/issues/51)).**
-> As of v0.1.2 the decision chain is `Human → bro → SWE` with two gates:
-> bro is the **task gate** (verifies after SWE returns), pr-reviewer is
-> the **push gate** (fires only at `git push`). Scenarios that still
-> describe the legacy `bro → architect → swe` chain (Flow 2.1/2.2/2.3,
-> 3, 8 and parts of 9) are STALE until rewritten — they will fail in
-> unhelpful ways if you walk them as written.
+> **What this is:** a tight, ~10-item checklist of the things **only a human walking through Claude Code can verify**. The previous 785-line version of this file tried to enumerate every workflow path; that's now covered structurally by L0–L4 (Docker install-smoke, lint, MCP unit + integration, workflow-simulation trajectory tests). What remains here is the residue — Claude-side behaviors that have no automated test surface.
 >
-> **Layer-3 dogfood targets that ARE current** in the bro-as-planner chain:
-> - **Flow 1 (onboarding)** — unchanged, still valid.
-> - **Flow 2 (simple task)** — use scenario `2.1.bro` below as the canonical end-to-end smoke test.
-> - **Flow 6 (push gate)** — pr-reviewer fires once per push over the batch of unsigned commits, not per task.
-> - **Flow 7 (architecture regen)** — still valid; bro is the only caller.
-> - **Flow C (consultant invocation)** — scenario `C.1` below.
-> - **Flow D (Direct Mode)** — trivial single-file fix should land in ≤30s without a SWE spawn.
->
-> The full template-rewrite of every scenario is tracked in [#51](https://github.com/trustmybot/plugin/issues/51).
-
-For each workflow in [`FLOWS.md`](../../docs/architecture/FLOWS.md), the verbatim user prompt that triggers it + the observable expected behavior + how to verify it landed correctly.
-
-These are the **manual test cases** for the plugin. Run during a fresh `claude --plugin-dir <PLUGIN_PATH>` session against a disposable scratch project (see [`setup.md`](./setup.md) for setup).
-
-## How to use this doc
-
-For each scenario:
-
-1. Set up the **prerequisites**.
-2. Type the **trigger prompt** verbatim into Claude Code.
-3. Watch the **expected agent chain** resolve in order.
-4. Cross-check the **expected MCP tool calls** against `/mcp` or the session log.
-5. Confirm **expected hooks** fired (or didn't).
-6. Run the **verification SQL/shell** to confirm DB + filesystem state.
-7. Tick ✓ on the checkbox, or file an issue quoting the scenario ID and what deviated.
-
-Reset between scenarios with `rm -rf .claude/tmb/` in the scratch project.
-
-## Scenario format — comprehensive template
-
-Every scenario below should have all eight sections. Flow 1 is rewritten to this template as the reference example; flows 2–9 are being brought up to it (tracked in [issue #51](https://github.com/trustmybot/plugin/issues/51)).
-
-Template:
-
-```
-### X.Y — short title
-
-Prerequisites: <exact setup state>
-
-Trigger prompt: <verbatim user input>
-
-Expected agent chain (in spawn order):
-  | # | Agent | Model | Via | Purpose |
-
-Expected MCP tool calls (in order):
-  | # | Caller | Tool | Key args | Purpose |
-
-Expected hooks fired:
-  - PreToolUse matcher → which script → expected verdict (allow / deny / defer)
-
-Expected user-visible output (key markers):
-  - Verbatim or fuzzy-match strings the Human should see
-
-Expected DB state after:
-  | Table | Rows / values |
-
-Verification (bash/sqlite):
-  <command>
-
-Common failure modes:
-  - What might go wrong and what it means
-
-Pass: [ ]
-```
-
-## Index by trigger style
-
-| Trigger style | Scenarios |
-|---|---|
-| Implicit (any first prompt) — fires on null DB state | 1.1, 1.2, 1.3 |
-| Code change implementation | 2.1–2.3, 3.1–3.3 |
-| Explicit magic word ("re-onboard", "refresh architecture", "roundtable") | 1.4, 7.1, 9.1, 9.2 |
-| On-demand domain agent ("I need an X agent") | 4.1–4.4 |
-| Implicit cross-domain question (architect detects → invokes roundtable) | 9.3, 9.4 |
-| Auto-fired (no user prompt) | 5.1, 6.1, 7.2–7.4, 8.1–8.2 |
-| Status / read-only | (no agent spawn — silent) |
-
-## Index by flow
-
-| Flow | FLOWS.md § | Scenarios |
-|---|---|---|
-| 1 — First-Run Onboarding | [§1](../../docs/architecture/FLOWS.md#1-first-run-onboarding) | 1.1, 1.2, 1.3, 1.4 |
-| 2 — Simple Task | [§2](../../docs/architecture/FLOWS.md#2-simple-task) | 2.1, 2.2, 2.3 |
-| 3 — Difficult Task | [§3](../../docs/architecture/FLOWS.md#3-difficult-task) | 3.1, 3.2, 3.3 |
-| 4 — Agent-creator | [§4](../../docs/architecture/FLOWS.md#4-agent-creator-on-demand-domain-agent) | 4.1, 4.2, 4.3, 4.4 |
-| 5 — Skill Creation | [§5](../../docs/architecture/FLOWS.md#5-skill-creation) | 5.1 |
-| 6 — PR Review | [§6](../../docs/architecture/FLOWS.md#6-pr-review) | 6.1 |
-| 7 — Architecture Regen | [§7](../../docs/architecture/FLOWS.md#7-architecture-regen) | 7.1, 7.2, 7.3, 7.4 |
-| 8 — SWE Retry / Escalation | [§8](../../docs/architecture/FLOWS.md#8-swe-retry--escalation) | 8.1, 8.2 |
-| 9 — Roundtable | [§9](../../docs/architecture/FLOWS.md#9-roundtable-multi-agent-deliberation) | 9.1, 9.2, 9.3, 9.4 |
+> **When you must run this:** before tagging any release `v0.2.0` or higher. The release script (`scripts/release.sh`) blocks tagging until you set `MANUAL_DOGFOOD_PASSED=v<X.Y.Z>` in your environment, signed off after walking the checklist below.
 
 ---
 
-## Flow 1 — First-Run Onboarding
-
-### 1.1 — Fresh DB, any first prompt triggers onboarding
-
-**Prerequisites:** `rm -rf .claude/tmb/` in the scratch project (no DB yet). Fresh `claude --plugin-dir "$PLUGIN_PATH"` session launched.
-
-**Trigger prompt:**
-> `bro hello` (the trigger word "bro" activates the persona; main Claude enters bro mode and runs onboarding)
-
-**Expected agent chain (in spawn order):**
-
-| # | Agent | Model | Via | Purpose |
-|---|---|---|---|---|
-| 1 | `tmb:bro` | opus | user @-mention | Session-start check; enters Onboarding Mode because identity + branching are both null |
-
-No other agents spawn during onboarding. `first-run-onboarding` is a skill bro loads inline, not a subagent.
-
-**Expected MCP tool calls (in order):**
-
-| # | Caller | Tool | Key args | Purpose |
-|---|---|---|---|---|
-| 1 | bro | `identity_get` | `agent='bro'` | Session-start identity check |
-| 2 | bro | `config_get` | `agent='bro', key='branching_model'` | Session-start config check — returns null → enter Onboarding Mode |
-| 3 | bro | `AskUserQuestion` | 3-question batch (name, branching, PR target) | Collect all answers in one radio form |
-| 4 | bro | `identity_set` | `agent='bro', human_name=<answer>` | Persist name (skip if Anonymous) |
-| 5 | bro | `config_set` | `agent='bro', key='branching_model', value=<canonical>` | Persist branching model |
-| 6 | bro | `config_set` | `agent='bro', key='pr_target', value=<answer>` | Persist PR target |
-| 7 | bro | `config_set` | `agent='bro', key='protected_branches', value=[<list>]` | Persist protected-branches list |
-| 8 | bro | `config_list` | `agent='bro'` | Post-write verify — retry any missing key before closing |
-
-**Expected hooks fired:** none during onboarding. Hooks only fire for Bash / Agent / WorktreeCreate events, and onboarding stays inside AskUserQuestion + MCP writes.
-
-**Expected user-visible output (key markers):**
-
-- Opens with the catchphrase: *"Hey, I'm bro. Trust me bro, it works — that's the plugin's whole pitch."*
-- A single `AskUserQuestion` radio form with three questions:
-  1. **Your name** — options: `Anonymous`, plus auto-`Other` for free text. (If the Human mentioned their name inline earlier, a `Use "<name>"` option is pre-populated.)
-  2. **Branching** — options: *"Trunk + feature branches (GitHub Flow) (Recommended)"* / *"Trunk + develop + releases (Git Flow)"* / *"Custom workflow"*.
-  3. **PR target** — options: `main (Recommended)` / `master` / `develop` / `trunk`, plus auto-`Other`.
-- For Custom workflow only: a second `AskUserQuestion` call with `multiSelect: true` for protected branches.
-- Per-write inline confirmations: *"✓ branching_model saved"*, etc.
-- Closes with: *"Done. Identity and branching model saved. Tell me what you want to work on — trust me bro, it works."*
-
-**Expected DB state after (choosing name=Zax, branching=GitHub Flow, PR target=main):**
-
-| Table | Rows / values |
-|---|---|
-| `identity` | `id=1, human_name='Zax', created_at=<ISO>, updated_at=<ISO>` |
-| `plugin_config` | Three rows: `branching_model='"github-flow"'`, `pr_target='"main"'`, `protected_branches='["main"]'` (stored as JSON text) |
-
-**Verification:**
+## Setup
 
 ```bash
-sqlite3 .claude/tmb/trajectory.db <<'SQL'
-  SELECT * FROM identity;
-  SELECT key, value_json FROM plugin_config WHERE key IN ('branching_model','pr_target','protected_branches') ORDER BY key;
-SQL
+# Fresh scratch project so no stale .claude/ contaminates the test
+mkdir -p /tmp/tmb-dogfood && cd /tmp/tmb-dogfood
+git init -q && git config user.email t@t.t && git config user.name T
+echo "init" > README.md && git add . && git commit -qm init
+
+# Run Claude Code with the plugin under test loaded
+claude --plugin-dir "$HOME/Git/GitHub/TMB/plugin"
 ```
 
-**Common failure modes:**
-
-- **Zero rows** → the MCP server isn't connected. Verify `/mcp` inside the session lists `plugin:tmb:trajectory-server: ✔ connected`. If missing, check `.mcp.json` and rebuild with `bun run build`.
-- **Bro asks text-based questions (`Reply with 1/2/3`) instead of rendering a radio form** → `AskUserQuestion` not actually being invoked. Check bro's `tools:` allowlist includes `AskUserQuestion` and that the skill's prompt explicitly calls it. Pull latest; revert confirmed fixed.
-- **Bro narrates "the write was denied" but zero rows appear in `plugin_config`** → bro hallucinated a rejection instead of calling `config_set`. Prompt-drift; the latest skill enforces a mandatory post-write verify via `config_list` that should surface this.
-- **`caller_role: 'unknown'` errors in the session log** → prompt is missing the `agent='bro'` param on MCP calls. Bug in the agent prompt or a tool that doesn't declare `agent` in its inputSchema.
-- **Bro closes onboarding with missing MCP writes** → post-write `config_list` verify was skipped. Prompt discipline regression.
-
-**Pass:** [ ]
+Reset between scenarios: `rm -rf /tmp/tmb-dogfood && <re-run setup>`.
 
 ---
 
-### 1.2 — Code-touching ask DURING onboarding is held
+## The checklist
 
-**Prerequisites:** Reset DB. Type the welcome trigger, let bro open the `AskUserQuestion` form. Before submitting answers, open a second chat turn.
+### ① Trigger word activation
 
-**Trigger prompt** (mid-onboarding, without finishing the form):
-> `add a hello-world endpoint to the api`
+**Type:** `hey` (no "bro")
+**Expected:** regular Claude Code response, no plugin involvement, no MCP call.
 
-**Expected agent chain:**
+**Type:** `@bro hello`
+**Expected:** Claude announces "Entering bro mode" before doing anything else. Onboarding kicks off (3 questions: name, branching model, PR target).
 
-| # | Agent | Model | Via | Purpose |
-|---|---|---|---|---|
-| 1 | `tmb:bro` | opus | active session | Recognizes code-touching ask; defers routing |
+✅ Pass criteria: trigger detection + onboarding launches **only** on `@bro`.
 
-**Expected MCP tool calls:** none for the held request. Bro's `first-run-onboarding` skill runs the hold-and-resume branch — no `issue_create`, no `task_create_batch`, no architect spawn.
+---
 
-**Expected hooks fired:** none.
+### ② AskUserQuestion radio UI rendering
 
-**Expected user-visible output:**
+During onboarding, the branching-model question is supposed to use Claude Code's radio-form UI (not a plain text question).
 
-- Acknowledgement like *"I'll get to that as soon as we finish setup — let's wrap the onboarding form first."*
-- The `AskUserQuestion` form re-surfaced.
-- After onboarding completes: *"Now — about that hello-world endpoint…"* and bro proceeds to the normal code-change flow (flow 2 or 3).
+✅ Pass criteria: you see a proper form with selectable options (github-flow / gitflow / custom), not "type 1, 2, or 3."
 
-**Expected DB state (during the hold):**
+---
 
-| Table | Rows / values |
-|---|---|
-| `issues` | 0 rows created |
-| `tasks` | 0 rows created |
-| `discussions` | 0 rows created |
+### ③ Silent template copy after onboarding
 
-**Verification:**
+After answering the 3 onboarding questions:
 
 ```bash
-sqlite3 .claude/tmb/trajectory.db "SELECT COUNT(*) FROM issues; SELECT COUNT(*) FROM tasks; SELECT COUNT(*) FROM discussions;"
-# Expect 0 / 0 / 0 until onboarding completes.
+ls .claude/agents/   # should contain swe.md (and ONLY swe.md)
+ls .claude/skills/   # should contain swe-checklist, code-quality, docs-conventions, git-conventions, naming-conventions
 ```
 
-**Common failure modes:**
-
-- **Architect spawns during onboarding** → bro's prompt isn't enforcing hold-and-resume. File against the `first-run-onboarding` skill.
-- **Bro forgets the held request** → after onboarding completes, bro should surface it. If not, prompt drift in bro's A.4 Mode Rules.
-
-**Pass:** [ ]
+✅ Pass criteria: `swe.md` is present. `pr-reviewer.md` is **NOT** present (it's lazy-copied at first push gate). The 5 swe-side default skills are present.
 
 ---
 
-### 1.3 — Read-only ask DURING onboarding is answered, then resumes
+### ④ Subagent prompt precedence
 
-**Prerequisites:** Reset DB. Trigger onboarding; pause with the `AskUserQuestion` form open.
+Ask: `@bro write a python file that prints hello`
 
-**Trigger prompt** (mid-onboarding):
-> `what files are in this repo?`
+When SWE spawns, the SWE subagent uses **its own template's prompt** (terse, task-focused), not bro's persona prompt. Test by inspecting the spawn:
 
-**Expected agent chain:**
+✅ Pass criteria: SWE doesn't say "Trust me bro" or "Entering bro mode." It just executes the task.
 
-| # | Agent | Model | Via | Purpose |
-|---|---|---|---|---|
-| 1 | `tmb:bro` | opus | active session | Handles read-only ask inline (no agent spawn) |
+---
 
-**Expected MCP tool calls:** none (read-only op; bro uses `Bash`/`Glob` directly).
+### ⑤ Worktree isolation
 
-**Expected hooks fired:**
-- `PreToolUse:Bash` → `git-guards.sh` → **allow** (read-only `ls` / `git status` / `find` are unconstrained).
-
-**Expected user-visible output:**
-
-- A file listing from `ls` or `git ls-files`.
-- Immediately after: the `AskUserQuestion` form re-surfaced.
-
-**Expected DB state:** unchanged — no MCP writes during a read-only branch.
-
-**Verification:**
+Same task as ④. After SWE returns:
 
 ```bash
-sqlite3 .claude/tmb/trajectory.db "SELECT COUNT(*) FROM issues; SELECT COUNT(*) FROM plugin_config WHERE key='branching_model';"
-# Expect 0 / 0 until the user finishes the onboarding form.
+git worktree list  # should show a worktree under .claude/worktrees/ or similar
 ```
 
-**Common failure modes:**
-
-- **Bro runs `find /` or scans outside cwd** → bash bug in project-prescan; shouldn't be invoked during onboarding anyway.
-- **Onboarding abandoned** → bro answered the read-only ask but didn't resume onboarding. Prompt-drift in `first-run-onboarding`'s hold-and-resume section.
-
-**Pass:** [ ]
+✅ Pass criteria: SWE worked in an isolated worktree, NOT directly on the main branch tree.
 
 ---
 
-### 1.4 — Re-onboarding (explicit phrase, post-onboarding)
+### ⑥ Bro task gate (verification before close)
 
-**Prerequisites:** Onboarding complete (1.1 passed). DB has identity + config rows.
+After SWE completes ④, bro should:
+1. Re-run the spec's `## Verification` commands.
+2. Sanity-check the diff against the spec's `## Files`.
+3. Confirm each `## Success Criteria` bullet.
+4. THEN flip the task to `closed`.
 
-**Trigger prompt:**
-> `bro, switch to gitflow` (already in bro mode from earlier; addressing bro again is fine but optional)
+✅ Pass criteria: bro's response includes evidence of running the verification (you see the command output in the conversation), not a bare "task closed."
 
-**Expected agent chain:**
+---
 
-| # | Agent | Model | Via | Purpose |
-|---|---|---|---|---|
-| 1 | `tmb:bro` | opus | user @-mention | Recognizes re-onboard phrase; invokes `tmb_reonboard` skill inline (no subagent spawn) |
+### ⑦ Push gate fires + lazy pr-reviewer copy
 
-**Expected MCP tool calls (in order):**
-
-| # | Caller | Tool | Key args | Purpose |
-|---|---|---|---|---|
-| 1 | bro | `identity_get` | `agent='bro'` | Read current name |
-| 2 | bro | `config_list` | `agent='bro'` | Read current branching/pr_target/protected |
-| 3 | bro | `AskUserQuestion` | 3-question batch with current values as `Keep "<current>"` first option | Offer one-click preserve + alternatives |
-| 4 | bro | `config_set` | `agent='bro', key='branching_model', value='gitflow'` | Only if changed |
-| 5 | bro | `config_set` | `agent='bro', key='pr_target', value=<answer>` | Only if changed |
-| 6 | bro | `config_set` | `agent='bro', key='protected_branches', value=[<list>]` | Recomputed from new branching + pr_target |
-
-**Expected hooks fired:** none.
-
-**Expected user-visible output:**
-
-- Form with first option `Keep "<current>"` for every question.
-- Closing line summarizing the 4 settings (including `human_name`).
-
-**Expected DB state after:**
-
-| Table | Rows / values |
-|---|---|
-| `identity` | unchanged (only re-written if name changed) |
-| `plugin_config` | `branching_model='"gitflow"'`, `protected_branches` includes both `main` and `<new pr_target>` deduplicated |
-
-**Verification:**
+After ④–⑥, set up a remote and try to push:
 
 ```bash
-sqlite3 .claude/tmb/trajectory.db <<'SQL'
-  SELECT key, value_json FROM plugin_config WHERE key IN ('branching_model','pr_target','protected_branches');
-  SELECT * FROM identity;
-SQL
+git remote add origin <a-bare-repo-or-fake>
+git push -u origin main 2>&1
 ```
 
-**Common failure modes:**
+Should be **blocked** by the pre-push hook with a message asking you to run `@bro review before push`.
 
-- **Bro re-asks every question with no `Keep` default** → `tmb_reonboard` isn't reading current state. Check skill's Step 1.
-- **protected_branches regresses to just `[pr_target]`** → the dedup-with-main logic for gitflow didn't run. Skill Step 3 bug.
-
-**Pass:** [ ]
-
----
-
-## Flow 2 — Simple Task (bro-as-planner chain)
-
-> **The 2.x scenarios below are STALE** — they describe the legacy
-> `bro → architect → swe` chain. Use **`2.1.bro` as the canonical
-> simple-task smoke test** in the new model. The original 2.1/2.2/2.3
-> are kept for reference until they're rewritten.
-
-### 2.1.bro — Simple task end-to-end (NEW canonical smoke test)
-
-**Prerequisites:** Onboarded scratch project with at least a README.
-
-**Trigger prompt:**
-> `@bro fix the typo in README — "recieve" should be "receive"`
-
-**Expected agent chain:**
-
-| # | Agent | Model | Via | Purpose |
-|---|---|---|---|---|
-| 1 | bro (main Claude) | opus | persona | Triages, captures intent in MCP, plans, authors task spec, spawns SWE, spawns pr-reviewer, closes |
-| 2 | swe | sonnet | Task tool | Implements typo fix in worktree; commits |
-| 3 | pr-reviewer | opus | Task tool | Reviews diff; records `validation_record(verdict='pass')` |
-
-**Expected MCP tool calls (bro is the only mutator outside swe/pr-reviewer's lane):**
-
-| # | Caller | Tool | Key args |
-|---|---|---|---|
-| 1 | bro | `issue_create` | `agent='bro'`, objective |
-| 2 | bro | `discussion_append` | `kind='intent'`, author='human' |
-| 3 | bro | `discussion_append` | `kind='note'`, body='Triage: simple' |
-| 4 | bro | `task_create_batch` | `agent='bro'`, single task with `waive_scope_gate=true`, reason citing simple-fast-lane defaults |
-| 5 | bro | `ledger_log` | `event_type='planning_complete'` |
-| 6 | swe | `task_get` | `agent='swe'`, task_id |
-| 7 | swe | `task_update_status` | `agent='swe'`, status='running' |
-| 8 | swe | `task_update_status` | `agent='swe'`, status='completed', commit_sha |
-| 9 | pr-reviewer | `task_get` | `agent='pr-reviewer'` |
-| 10 | pr-reviewer | `validation_record` | `agent='pr-reviewer'`, verdict='pass' |
-| 11 | bro | `task_update_status` | `agent='bro'`, status='closed' |
-
-**Expected DB state after:**
-- 1 issue, status='open' (or closed if bro closed it)
-- 1 task, status='closed', commit_sha non-empty
-- 1 validation_attempts row, verdict='pass', agent='pr-reviewer'
-- ledger row with event_type='planning_complete'
-
-**Verification:**
-```bash
-sqlite3 .claude/tmb/trajectory.db "
-  SELECT t.branch_id, t.status, t.commit_sha, v.verdict, v.agent
-  FROM tasks t LEFT JOIN validation_attempts v ON v.task_id=t.id
-  ORDER BY t.id DESC LIMIT 1;"
-```
-
-Expect a row with status='closed', commit_sha matching git log, verdict='pass', agent='pr-reviewer'.
-
-**Common failure modes:**
-- bro spawns architect via Task tool → routing regression (architect is consultant-only now)
-- task_create_batch returns `forbidden` → bro called with wrong agent param (must be 'bro')
-- validation_record returns `forbidden` for any caller other than pr-reviewer
-
-**Pass:** [ ]
-
-### 2.1 — Typo fix [STALE — use 2.1.bro]
-
-(Original architect-as-planner scenario; kept for reference.)
-
-### 2.2 — Add a code comment [STALE]
-
-(Original; will be re-derived from 2.1.bro after the cleanup PR settles.)
-
-### 2.3 — Internal refactor with no API change [STALE]
-
-(Original; same as above.)
-
----
-
-## Flow 3 — Difficult Task
-
-All three should produce: `triage:difficult`, ADR file at `docs/trustmybot/architecture/manual/decisions/`, `discussion_append(kind='decision')` row, standard-template task spec.
-
-### 3.1 — Add a new public API surface
-
-**Trigger prompt:**
-> `add OAuth login to our API — support Google and GitHub providers`
-
-**Expected behavior:**
-1. Pre-scan emitted.
-2. Proposes branch_id like `feat/oauth-login` + `triage: difficult`.
-3. After confirmation, architect spawns.
-4. Architect aligns via `discussion_append(kind='question')` if any open questions.
-5. Architect appends `discussion_append(kind='decision')` with the architectural plan.
-6. Architect creates ADR at `docs/trustmybot/architecture/manual/decisions/N-oauth.md`.
-7. THEN creates standard-template tasks; spawns SWE; pr-reviewer signs off.
-
-**Verification:**
-```bash
-ls docs/trustmybot/architecture/manual/decisions/
-```
-Expect a new ADR file.
-
-```sql
-SELECT kind, body FROM discussions WHERE issue_id=<latest> ORDER BY id;
-```
-Expect at least one row with `kind='decision'`.
-
-**Pass:** [ ]
-
-### 3.2 — Schema / data-model change
-
-**Trigger prompt:**
-> `migrate from SQLite to Postgres for production`
-
-**Expected:** difficult triage (data model change + new dependency); ADR + standard template.
-
-**Pass:** [ ]
-
-### 3.3 — Cross-cutting concern
-
-**Trigger prompt:**
-> `add structured request logging across every API endpoint`
-
-**Expected:** difficult triage (new cross-cutting concern); ADR + standard template.
-
-**Pass:** [ ]
-
----
-
-## Flow C — Consultant invocation (NEW — bro-as-planner model)
-
-When the Human asks bro for a second opinion, bro checks for the named consultant in `.claude/agents/`. If absent, bro invokes `agent-creator` to draft + write the file with explicit Human approval (consultants are project-local, not shipped). Then bro spawns it in **analysis-only** mode. Consultants return a read; bro summarizes; Human decides. Consultants must NOT call `task_create_batch`, `task_update_status`, `validation_record`, or `issue_create` (server-enforced via `requireRoles`).
-
-### C.1 — Architect invoked for a second opinion on a design choice
-
-**Prerequisites:** Onboarded scratch project. An open issue with a design question (you can seed via `2.1.bro` and stop before SWE spawn, or open a fresh design discussion via bro). `.claude/agents/architect.md` may or may not exist yet — both branches tested below.
-
-**Trigger prompt:**
-> `@bro get the architect's read on whether we should use SQLite or a JSON file for this CLI's storage. Single-user laptop scope.`
-
-**Expected agent chain (when `architect.md` doesn't exist yet):**
-
-| # | Agent | Model | Via | Purpose |
-|---|---|---|---|---|
-| 1 | bro (main Claude) | opus | persona | Detects no `.claude/agents/architect.md`; invokes `agent-creator` skill |
-| 1a | bro | opus | AskUserQuestion | Proposes architect spec; gets Human approval |
-| 1b | bro | opus | Write tool | Writes `.claude/agents/architect.md` to project |
-| 2 | architect | opus | Task tool (consultant) | Analyzes; returns analysis text + appends `discussion_append(kind='analysis')` |
-
-**Expected agent chain (when `architect.md` already exists):**
-
-| # | Agent | Model | Via | Purpose |
-|---|---|---|---|---|
-| 1 | bro (main Claude) | opus | persona | Spawns architect with `consultant: analysis-only` marker |
-| 2 | architect | opus | Task tool (consultant) | Analyzes; returns analysis text + appends `discussion_append(kind='analysis')` |
-
-**Expected MCP tool calls:**
-
-| # | Caller | Tool | Key args |
-|---|---|---|---|
-| 1 | architect | `issue_get_with_discussions` | `agent='architect'`, issue_id |
-| 2 | architect | `discussion_append` | `agent='architect'`, kind='analysis', author='architect' |
-| 3 | bro | (summary back to Human via chat) | — |
-
-**Server-enforced negative checks (architect must be REJECTED if it tries):**
-
-| Tool | Expected response |
-|---|---|
-| `task_create_batch` (agent=architect) | `forbidden`, allowed_roles=[bro] |
-| `task_update_status` (agent=architect) | `forbidden`, allowed_roles=[bro,swe] |
-| `validation_record` (agent=architect) | `forbidden`, allowed_roles=[pr-reviewer] |
-| `issue_create` (agent=architect) | `forbidden`, allowed_roles=[bro] |
-
-**Verification:**
-```bash
-sqlite3 .claude/tmb/trajectory.db "
-  SELECT id, kind, author, substr(body,1,80) FROM discussions
-  WHERE issue_id=<id> AND author='architect' ORDER BY id DESC LIMIT 3;"
-```
-
-Expect a `kind='analysis'` row with substantive text. No new tasks should appear (architect is consultant-only).
-
-**Common failure modes:**
-- Architect calls `task_create_batch` and the call **succeeds** → MCP role enforcement regression (it should be forbidden).
-- Architect tries to spawn SWE itself → architect prompt regression (subagents can't spawn subagents anyway, but the explicit prohibition should be in the prompt).
-- Architect's analysis is recorded as `kind='decision'` instead of `kind='analysis'` → prompt drift; analyses are not decisions.
-
-**Pass:** [ ]
-
----
-
-## Flow 4 — Agent-creator
-
-### 4.1 — User requests a domain role that doesn't exist
-
-**Prerequisites:** No `legal-reviewer.md` in `.claude/agents/`.
-
-**Trigger prompt:**
-> `I need a legal-reviewer for this PR — someone who knows GDPR`
-
-**Expected behavior:**
-1. Bro recognizes role not in roster.
-2. Says: "There's no legal-reviewer agent. Want me to create it via agent-creator? (yes/no)"
-3. Waits for explicit yes.
-
-**Pass:** [ ]
-
-### 4.2 — User says yes; agent gets created
-
-**Continuation of 4.1.**
-
-**Trigger prompt:**
-> `yes`
-
-**Expected behavior:**
-1. agent-creator skill asks up to 3 clarifying questions about scope/tools/responsibilities.
-2. Drafts a tailored prompt.
-3. Shows the prompt; asks final approval.
-4. On final yes → writes `.claude/agents/legal-reviewer.md`.
-5. Future routing recognizes the new agent.
-
-**Verification:** `ls .claude/agents/` shows `legal-reviewer.md`.
-
-**Pass:** [ ]
-
-### 4.3 — User says no; bro routes via existing roster
-
-**Continuation of 4.1, but say no instead.**
-
-**Trigger prompt:**
-> `no`
-
-**Expected:** No file created; bro routes the original request through architect (or whichever agent best fits).
-
-**Pass:** [ ]
-
-### 4.4 — Reserved name refused
-
-**Trigger prompt:**
-> `create a new architect2 agent`
-
-**Expected:** Skill refuses with "architect is a reserved name." (Same for `bro`, `swe`, `pr-reviewer`.)
-
-**Pass:** [ ]
-
----
-
-## Flow 5 — Skill Creation
-
-Skill creation is mostly an internal architect decision — not directly user-triggered. Verified indirectly when architect identifies a recurring pattern.
-
-### 5.1 — Architect proposes a skill after recurring pattern
-
-**Hard to trigger reliably in a single session.** Observable when:
-- Architect has executed the same checklist 2+ times in different tasks
-- Architect surfaces: "I notice we keep doing X. Should I create a `<name>` skill so SWE has the checklist available?"
-
-**Pass / Skip:** [ ]
-
----
-
-## Flow 6 — PR Review
-
-### 6.1 — pr-reviewer fires after SWE marks task completed
-
-Auto-triggered as part of every successful task in flow 2 / 3. Verification:
-
-```sql
-SELECT t.branch_id, v.attempt_n, v.verdict, v.feedback
-FROM validation_attempts v
-JOIN tasks t ON v.task_id = t.id
-ORDER BY v.id DESC LIMIT 5;
-```
-
-Expect at least one row per closed task with `verdict='pass'` (or `'fail'` followed by retry attempts).
-
-**Pass:** [ ]
-
----
-
-## Flow 7 — Architecture Regen
-
-### 7.1 — Explicit phrase, full regen
-
-**Trigger prompt:**
-> `refresh architecture docs`
-
-**Expected behavior:**
-1. Bro recognizes the phrase (no architect spawn, no triage).
-2. Invokes `tmb_refresh-architecture` skill with `scope:'full'`.
-3. Calls `architecture_regen`.
-4. 4 files updated under `docs/trustmybot/architecture/auto/`: `codebase-tree.md`, `erd.md`, `module-graph.md`, `changelog.md`.
-5. Each carries a generated-header on line 1.
-6. One-line summary if files changed; else silent.
-
-**Verification:**
-```bash
-head -1 docs/trustmybot/architecture/auto/codebase-tree.md
-sqlite3 .claude/tmb/trajectory.db "SELECT target, last_seen_sha FROM regen_state;"
-```
-
-**Pass:** [ ]
-
-### 7.2 — First code-touching ask, > 25 commits behind
-
-**Prerequisites:** Onboarded; some commits already on dev; `regen_state.last_seen_sha` is more than 25 commits behind HEAD.
-
-**Trigger prompt:**
-> `fix the navbar colour`
-
-**Expected:** Bro emits exactly one nudge line BEFORE the pre-scan: `"Architecture docs are N commits behind. Run /tmb refresh-architecture when convenient."` Then proceeds with normal flow 2 chain.
-
-**Pass:** [ ]
-
-### 7.3 — First code-touching ask, ≤ 25 commits behind
-
-**Prerequisites:** Same as 7.2 but `regen_state.last_seen_sha` is within 25 commits.
-
-**Trigger prompt:**
-> `fix the navbar colour`
-
-**Expected:** Bro silently invokes `tmb_refresh-architecture` with `scope:'incremental'`. No user-facing output for the regen. Then proceeds with normal flow 2 chain.
-
-**Pass:** [ ]
-
-### 7.4 — First-ever session, no `regen_state` rows
-
-**Prerequisites:** Fresh DB (no regen has ever run).
-
-**Trigger prompt:**
-> `add a feature`
-
-**Expected:** lazy-regen-check stays silent (no regen attempted; full initial regen could be expensive). Pre-scan proceeds normally.
-
-**Pass:** [ ]
-
----
-
-## Flow 8 — SWE Retry / Escalation
-
-### 8.1 — Validation fails once → architect retries with feedback
-
-**Hard to deterministically trigger.** Observable when SWE produces output that fails the spec's `## Verification` commands.
-
-**Verification:**
-```sql
-SELECT attempt_n, verdict, feedback FROM validation_attempts
-WHERE task_id=<failing_task> ORDER BY attempt_n;
-```
-
-Expect 2 rows: `attempt_n=1, verdict='fail'` then `attempt_n=2, verdict='pass'`.
-
-**Pass:** [ ]
-
-### 8.2 — 3 fails → escalation to Human
-
-Set the `success_criteria` deliberately impossible (manual setup) so SWE will fail 3 times.
-
-**Expected:**
-- 3 rows in `validation_attempts` all with `verdict='fail'`.
-- `tasks.status = 'escalated'`.
-- `discussion_append(kind='note', body=<blocker>)` appended.
-- Bro surfaces to Human: "this task hit 3 fails — split / change approach / abandon?"
-
-**Pass:** [ ]
-
----
-
-## Flow 9 — Roundtable
-
-This flow has **four distinct corners** depending on whether the trigger is explicit/implicit and whether enough planning agents exist.
-
-### 9.1 — Explicit magic word, ≥2 planners present
-
-**Prerequisites:** `.claude/agents/` contains `architect.md`, `ceo.md`, `cto.md` (or any combination ≥ 2 planners; SWE always excluded).
-
-**Trigger prompt:**
-> `let's do a roundtable on whether to adopt OAuth or stay with session cookies`
-
-**Expected behavior:**
-1. Bro recognizes "roundtable" magic word + topic.
-2. Routes to architect; architect invokes `tmb_roundtable` skill.
-3. Skill globs `.claude/agents/`, picks 2-4 best-matching participants by frontmatter description (excluding SWE).
-4. Spawns participants in **parallel** (multiple `Task` calls in one message).
-5. Each participant returns a position + reasoning.
-6. Architect synthesizes XML output: convergence + tensions + recommendation.
-7. `ledger_log(event_type='roundtable_summary', topic=..., participants=..., recommendation=...)`.
-8. Invokes `roundtable-cleanup` skill.
-
-**Verification:**
-```sql
-SELECT event_type, summary FROM ledger
-WHERE event_type='roundtable_summary' ORDER BY id DESC LIMIT 1;
-```
-
-**Pass:** [ ]
-
-### 9.2 — Explicit magic word, only `architect` present
-
-**Prerequisites:** Fresh project with only the four shipped agents (bro, architect, swe, pr-reviewer); no domain agents.
-
-**Trigger prompt:**
-> `let's do a roundtable on whether to adopt OAuth or stay with session cookies`
-
-**Expected behavior:**
-1. Bro / architect recognizes roundtable request.
-2. Skill checks: only `architect` is a planner (SWE always excluded; pr-reviewer reviews code, not strategy).
-3. Skill **escalates back**: "Roundtable needs ≥2 planning voices. Currently only architect is available. Want me to create additional planners (e.g., `ceo`, `cto`)?"
-4. Routes via `agent-creator` flow if user says yes; otherwise architect proceeds solo.
-
-**Pass:** [ ]
-
-### 9.3 — Implicit cross-domain question, ≥2 planners present
-
-**Prerequisites:** `.claude/agents/` contains `ceo.md` + `cto.md` + `architect.md` already (created via flow 4 earlier).
-
-**Trigger prompt** (no magic word — architect must DETECT cross-domain):
-> `should we ship our beta to enterprise customers next quarter or wait until we have SSO?`
-
-**Expected behavior:**
-1. Bro routes to architect (could be ceo since it's strategic — bro may ask the framing question).
-2. Architect detects: this isn't a single-domain decision (touches product timing, technical readiness, business risk).
-3. Architect invokes `tmb_roundtable` skill **without explicit user request**.
-4. Skill picks ceo + cto (+ architect as convener).
-5. Same flow as 9.1 from there.
-
-**Pass:** [ ]
-
-**Notes:** This is the trickiest scenario — architect's judgment of "this is cross-domain" is fuzzy. May fail if architect's prompt doesn't clearly direct it to invoke roundtable for cross-domain calls. If it fails: file as a follow-up issue; architect prompt may need a clearer "when to invoke roundtable" rule.
-
-### 9.4 — Implicit cross-domain question, only `architect` present
-
-**Prerequisites:** Only the four shipped agents; no domain planners.
-
-**Trigger prompt:**
-> `should we ship our beta to enterprise customers next quarter or wait until we have SSO?`
-
-**Expected behavior:**
-1. Bro routes to architect (no ceo/cto to route to).
-2. Architect recognizes the question is cross-domain (product + tech + risk) and beyond its scope.
-3. Architect surfaces: "This question spans product + tech + risk decisions — I'd want a `ceo` and `cto` voice on it. Want me to create them via agent-creator first, then run a roundtable?"
-4. If user says yes → flow 4 (agent-creator) for each missing role → flow 9.3 from there.
-5. If user says no → architect makes a best-effort solo recommendation, flagging the dimensions it couldn't credibly evaluate.
-
-**Pass:** [ ]
-
----
-
-## Reset / cleanup between scenarios
+Run that:
 
 ```bash
-# In the scratch project root:
-rm -rf .claude/tmb/                         # wipe trajectory DB
-rm -rf .claude/agents/                      # wipe user-created domain agents
-rm -rf docs/trustmybot/                     # wipe generated + manual architecture docs
-git checkout -- .                           # revert any SWE-committed changes
+@bro review before push
 ```
 
-## Filing observed deviations
+✅ Pass criteria:
+- `.claude/agents/pr-reviewer.md` appears (lazy-copied).
+- pr-reviewer is spawned, runs review, signs off via MCP.
+- Re-running `git push` succeeds.
 
-When a scenario's expected behavior doesn't match actual output:
+---
 
-1. Note the scenario ID (e.g., 9.3) and what diverged.
-2. Capture the relevant agent output as a code block.
-3. File an issue tagged `dogfood` with the title `dogfood: <scenario ID> — <one-line deviation>`.
-4. Reference this file: `See SCENARIOS.md#<scenario-anchor>`.
+### ⑧ Direct Mode for trivial fix
 
-## Related
+Reset (`rm -rf /tmp/tmb-dogfood/.claude/`). Re-onboard. Then:
 
-- [`FLOWS.md`](../../docs/architecture/FLOWS.md) — the flowcharts each scenario verifies
-- [`setup.md`](./setup.md) — how to launch a scratch session
-- [`tests/run-all.sh`](../../tests/run-all.sh) — automated suites that run before any dogfood test
+```
+@bro fix typo "recieve" → "receive" in README.md
+```
+
+✅ Pass criteria:
+- bro responds in **<30s** total (faster than full SWE spawn).
+- bro edits the file directly using the `Edit` tool, no SWE spawn.
+- A `direct_mode_used` event lands in `ledger`.
+
+---
+
+### ⑨ Resume after kill
+
+Mid-task (during ④), kill Claude Code (`Ctrl-C`). Restart, re-enter the project. Type:
+
+```
+@bro
+```
+
+✅ Pass criteria: bro detects the in-progress issue/task via `issue_resume`, summarizes where it left off, and offers to continue. **Not** "what would you like me to do?" (that would mean amnesia).
+
+---
+
+### ⑩ Bro tone + catchphrase discipline
+
+Across all scenarios:
+
+✅ Pass criteria:
+- Tone is terse and in-character (not corporate AI-fluff).
+- "Trust me bro, it works" only appears AFTER a successful task close + push gate, never on a fail / retry / unverified state.
+- No padding, no narration of what bro is about to do — bro just does it and reports.
+
+---
+
+## How to sign off
+
+Once every checkbox passes for the version you're about to release:
+
+```bash
+export MANUAL_DOGFOOD_PASSED=v0.2.0
+bash scripts/release.sh
+```
+
+`release.sh` checks `$MANUAL_DOGFOOD_PASSED` matches `plugin.json` version. If not set or mismatched, it refuses to tag.
+
+If something fails, **do not tag**. File an issue, fix it, re-run the affected checklist item, then sign off.
+
+## Why this is the only manual layer
+
+L0–L4 cover everything that can be verified without Claude Code in the loop:
+
+- **L0** Docker: install-smoke (cold-start MCP boot).
+- **L1** lint: structural integrity of every shipped artifact.
+- **L2** unit: per-handler / per-hook behavior.
+- **L3** integration: real MCP server + real DB + real hooks cooperating.
+- **L4** workflow-sim: every FLOWS.md flow as a scripted MCP-tool sequence.
+
+What L5 catches is the *Claude-side* behavior — trigger detection, AskUserQuestion rendering, agent spawn isolation, subagent prompt precedence, tone, real worktree creation. None of those have an MCP surface to test.
+
+Keep this checklist tight. If you find yourself adding a 30-line scenario, ask: can it be moved to L4 by simulating the MCP-tool sequence? Almost always yes.

--- a/tests/mcp-integration/run.sh
+++ b/tests/mcp-integration/run.sh
@@ -17,4 +17,8 @@ if [ ! -f "mcp/trajectory-server/dist/index.js" ]; then
   (cd mcp/trajectory-server && bun run build)
 fi
 
-exec node --test --test-reporter spec "$HERE"/*.test.mjs
+WORKFLOW_SIM="$PLUGIN_ROOT/tests/workflow-sim"
+
+# Run both L3 integration tests and L4 workflow-simulation flows in one Node
+# process. Both share the same harness + spawn the real MCP server.
+exec node --test --test-reporter spec "$HERE"/*.test.mjs "$WORKFLOW_SIM"/*.test.mjs

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,56 +1,66 @@
 #!/usr/bin/env bash
-# Full TMB plugin test suite: MCP server + hook scripts.
-# Exit 0 only if every suite passes.
+# Full TMB plugin test suite. Exit 0 only if every layer passes.
+#
+# Layered model (see docs/architecture/FLOWS.md + CONTRIBUTING.md):
+#   L0 — Distribution / install-smoke   → tests/docker/install-smoke.Dockerfile (CI-only)
+#   L1 — Static / lint                  → tests/lint/*.sh (this file runs them)
+#   L2 — Unit (per-component)           → mcp/trajectory-server/src/test/*.ts
+#   L3 — Integration (cross-component)  → tests/mcp-integration/*.mjs + tests/hooks/*.sh
+#   L4 — Workflow simulation            → (planned for v0.2.0)
+#   L5 — Manual dogfood                 → tests/manual/scenarios.md (human-walked)
+#   L6 — Release canary                 → scripts/release.sh post-tag step
+
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 FAIL=0
 
-printf "=== Layer 1: MCP unit tests (handlers direct, no protocol) ===\n"
+run_step() {
+  local label="$1"
+  shift
+  printf "\n=== %s ===\n" "$label"
+  if "$@"; then
+    printf "→ PASS\n"
+  else
+    printf "→ FAIL\n"
+    FAIL=1
+  fi
+}
+
+# ----- L1 — Static / lint -----------------------------------------------
+
+run_step "L1 lint: agent template line budget"        bash "$HERE/lint/agent-line-budget.sh"
+run_step "L1 lint: onboarding skill contract"         bash "$HERE/lint/onboarding-skill-contract.sh"
+run_step "L1 lint: skill frontmatter + name=dirname"  bash "$HERE/lint/skill-frontmatter.sh"
+run_step "L1 lint: manifest shape (plugin/.mcp/hooks)" bash "$HERE/lint/manifest-shape.sh"
+run_step "L1 lint: version sync (3 manifests agree)"  bash "$HERE/lint/version-sync.sh"
+run_step "L1 lint: changelog top section current"     bash "$HERE/lint/changelog-current.sh"
+run_step "L1 lint: link-check (relative md links)"    bash "$HERE/lint/link-check.sh"
+run_step "L1 lint: shellcheck on shell scripts"       bash "$HERE/lint/shellcheck-hooks.sh"
+run_step "L1 lint: tsc --noEmit on MCP server"        bash "$HERE/lint/tsc-noemit.sh"
+
+# ----- L2 — Unit + L3 — Integration -------------------------------------
+
+printf "\n=== L2 unit: MCP handlers (node --test on built dist/) ===\n"
 if (cd "$PLUGIN_ROOT/mcp/trajectory-server" && bun run build && node --test dist/test/*.test.js); then
-  printf "MCP unit suite: PASS\n\n"
+  printf "→ PASS\n"
 else
-  printf "MCP unit suite: FAIL\n\n"
+  printf "→ FAIL\n"
   FAIL=1
 fi
 
-printf "=== Layer 2: MCP integration tests (real server subprocess + stdio JSON-RPC) ===\n"
-if bash "$HERE/mcp-integration/run.sh"; then
-  printf "\nMCP integration suite: PASS\n\n"
-else
-  printf "\nMCP integration suite: FAIL\n\n"
-  FAIL=1
-fi
+run_step "L3 integration: MCP server end-to-end (stdio JSON-RPC)"  bash "$HERE/mcp-integration/run.sh"
+run_step "L3 integration: hook script tests"                         bash "$HERE/hooks/run.sh"
 
-printf "=== Hook script tests (tests/hooks) ===\n"
-if bash "$HERE/hooks/run.sh"; then
-  printf "\nHook suite: PASS\n"
-else
-  printf "\nHook suite: FAIL\n"
-  FAIL=1
-fi
+# ----- summary -----------------------------------------------------------
 
-printf "\n=== Lint: agent prompt budget (tests/lint) ===\n"
-if bash "$HERE/lint/agent-line-budget.sh"; then
-  printf "\nLint suite: PASS\n"
-else
-  printf "\nLint suite: FAIL\n"
-  FAIL=1
-fi
-
-printf "\n=== Lint: onboarding skill contract (tests/lint) ===\n"
-if bash "$HERE/lint/onboarding-skill-contract.sh"; then
-  printf "\nOnboarding contract lint: PASS\n"
-else
-  printf "\nOnboarding contract lint: FAIL\n"
-  FAIL=1
-fi
-
+printf "\n========================================\n"
 if [ "$FAIL" -eq 0 ]; then
-  printf "\nAll test suites passed.\n"
+  printf "All test layers passed (L1 + L2 + L3).\n"
+  printf "L0 install-smoke runs separately in CI (docker required).\n"
   exit 0
 else
-  printf "\nOne or more test suites failed. See output above.\n"
+  printf "One or more layers FAILED. See output above.\n"
   exit 1
 fi

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -39,6 +39,7 @@ run_step "L1 lint: changelog top section current"     bash "$HERE/lint/changelog
 run_step "L1 lint: link-check (relative md links)"    bash "$HERE/lint/link-check.sh"
 run_step "L1 lint: shellcheck on shell scripts"       bash "$HERE/lint/shellcheck-hooks.sh"
 run_step "L1 lint: tsc --noEmit on MCP server"        bash "$HERE/lint/tsc-noemit.sh"
+run_step "L1 lint: release script safety guards"      bash "$HERE/lint/release-script-safety.sh"
 
 # ----- L2 — Unit + L3 — Integration -------------------------------------
 

--- a/tests/workflow-sim/README.md
+++ b/tests/workflow-sim/README.md
@@ -1,0 +1,56 @@
+# Layer 4 — Workflow Simulation
+
+These tests **drive the real MCP server through scripted tool sequences** to verify that each FLOWS.md flow produces the right state transitions, ledger events, and role-enforcement behavior — **without needing Claude Code to be running**.
+
+The harness is `tests/mcp-integration/harness.mjs` (shared with L3). Each test spawns the MCP server in a subprocess, opens an in-memory SQLite DB (`TRAJECTORY_DB_PATH=:memory:`), and walks one flow end-to-end as multiple MCP tool calls — first as bro, then SWE, then pr-reviewer, etc.
+
+## Coverage map
+
+Cross-reference: [`docs/architecture/FLOWS.md`](../../docs/architecture/FLOWS.md).
+
+| FLOWS.md flow | Test file | Status |
+|---|---|---|
+| 1 — First-run onboarding | n/a | **L5 only** — depends on Claude AskUserQuestion + filesystem template copy |
+| 2 — Simple task | `flow-02-simple-task.test.mjs` | ✅ end-to-end MCP sequence |
+| 3 — Difficult task | `flow-03-difficult-task.test.mjs` | ✅ Q+A discussions + decision record |
+| 4 — Agent-creator | n/a | **L5 only** — pure filesystem write |
+| 5 — Skill creation | n/a | **L5 only** — pure filesystem write |
+| 6 — Push gate | `flow-06-push-gate.test.mjs` | ✅ closed-task + validation_record + retry |
+| 7 — Architecture regen | `flow-07-architecture-regen.test.mjs` | ✅ regen_state + file_registry orchestration |
+| 8 — SWE retry / escalation | `flow-08-swe-retry.test.mjs` | ✅ multiple validation_attempts + status='escalated' |
+| 9 — Roundtable | n/a | covered by ledger 'roundtable_summary' event in flow-03 + role-matrix |
+| C — Consultant invocation | n/a | covered by `tests/mcp-integration/role-matrix.test.mjs` |
+| D — Direct Mode | `flow-D-direct-mode.test.mjs` | ✅ ledger event_type='direct_mode_used' |
+
+## What L4 does NOT test
+
+- The **Claude side** of the chain — bro's prompt parsing, AskUserQuestion rendering, agent-spawn isolation, subagent prompt precedence. Those need L5 (manual dogfood with Claude Code).
+- **Filesystem-only flows** (template copy, ADR file write, agent-creator file write) — handled directly by bash via Bro's tools, not by MCP. Those are caught at Layer 0 (file presence after install) and Layer 5 (visual confirmation).
+
+## Why these flows exist as L4 tests
+
+Each test asserts the **structural contract** of a flow:
+
+- The right MCP tools get called in the right order
+- The right rows land in the right tables
+- Role enforcement (`requireRoles`) fires correctly per agent
+- Ledger events are recorded for downstream snapshot/report use
+- Status transitions follow the documented state machine
+
+If a flow's contract changes (new step, new role enforcement, new ledger event), the corresponding test file changes too — that's how `FLOWS.md` and the code stay in sync.
+
+## Running
+
+These tests are run by the integration runner alongside `tests/mcp-integration/`:
+
+```
+bash tests/mcp-integration/run.sh
+```
+
+Or via the full suite:
+
+```
+bash tests/run-all.sh
+```
+
+CI runs them on every PR.

--- a/tests/workflow-sim/flow-02-simple-task.test.mjs
+++ b/tests/workflow-sim/flow-02-simple-task.test.mjs
@@ -1,0 +1,121 @@
+// Flow 2 — Simple Task (FLOWS.md §2)
+//
+// Trajectory: bro triages simple → issue_create → discussion (intent + triage) →
+// task_create_batch + ledger_log(planning_complete) → SWE returns
+// (task_update_status='completed') → bro verifies (no validation row at task close;
+// pr-reviewer fires only at push gate) → bro flips task to 'closed' → issue_close.
+//
+// Asserts the structural contract: state transitions, ledger events, role
+// enforcement at each call. Direct-runs the MCP server, no Claude.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { startClient, call } from '../mcp-integration/harness.mjs';
+
+test('Flow 2 — simple task: bro plans → swe completes → bro closes (no per-task pr-reviewer)', async (t) => {
+  const { client, close } = await startClient();
+  t.after(async () => { await close(); });
+
+  // Setup: minimal identity + config so role checks are cleaner
+  await call(client, 'identity_set', { agent: 'bro', human_name: 'Test' });
+
+  // 1. bro creates issue
+  const issue = await call(client, 'issue_create', {
+    agent: 'bro',
+    objective: 'Add /hello endpoint',
+    description: 'Single-file route, no architecture impact.',
+  });
+  assert.equal(issue.ok, true, `issue_create: ${JSON.stringify(issue)}`);
+  const issueId = issue.data.id;
+
+  // 2. bro logs intent + triage discussion
+  const intent = await call(client, 'discussion_append', {
+    agent: 'bro', issue_id: issueId, author: 'human', kind: 'intent',
+    body: '@bro add /hello endpoint',
+  });
+  assert.equal(intent.ok, true);
+
+  const triage = await call(client, 'discussion_append', {
+    agent: 'bro', issue_id: issueId, author: 'bro', kind: 'note',
+    body: 'Triage: simple — single file, defaults applied.',
+  });
+  assert.equal(triage.ok, true);
+
+  // 3. bro authors task spec + emits planning_complete
+  const batch = await call(client, 'task_create_batch', {
+    agent: 'bro',
+    issue_id: issueId,
+    waive_scope_gate: true,
+    waive_scope_gate_reason: 'simple-triage personal endpoint; defaults named in triage note (single file, stdlib router)',
+    tasks: [{
+      branch_id: 'feat/hello',
+      title: 'Add /hello endpoint',
+      description: 'Wire /hello → 200 OK {msg:"hello"}.',
+      success_criteria: 'GET /hello returns 200 with documented body',
+      spec_body: '## Files\n- app/routes.py\n## Verification\n```\ncurl localhost/hello\n```\n## Success Criteria\n- 200 OK',
+    }],
+  });
+  assert.equal(batch.ok, true, `task_create_batch: ${JSON.stringify(batch)}`);
+  // batch.data may be an array of created tasks OR {tasks: [...]} depending on API revision
+  const taskId = Array.isArray(batch.data) ? batch.data[0]?.id : batch.data.tasks?.[0]?.id;
+  assert.ok(taskId, `no task id returned: ${JSON.stringify(batch.data)}`);
+
+  const planning = await call(client, 'ledger_log', {
+    agent: 'bro', issue_id: issueId, branch_id: 'feat/hello',
+    from_node: 'bro',
+    event_type: 'planning_complete', summary: 'Triage simple. Spec authored for task_id=' + taskId,
+  });
+  assert.equal(planning.ok, true, `ledger_log: ${JSON.stringify(planning)}`);
+
+  // 4. SWE picks up the task: read spec → mark running
+  const taskRead = await call(client, 'task_get', { agent: 'swe', task_id: taskId });
+  assert.equal(taskRead.ok, true);
+  assert.match(taskRead.data.spec_body, /Files/);
+
+  const running = await call(client, 'task_update_status', {
+    agent: 'swe', task_id: taskId, status: 'running',
+  });
+  assert.equal(running.ok, true);
+
+  // 5. SWE completes with commit_sha
+  const completed = await call(client, 'task_update_status', {
+    agent: 'swe', task_id: taskId, status: 'completed',
+    commit_sha: 'aaaaaaa1111111111111111111111111111aaaaa',
+  });
+  assert.equal(completed.ok, true, `swe→completed: ${JSON.stringify(completed)}`);
+
+  // 6. CRITICAL: bro's task gate — verifies and closes (no pr-reviewer at this point).
+  // PR-reviewer is the PUSH gate, not the task gate. validation_attempts stays empty
+  // until the push gate fires (Flow 6).
+  const preCloseValidations = await call(client, 'validation_history', {
+    agent: 'bro', task_id: taskId,
+  });
+  assert.equal(preCloseValidations.ok, true);
+  assert.equal(preCloseValidations.data.length, 0,
+    'simple-task close must NOT spawn pr-reviewer (push gate is amortized)');
+
+  const closed = await call(client, 'task_update_status', {
+    agent: 'bro', task_id: taskId, status: 'closed',
+  });
+  assert.equal(closed.ok, true);
+
+  // 7. bro closes the issue
+  const issueClosed = await call(client, 'issue_close', {
+    agent: 'bro', issue_id: issueId,
+  });
+  assert.equal(issueClosed.ok, true);
+
+  // 8. Final state: issue closed, task closed with commit_sha, no validation rows yet
+  const finalIssue = await call(client, 'issue_get', { agent: 'bro', issue_id: issueId });
+  assert.equal(finalIssue.data.status, 'closed');
+
+  const finalTask = await call(client, 'task_get', { agent: 'bro', task_id: taskId });
+  assert.equal(finalTask.data.status, 'closed');
+  assert.equal(finalTask.data.commit_sha, 'aaaaaaa1111111111111111111111111111aaaaa');
+
+  // ledger event recorded
+  const ledger = await call(client, 'ledger_list', { agent: 'bro', issue_id: issueId });
+  assert.equal(ledger.ok, true);
+  assert.ok(ledger.data.some(e => e.event_type === 'planning_complete'),
+    'planning_complete event must land in ledger');
+});

--- a/tests/workflow-sim/flow-03-difficult-task.test.mjs
+++ b/tests/workflow-sim/flow-03-difficult-task.test.mjs
@@ -1,0 +1,135 @@
+// Flow 3 — Difficult Task (FLOWS.md §3)
+//
+// Trajectory: bro triages difficult → issue_create → discussion (intent + triage) →
+// LOOP { discussion(question) ↔ discussion(answer) } → discussion(decision) →
+// (bro writes ADR file — bash, NOT MCP, so out of scope here) →
+// task_create_batch (no waive_scope_gate; the Q+A *is* the scope-gate satisfaction) →
+// SWE completes → bro closes.
+//
+// Asserts: scope-gate is satisfied by question rows (no waive needed),
+// the discussion thread is queryable in order, and the decision rows
+// are visible to issue_get_with_discussions for ADR generation.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { startClient, call } from '../mcp-integration/harness.mjs';
+
+test('Flow 3 — difficult task: Q+A discussions satisfy scope gate; decision row drives ADR', async (t) => {
+  const { client, close } = await startClient();
+  t.after(async () => { await close(); });
+
+  await call(client, 'identity_set', { agent: 'bro', human_name: 'Test' });
+
+  // 1. Issue
+  const issue = await call(client, 'issue_create', {
+    agent: 'bro',
+    objective: 'Migrate auth from session-cookie to JWT',
+    description: 'Cross-cutting refactor; touches docs/trustmybot/architecture/.',
+  });
+  assert.equal(issue.ok, true);
+  const issueId = issue.data.id;
+
+  // 2. Intent + triage note
+  await call(client, 'discussion_append', {
+    agent: 'bro', issue_id: issueId, author: 'human', kind: 'intent',
+    body: '@bro switch us to JWT auth',
+  });
+  await call(client, 'discussion_append', {
+    agent: 'bro', issue_id: issueId, author: 'bro', kind: 'note',
+    body: 'Triage: difficult — touches architecture, multiple services.',
+  });
+
+  // 3. Q+A loop — bro asks scope-clarifying questions one at a time
+  const q1 = await call(client, 'discussion_append', {
+    agent: 'bro', issue_id: issueId, author: 'bro', kind: 'question',
+    body: 'JWT signing key: HS256 with shared secret OR RS256 with key rotation?',
+  });
+  assert.equal(q1.ok, true);
+
+  const a1 = await call(client, 'discussion_append', {
+    agent: 'bro', issue_id: issueId, author: 'human', kind: 'answer',
+    body: 'RS256 with rotation; we need this for compliance.',
+  });
+  assert.equal(a1.ok, true);
+
+  const q2 = await call(client, 'discussion_append', {
+    agent: 'bro', issue_id: issueId, author: 'bro', kind: 'question',
+    body: 'Migrate existing sessions OR force re-login on cutover?',
+  });
+  assert.equal(q2.ok, true);
+
+  const a2 = await call(client, 'discussion_append', {
+    agent: 'bro', issue_id: issueId, author: 'human', kind: 'answer',
+    body: 'Force re-login; cleaner cutover, acceptable UX cost.',
+  });
+  assert.equal(a2.ok, true);
+
+  // 4. Decision row (the ADR seed)
+  const decision = await call(client, 'discussion_append', {
+    agent: 'bro', issue_id: issueId, author: 'bro', kind: 'decision',
+    body: 'Decision: RS256 + key rotation, force re-login on cutover. ADR-0042 will capture rationale.',
+  });
+  assert.equal(decision.ok, true);
+
+  // 5. Task creation — NO waive_scope_gate (the Q+A satisfies it).
+  // This is the structural difference from Flow 2: difficult triage MUST go
+  // through the Q+A scope gate.
+  const batch = await call(client, 'task_create_batch', {
+    agent: 'bro',
+    issue_id: issueId,
+    tasks: [{
+      branch_id: 'refactor/jwt-auth',
+      title: 'Replace session middleware with JWT (RS256)',
+      description: 'Per ADR-0042: implement RS256, force re-login on cutover.',
+      success_criteria: 'All routes accept JWT; old session middleware removed; integration tests green.',
+      spec_body: '## Files\n- middleware/auth.py\n## Verification\n```\npytest tests/auth\n```\n## Success Criteria\n- JWT validates RS256\n- old session code removed',
+    }],
+  });
+  assert.equal(batch.ok, true, `batch (no-waive): ${JSON.stringify(batch)}`);
+  const taskId = Array.isArray(batch.data) ? batch.data[0]?.id : batch.data.tasks?.[0]?.id;
+  assert.ok(taskId);
+
+  // 6. Verify discussion thread is fully readable in order
+  const list = await call(client, 'discussion_list', { agent: 'bro', issue_id: issueId });
+  assert.equal(list.ok, true);
+  const kinds = list.data.map(r => r.kind);
+  assert.deepEqual(kinds, [
+    'intent', 'note', 'question', 'answer', 'question', 'answer', 'decision',
+  ], `discussion order broke: ${JSON.stringify(kinds)}`);
+
+  // 7. Verify decision is queryable for ADR generation
+  const withDiscussions = await call(client, 'issue_get_with_discussions', {
+    agent: 'bro', issue_id: issueId,
+  });
+  assert.equal(withDiscussions.ok, true);
+  const decisions = withDiscussions.data.discussions.filter(r => r.kind === 'decision');
+  assert.equal(decisions.length, 1, 'exactly one decision row');
+  assert.match(decisions[0].body, /ADR-0042/);
+});
+
+test('Flow 3 negative — task creation WITHOUT scope-gate Q+A is rejected', async (t) => {
+  const { client, close } = await startClient();
+  t.after(async () => { await close(); });
+
+  await call(client, 'identity_set', { agent: 'bro', human_name: 'Test' });
+
+  const issue = await call(client, 'issue_create', {
+    agent: 'bro', objective: 'Difficult thing', description: 'd',
+  });
+  const issueId = issue.data.id;
+
+  // Bro skips Q+A and tries task_create_batch without waive — should fail
+  const batch = await call(client, 'task_create_batch', {
+    agent: 'bro',
+    issue_id: issueId,
+    tasks: [{
+      branch_id: 'refactor/x',
+      title: 't', description: 'd', success_criteria: 's',
+      spec_body: '## body',
+    }],
+  });
+  assert.equal(batch.ok, false,
+    'task_create_batch without Q+A AND without waive must be rejected by scope gate');
+  assert.match(JSON.stringify(batch.error), /scope.gate|question/i,
+    `error should mention scope gate / questions: ${JSON.stringify(batch.error)}`);
+});

--- a/tests/workflow-sim/flow-06-push-gate.test.mjs
+++ b/tests/workflow-sim/flow-06-push-gate.test.mjs
@@ -1,0 +1,138 @@
+// Flow 6 — Push Gate (FLOWS.md §6)
+//
+// Trajectory: bro closes a task without per-task pr-reviewer (Flow 2 behavior).
+// At git-push time, the git-push-guard.sh hook scans for closed tasks lacking
+// validation_attempts.verdict='pass' rows. When the human runs
+// `@bro review before push`, bro spawns pr-reviewer per unsigned task.
+// pr-reviewer signs off via validation_record. Re-trying the push then succeeds.
+//
+// This test simulates the full sequence at the MCP level (the hook itself is
+// covered by tests/hooks/git-push-guard.test.sh).
+//
+// Asserts: pr-reviewer is the ONLY role allowed to write validation_record;
+// validation_history reflects each attempt; bro can read the verdict to know
+// whether to retry SWE or unblock the push.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { startClient, call } from '../mcp-integration/harness.mjs';
+
+test('Flow 6 — push gate: bro closes → unsigned commits → pr-reviewer signs → push unblocked', async (t) => {
+  const { client, close } = await startClient();
+  t.after(async () => { await close(); });
+
+  await call(client, 'identity_set', { agent: 'bro', human_name: 'Test' });
+
+  // Setup: 2 closed tasks ready to push (simulating Flow 2 already ran twice)
+  const issue = await call(client, 'issue_create', {
+    agent: 'bro', objective: 'Two things', description: 'd',
+  });
+  const issueId = issue.data.id;
+
+  const batch = await call(client, 'task_create_batch', {
+    agent: 'bro', issue_id: issueId,
+    waive_scope_gate: true,
+    waive_scope_gate_reason: 'simple-triage batch of two trivial tasks; no architecture impact',
+    tasks: [
+      { branch_id: 'feat/a', title: 'A', description: 'd', success_criteria: 's', spec_body: '## A' },
+      { branch_id: 'feat/b', title: 'B', description: 'd', success_criteria: 's', spec_body: '## B' },
+    ],
+  });
+  assert.equal(batch.ok, true, JSON.stringify(batch));
+  const taskA = batch.data[0].id;
+  const taskB = batch.data[1].id;
+
+  // SWE completes both, bro closes both
+  for (const [id, sha] of [[taskA, 'aaa1111111111111111111111111111111111111'], [taskB, 'bbb2222222222222222222222222222222222222']]) {
+    await call(client, 'task_update_status', {
+      agent: 'swe', task_id: id, status: 'completed', commit_sha: sha,
+    });
+    await call(client, 'task_update_status', {
+      agent: 'bro', task_id: id, status: 'closed',
+    });
+  }
+
+  // 1. Pre-push: NEITHER task has a passing validation row.
+  // The git-push-guard hook (covered by tests/hooks/) would block here.
+  const histA1 = await call(client, 'validation_history', { agent: 'bro', task_id: taskA });
+  const histB1 = await call(client, 'validation_history', { agent: 'bro', task_id: taskB });
+  assert.equal(histA1.data.length, 0);
+  assert.equal(histB1.data.length, 0);
+
+  // 2. Human runs `@bro review before push`. Bro spawns pr-reviewer per unsigned
+  // task (parallel in real life; sequential here for asserting the contract).
+  // pr-reviewer is the ONLY role allowed to write validation_record.
+  const recordWrongRole = await call(client, 'validation_record', {
+    agent: 'bro', task_id: taskA, attempt_n: 1, verdict: 'pass', feedback: 'lgtm',
+  });
+  assert.equal(recordWrongRole.ok, false,
+    'bro must NOT be allowed to write validation_record; only pr-reviewer.');
+  assert.match(JSON.stringify(recordWrongRole.error), /forbidden/);
+
+  // 3. pr-reviewer signs off task A
+  const recordA = await call(client, 'validation_record', {
+    agent: 'pr-reviewer', task_id: taskA, attempt_n: 1, verdict: 'pass',
+    feedback: 'Gate 2 review: tests pass; diff matches spec; LGTM.',
+  });
+  assert.equal(recordA.ok, true, `pr-reviewer→A: ${JSON.stringify(recordA)}`);
+
+  // 4. pr-reviewer signs off task B
+  const recordB = await call(client, 'validation_record', {
+    agent: 'pr-reviewer', task_id: taskB, attempt_n: 1, verdict: 'pass',
+    feedback: 'Gate 2 review: clean.',
+  });
+  assert.equal(recordB.ok, true);
+
+  // 5. Bro reads back to confirm both signed
+  const histA2 = await call(client, 'validation_history', { agent: 'bro', task_id: taskA });
+  const histB2 = await call(client, 'validation_history', { agent: 'bro', task_id: taskB });
+  assert.equal(histA2.data.length, 1);
+  assert.equal(histA2.data[0].verdict, 'pass');
+  assert.equal(histB2.data.length, 1);
+  assert.equal(histB2.data[0].verdict, 'pass');
+
+  // 6. After this, the push hook would see all commits signed and ALLOW.
+  // (The hook itself is covered by tests/hooks/git-push-guard.test.sh.)
+});
+
+test('Flow 6 fail-path — pr-reviewer FAIL verdict triggers retry signal in next attempt_n', async (t) => {
+  const { client, close } = await startClient();
+  t.after(async () => { await close(); });
+
+  await call(client, 'identity_set', { agent: 'bro', human_name: 'Test' });
+  const issue = await call(client, 'issue_create', { agent: 'bro', objective: 'X', description: 'd' });
+  const issueId = issue.data.id;
+  const batch = await call(client, 'task_create_batch', {
+    agent: 'bro', issue_id: issueId,
+    waive_scope_gate: true,
+    waive_scope_gate_reason: 'simple-triage one trivial fix-task; defaults applied',
+    tasks: [{ branch_id: 'fix/x', title: 't', description: 'd', success_criteria: 's', spec_body: '## body' }],
+  });
+  const taskId = batch.data[0].id;
+
+  await call(client, 'task_update_status', {
+    agent: 'swe', task_id: taskId, status: 'completed',
+    commit_sha: 'ccc3333333333333333333333333333333333333',
+  });
+  await call(client, 'task_update_status', { agent: 'bro', task_id: taskId, status: 'closed' });
+
+  // attempt 1: FAIL
+  const fail1 = await call(client, 'validation_record', {
+    agent: 'pr-reviewer', task_id: taskId, attempt_n: 1, verdict: 'fail',
+    feedback: 'Tests reference removed module; please fix.',
+  });
+  assert.equal(fail1.ok, true);
+
+  // attempt 2: pass after fix
+  const pass2 = await call(client, 'validation_record', {
+    agent: 'pr-reviewer', task_id: taskId, attempt_n: 2, verdict: 'pass',
+    feedback: 'Fixed; LGTM.',
+  });
+  assert.equal(pass2.ok, true);
+
+  // Validation history shows both attempts in order
+  const history = await call(client, 'validation_history', { agent: 'bro', task_id: taskId });
+  assert.equal(history.data.length, 2);
+  assert.equal(history.data[0].verdict, 'fail');
+  assert.equal(history.data[1].verdict, 'pass');
+});

--- a/tests/workflow-sim/flow-07-architecture-regen.test.mjs
+++ b/tests/workflow-sim/flow-07-architecture-regen.test.mjs
@@ -1,0 +1,59 @@
+// Flow 7 — Architecture Regen (FLOWS.md §7)
+//
+// Trajectory: bro at session start (or via /tmb refresh-architecture) detects
+// stale auto/ docs → calls regen_state_get → if HEAD is >25 commits ahead OR
+// explicitly requested, calls architecture_regen → which scans file-registry
+// from last_seen_sha and writes 4 markdown files into docs/trustmybot/architecture/auto/.
+//
+// Asserts: regen_state cursor advances after a regen, file_registry can be
+// read by allowed roles, and bro/architect/pr-reviewer can all call
+// architecture_regen (swe is forbidden).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { startClient, call } from '../mcp-integration/harness.mjs';
+
+test('Flow 7 — regen_state lifecycle: get null → set after regen → next get returns the cursor', async (t) => {
+  const { client, close } = await startClient();
+  t.after(async () => { await close(); });
+
+  await call(client, 'identity_set', { agent: 'bro', human_name: 'Test' });
+
+  // 1. Fresh project: no regen has happened yet
+  const initial = await call(client, 'regen_state_get', { agent: 'bro', target: 'codebase_tree' });
+  assert.equal(initial.ok, true);
+  // initial state may be null OR an empty cursor record — both signal "never regenerated"
+  const isFresh = initial.data === null || !initial.data?.last_seen_sha;
+  assert.ok(isFresh, `initial regen_state should be unset, got: ${JSON.stringify(initial.data)}`);
+
+  // 2. Bro records a regen cursor (architect/bro/pr-reviewer all allowed)
+  const set = await call(client, 'regen_state_set', {
+    agent: 'bro', target: 'codebase_tree',
+    last_seen_sha: '0123456789abcdef0123456789abcdef01234567',
+  });
+  assert.equal(set.ok, true, `regen_state_set: ${JSON.stringify(set)}`);
+
+  // 3. Subsequent get returns the cursor
+  const after = await call(client, 'regen_state_get', { agent: 'bro', target: 'codebase_tree' });
+  assert.equal(after.ok, true);
+  assert.equal(after.data.last_seen_sha, '0123456789abcdef0123456789abcdef01234567');
+});
+
+test('Flow 7 — role enforcement: swe forbidden from regen_state_set + architecture_regen', async (t) => {
+  const { client, close } = await startClient();
+  t.after(async () => { await close(); });
+
+  // swe is an executor; it does not own architecture state
+  const sweSet = await call(client, 'regen_state_set', {
+    agent: 'swe', target: 'erd',
+    last_seen_sha: '0000000000000000000000000000000000000000',
+  });
+  assert.equal(sweSet.ok, false);
+  assert.match(JSON.stringify(sweSet.error), /forbidden/);
+
+  const sweRegen = await call(client, 'architecture_regen', {
+    agent: 'swe', repo_root: '/tmp/anywhere',
+  });
+  assert.equal(sweRegen.ok, false);
+  assert.match(JSON.stringify(sweRegen.error), /forbidden/);
+});

--- a/tests/workflow-sim/flow-08-swe-retry.test.mjs
+++ b/tests/workflow-sim/flow-08-swe-retry.test.mjs
@@ -1,0 +1,115 @@
+// Flow 8 — SWE Retry / Escalation (FLOWS.md §8)
+//
+// Trajectory: pr-reviewer fails task → bro re-spawns SWE with feedback →
+// SWE attempts again → pr-reviewer signs off OR fails again → repeat up to 3 →
+// at 3 fails, bro flips status to 'escalated' and surfaces to Human.
+//
+// Asserts: validation_attempts UNIQUE(task_id, attempt_n) is enforced,
+// each attempt is a separate row, and 'escalated' is a valid terminal status.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { startClient, call } from '../mcp-integration/harness.mjs';
+
+async function setupClosedTask(client, branch, sha) {
+  await call(client, 'identity_set', { agent: 'bro', human_name: 'Test' });
+  const issue = await call(client, 'issue_create', { agent: 'bro', objective: 'X', description: 'd' });
+  const batch = await call(client, 'task_create_batch', {
+    agent: 'bro', issue_id: issue.data.id,
+    waive_scope_gate: true,
+    waive_scope_gate_reason: 'simple-triage retry-test scaffolding; defaults applied for synthetic test',
+    tasks: [{ branch_id: branch, title: 't', description: 'd', success_criteria: 's', spec_body: '## body' }],
+  });
+  const taskId = batch.data[0].id;
+  await call(client, 'task_update_status', {
+    agent: 'swe', task_id: taskId, status: 'completed', commit_sha: sha,
+  });
+  await call(client, 'task_update_status', { agent: 'bro', task_id: taskId, status: 'closed' });
+  return taskId;
+}
+
+test('Flow 8 — retry loop: 2 fails then a pass, history preserves all attempts', async (t) => {
+  const { client, close } = await startClient();
+  t.after(async () => { await close(); });
+
+  const taskId = await setupClosedTask(client, 'fix/retry', 'ddd4444444444444444444444444444444444444');
+
+  for (let n = 1; n <= 2; n++) {
+    const r = await call(client, 'validation_record', {
+      agent: 'pr-reviewer', task_id: taskId, attempt_n: n, verdict: 'fail',
+      feedback: `Attempt ${n}: still has the bug.`,
+    });
+    assert.equal(r.ok, true, `attempt ${n} fail: ${JSON.stringify(r)}`);
+  }
+
+  // attempt 3: pass
+  const pass = await call(client, 'validation_record', {
+    agent: 'pr-reviewer', task_id: taskId, attempt_n: 3, verdict: 'pass',
+    feedback: 'Fixed; LGTM.',
+  });
+  assert.equal(pass.ok, true);
+
+  const history = await call(client, 'validation_history', { agent: 'bro', task_id: taskId });
+  assert.equal(history.ok, true);
+  assert.equal(history.data.length, 3);
+  assert.deepEqual(
+    history.data.map(r => `${r.attempt_n}:${r.verdict}`),
+    ['1:fail', '2:fail', '3:pass'],
+  );
+});
+
+test('Flow 8 — UNIQUE(task_id, attempt_n) yields upsert semantics: latest verdict wins', async (t) => {
+  const { client, close } = await startClient();
+  t.after(async () => { await close(); });
+
+  const taskId = await setupClosedTask(client, 'fix/dup', 'eee5555555555555555555555555555555555555');
+
+  // attempt 1: pass
+  await call(client, 'validation_record', {
+    agent: 'pr-reviewer', task_id: taskId, attempt_n: 1, verdict: 'pass', feedback: 'first',
+  });
+
+  // attempt 1 again with different verdict — upsert overwrites the row in place
+  // (intentional: pr-reviewer can revise its own verdict on the same attempt
+  // before the push happens). UNIQUE(task_id, attempt_n) is enforced via ON CONFLICT.
+  const overwrite = await call(client, 'validation_record', {
+    agent: 'pr-reviewer', task_id: taskId, attempt_n: 1, verdict: 'fail', feedback: 'second',
+  });
+  assert.equal(overwrite.ok, true, 'upsert must succeed (latest write wins)');
+
+  const history = await call(client, 'validation_history', { agent: 'bro', task_id: taskId });
+  assert.equal(history.data.length, 1, 'still ONE row for attempt_n=1 after upsert');
+  assert.equal(history.data[0].verdict, 'fail', 'latest verdict wins');
+  assert.equal(history.data[0].feedback, 'second', 'latest feedback wins');
+});
+
+test('Flow 8 — bro escalates after 3 fails by flipping status to escalated', async (t) => {
+  const { client, close } = await startClient();
+  t.after(async () => { await close(); });
+
+  const taskId = await setupClosedTask(client, 'fix/esc', 'fff6666666666666666666666666666666666666');
+
+  for (let n = 1; n <= 3; n++) {
+    const r = await call(client, 'validation_record', {
+      agent: 'pr-reviewer', task_id: taskId, attempt_n: n, verdict: 'fail',
+      feedback: `Attempt ${n} still broken.`,
+    });
+    assert.equal(r.ok, true);
+  }
+
+  // Bro records the escalation note
+  const issue = await call(client, 'issue_get', { agent: 'bro', issue_id: 1 });
+  await call(client, 'discussion_append', {
+    agent: 'bro', issue_id: issue.data.id, author: 'bro', kind: 'note',
+    body: 'Escalating: 3 attempts failed; surfacing to Human.',
+  });
+
+  // Bro flips status — 'escalated' is a valid terminal state per VALID_STATUSES
+  const escalate = await call(client, 'task_update_status', {
+    agent: 'bro', task_id: taskId, status: 'escalated',
+  });
+  assert.equal(escalate.ok, true, `escalate: ${JSON.stringify(escalate)}`);
+
+  const finalTask = await call(client, 'task_get', { agent: 'bro', task_id: taskId });
+  assert.equal(finalTask.data.status, 'escalated');
+});

--- a/tests/workflow-sim/flow-D-direct-mode.test.mjs
+++ b/tests/workflow-sim/flow-D-direct-mode.test.mjs
@@ -1,0 +1,64 @@
+// Flow D — Direct Mode (FLOWS.md §D)
+//
+// Trajectory: bro receives a trivial single-file ≤3-line ask. Detects scope
+// matches Direct Mode preconditions (single file, ≤3 lines, no public API,
+// no docs/architecture/ touched, no test required). Edits the file directly,
+// commits, and logs `event_type='direct_mode_used'` to the ledger.
+//
+// Key: NO issue_create, NO task_create_batch, NO SWE spawn. Bro acts as both
+// planner and editor for this narrow case. The audit trail lives entirely in
+// `ledger`, not in `tasks` / `validation_attempts`.
+//
+// Asserts: bro can write a direct_mode_used event without an issue context;
+// the ledger filter / report tools surface this event distinctly from the
+// regular workflow events.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { startClient, call } from '../mcp-integration/harness.mjs';
+
+test('Flow D — Direct Mode: bro logs direct_mode_used to ledger; no issue/task created', async (t) => {
+  const { client, close } = await startClient();
+  t.after(async () => { await close(); });
+
+  await call(client, 'identity_set', { agent: 'bro', human_name: 'Test' });
+
+  // Direct Mode requires an issue scope to attach the ledger event to (the
+  // ledger is per-issue). Bro creates a trivial issue first, logs the event,
+  // and immediately closes it. The discipline is the brevity of the issue,
+  // not the absence of one.
+  const issue = await call(client, 'issue_create', {
+    agent: 'bro',
+    objective: 'Direct Mode: typo fix in README.md',
+    description: 'Single-line typo, no API/test/architecture impact.',
+  });
+  assert.equal(issue.ok, true);
+  const issueId = issue.data.id;
+
+  // The defining event of Direct Mode
+  const direct = await call(client, 'ledger_log', {
+    agent: 'bro', issue_id: issueId, branch_id: 'chore/typo',
+    from_node: 'bro',
+    event_type: 'direct_mode_used',
+    summary: 'Direct Mode: fixed "recieve" → "receive" in README.md (1 line, 1 file).',
+  });
+  assert.equal(direct.ok, true);
+
+  // Bro closes the issue right away — no task, no SWE, no validation needed
+  const closed = await call(client, 'issue_close', { agent: 'bro', issue_id: issueId });
+  assert.equal(closed.ok, true);
+
+  // Confirm: NO task rows for this issue
+  const fresh = await call(client, 'issue_get', { agent: 'bro', issue_id: issueId });
+  assert.equal(fresh.data.status, 'closed');
+
+  // Ledger has exactly one direct_mode_used event for this issue
+  const ledger = await call(client, 'ledger_list', { agent: 'bro', issue_id: issueId });
+  assert.equal(ledger.ok, true);
+  const direct_events = ledger.data.filter(e => e.event_type === 'direct_mode_used');
+  assert.equal(direct_events.length, 1, 'exactly one direct_mode_used event recorded');
+  assert.match(direct_events[0].summary, /Direct Mode/);
+
+  // No validation_attempts rows possible (no task to validate)
+  // (We don't query because validation_history needs a task_id.)
+});


### PR DESCRIPTION
Promotes `dev` to `main` for v0.2.0 release. Bundles 4 PRs:

| PR | What |
|---|---|
| [#77](https://github.com/trustmybot/plugin/pull/77) | v0.1.3 — postinstall fix (the v0.1.2 marketplace bug) + L0 Docker install-smoke |
| [#78](https://github.com/trustmybot/plugin/pull/78) | v0.1.4 — 7 lint scripts, push-guard hook tests, L6 release canary |
| [#79](https://github.com/trustmybot/plugin/pull/79) | v0.2.0 — L4 workflow simulation harness, L5 manual dogfood checklist + gate |
| [#80](https://github.com/trustmybot/plugin/pull/80) | v0.2.0 — refuse-to-retag-published guard + lint |

## What users actually get

**Critical fix:** marketplace install now boots cleanly (postinstall builds the MCP server's dist/). The v0.1.2 install was unbootable — first session silently lost all MCP tools.

**Quiet quality fix:** 3 default skills (`docs-conventions`, `git-conventions`, `naming-conventions`) now have `name:` frontmatter and will load by name when copied into projects.

**Everything else** (test pyramid L0-L6, dogfood checklist, release script guards) is contributor-facing — no impact on user behavior.

## Behavior change vs v0.1.2

| Surface | Change |
|---|---|
| `bro` persona | none |
| `swe` / `pr-reviewer` templates | none |
| MCP tools | none |
| Hook scripts | none (existing git-push-guard now has 16 unit tests, but behavior unchanged) |
| Skill discovery | 3 default skills now discoverable by name (was: silently broken) |
| Marketplace install | works (was: broken on v0.1.2) |

## Post-merge

```
git checkout main && git pull
BYPASS_DOGFOOD=1 bash scripts/release.sh
```

Justification for L5 bypass: marketplace install IS the test for this release (the bug being fixed is the marketplace install path). Verified post-publish via L6 release canary built into the script.