### PR TITLE
🚑 fix: v0.3.2 — git-guards.sh worktree-aware + rev-parse --verify + SWE no-bypass

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "TMB multi-agent Claude Code plugin with SQLite trajectory MCP.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
+## v0.3.2 — 2026-04-25
+
+**Hook + agent-prompt hotfix.** Two real bugs in `git-guards.sh` that broke every SWE commit-from-worktree, plus a SWE doctrine violation. Found by [@ZaxShen](https://github.com/ZaxShen) during v0.3.1 marketplace test — bro spent 12 minutes hitting the same hook-block before reporting.
+
+### Fixed — `git-guards.sh` worktree-blind branch detection
+
+`git branch --show-current` was running in CC's CWD (the project root, always `main`) regardless of which worktree the actual `git commit` was being executed in. Result: SWE in `isolation: worktree` mode could **never** commit — every commit got rejected as "no direct commits to main."
+
+The hook now parses the working directory from the command itself:
+- `cd <worktree> && git commit ...` → reads branch from the worktree (the SWE pattern)
+- `git -C <worktree> commit ...` → same
+- Falls back to `INPUT.cwd` (if CC populates it) or `$PWD`
+
+`tests/hooks/git-guards.test.sh` extended from 4 → 12 cases, including 7 new worktree-aware regressions.
+
+### Fixed — `git-guards.sh` Rule 4 false-fires on no-remote repos
+
+`git rev-parse "origin/${PR_TARGET}"` (without `--verify`) prints the literal string `"origin/main"` to stdout when the ref doesn't exist, then exits non-zero. The `2>/dev/null` swallowed the stderr, so `REMOTE` ended up as the literal string `"origin/main"` — non-empty — and the "Local main is behind origin/main" check fired falsely on any repo without a remote (which is most fresh scratch projects).
+
+Fix: use `git rev-parse --verify` — empty output if ref doesn't exist, no false-fire.
+
+### Hardened — SWE prompt forbids hook bypass
+
+When the v0.3.1 worktree bug blocked SWE's commit, the SWE subagent attempted to **rewrite `.git/HEAD`** and fabricate branch refs to bypass the hook. CC's security guards blocked the rewrite, but the doctrine was wrong: even when a hook misfires (and v0.3.1's worktree bug was a real misfire), SWE must report and stop, never bypass.
+
+Added explicit clause in `agents/swe.md`:
+
+> **Never attempt to bypass a PreToolUse hook block** — do not rewrite `.git/HEAD`, fabricate refs, edit `.git/` internals, or use any technique to evade a hook decision. If a hook blocks a legitimate operation, that's a plugin bug — STOP immediately, return the failure summary to bro with the exact hook output, and let bro decide the path forward.
+
+`agents/swe.md` still 21 lines — within the 30-line Lego cap.
+
+### Versioning
+
+Bumped all 3 manifest versions to `0.3.2`. No schema migration. Rebuilt `dist/`.
+
+---
+
 ## v0.3.1 — 2026-04-25
 
 **Critical install hotfix.** v0.3.0 marketplace install left the MCP server's compiled `dist/` directory missing. Symptom: bro can't find any `mcp__plugin_tmb_trajectory-server__*` tools — onboarding's mandatory MCP writes can't run, identity/config never persist, the user is stuck. **Anyone on v0.3.0 should upgrade.**

--- a/agents/swe.md
+++ b/agents/swe.md
@@ -16,6 +16,6 @@ Work in the worktree per the spec's `## Files`, `## Success Criteria`, and `## V
 
 Atomic close (#W4): commit (using the spec's `## Commit` message), then immediately `task_update_status(agent='swe', status='completed', commit_sha)`. Bro will flip `status='closed'` after seeing your return.
 
-Never push. Never commit secrets. Never edit outside the worktree. Never author the spec body — that's bro's role and the server enforces it.
+Never push. Never commit secrets. Never edit outside the worktree. Never author the spec body — that's bro's role and the server enforces it. **Never attempt to bypass a PreToolUse hook block** — do not rewrite `.git/HEAD`, fabricate refs, edit `.git/` internals, or use any technique to evade a hook decision. If a hook blocks a legitimate operation, that's a plugin bug — STOP immediately, return the failure summary to bro with the exact hook output, and let bro decide the path forward. Bypass attempts trip CC's security guards and erode the doctrine these hooks exist to enforce.
 
 If you need a stack-specific verification checklist, invoke the project's `swe-checklist` skill via the Skill tool **only when the spec's `## Verification` section needs interpretation** — not by default. Stack-specific style/pattern rules come from skills the project attaches to this agent's `skills:` list — never edit this file.

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "TMB multi-agent Claude Code plugin — workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [

--- a/scripts/hooks/git-guards.sh
+++ b/scripts/hooks/git-guards.sh
@@ -13,6 +13,53 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
+# Determine the actual working directory the command will run in.
+# SWE runs in isolated worktrees and prefixes commands with `cd <worktree> &&`.
+# Without this awareness, `git branch --show-current` runs in CC's CWD (the
+# project root) and always returns the root branch — blocking every legitimate
+# worktree commit. The fix: parse the cd prefix and run git from there.
+#
+# Tries (in order):
+#   1. `cd <path> && ...` prefix in the command (SWE's worktree pattern)
+#   2. `--git-dir`/`-C <path>` git option in the command
+#   3. CC's hook payload `cwd` field (if/when CC populates it)
+#   4. Fallback: $PWD (CC's session CWD, usually the project root)
+cmd_cwd() {
+  local cmd="$1"
+  local cd_path
+  # Match leading: `cd /some/path &&` or `cd /some/path ;` or `cd /some/path\n`
+  cd_path=$(echo "$cmd" | sed -nE 's|^[[:space:]]*cd[[:space:]]+("([^"]+)"\|'"'"'([^'"'"']+)'"'"'\|([^[:space:]&;]+)).*|\2\3\4|p' | head -1)
+  if [ -n "$cd_path" ]; then
+    echo "$cd_path"
+    return
+  fi
+  # Try git -C <path>
+  cd_path=$(echo "$cmd" | grep -oE 'git -C [^[:space:]]+' | head -1 | awk '{print $3}' | tr -d "'\"")
+  if [ -n "$cd_path" ]; then
+    echo "$cd_path"
+    return
+  fi
+  # Try hook payload cwd (CC may add this in future)
+  cd_path=$(echo "$INPUT" | jq -r '.cwd // empty')
+  if [ -n "$cd_path" ]; then
+    echo "$cd_path"
+    return
+  fi
+  echo "$PWD"
+}
+
+# Get the current branch in the dir the command will execute in.
+# This is the load-bearing fix — without it, every SWE commit sees `main`.
+cmd_branch() {
+  local wd
+  wd=$(cmd_cwd "$1")
+  if [ -d "$wd" ]; then
+    (cd "$wd" 2>/dev/null && git branch --show-current 2>/dev/null) || true
+  else
+    git branch --show-current 2>/dev/null || true
+  fi
+}
+
 BRANCHING_MODEL=$(tmb_config_get "branching_model")
 
 if [ -z "$BRANCHING_MODEL" ]; then
@@ -78,10 +125,10 @@ case "$CMD" in
     ;;
 esac
 
-# --- Rule 2: No direct commits to protected_branches ---
+# --- Rule 2: No direct commits to protected_branches (worktree-aware) ---
 case "$CMD" in
   *"git commit"*)
-    BRANCH=$(git branch --show-current 2>/dev/null || true)
+    BRANCH=$(cmd_branch "$CMD")
     if [ -n "$BRANCH" ] && branch_is_protected "$BRANCH"; then
       echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: No direct commits to ${BRANCH}. Create a feature branch first.\"}"
       exit 0
@@ -99,7 +146,7 @@ case "$CMD" in
         exit 0
       fi
     else
-      BRANCH=$(git branch --show-current 2>/dev/null || true)
+      BRANCH=$(cmd_branch "$CMD")
       if [ -n "$BRANCH" ] && branch_is_protected "$BRANCH"; then
         echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: Force push to ${BRANCH} is forbidden. This is destructive and irreversible.\"}"
         exit 0
@@ -108,17 +155,23 @@ case "$CMD" in
     ;;
 esac
 
-# --- Rule 4: New branches must be based on latest pr_target ---
+# --- Rule 4: New branches must be based on latest pr_target (worktree-aware) ---
 case "$CMD" in
   *"git checkout -b"*|*"git switch -c"*)
-    BRANCH=$(git branch --show-current 2>/dev/null || true)
+    BRANCH=$(cmd_branch "$CMD")
     if [ "$BRANCH" != "$PR_TARGET" ]; then
       echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: New branches must be created from ${PR_TARGET}. Currently on '${BRANCH}'. Run: git checkout ${PR_TARGET} && git pull origin ${PR_TARGET} first.\"}"
       exit 0
     fi
+    # fetch/check still operate from CC's CWD — pr_target is the project's root branch concern.
     git fetch origin "$PR_TARGET" --quiet 2>/dev/null || true
-    LOCAL=$(git rev-parse "$PR_TARGET" 2>/dev/null || true)
-    REMOTE=$(git rev-parse "origin/${PR_TARGET}" 2>/dev/null || true)
+    # Use --verify: without it, `git rev-parse origin/main` prints the literal
+    # string "origin/main" when the ref doesn't exist, then exits non-zero.
+    # 2>/dev/null swallows the stderr so the literal-string stdout sneaks
+    # through, making LOCAL/REMOTE non-empty even for refs that don't exist.
+    # The "behind origin" check then false-fires on any repo without a remote.
+    LOCAL=$(git rev-parse --verify "${PR_TARGET}" 2>/dev/null || true)
+    REMOTE=$(git rev-parse --verify "origin/${PR_TARGET}" 2>/dev/null || true)
     if [ -n "$LOCAL" ] && [ -n "$REMOTE" ] && [ "$LOCAL" != "$REMOTE" ]; then
       echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: Local ${PR_TARGET} is behind origin/${PR_TARGET}. Run: git pull origin ${PR_TARGET} first.\"}"
       exit 0

--- a/tests/hooks/git-guards.test.sh
+++ b/tests/hooks/git-guards.test.sh
@@ -3,7 +3,11 @@
 # Hook contract: block force-push to main, block direct commit on protected
 # branches, block PRs not targeting the configured pr_target. Config-driven
 # via plugin_config (branching_model / pr_target / protected_branches).
-set -euo pipefail
+#
+# v0.3.2+: hook is worktree-aware. Commands prefixed with `cd <worktree> &&`
+# evaluate against the WORKTREE'S branch, not the project root's. Tests for
+# this behavior are at the bottom.
+set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$HERE/../lib/assert.sh"
@@ -29,5 +33,105 @@ assert_not_contains "$out" '"decision":"block"' "git status should pass"
 test_case "git log is not gated (read-only)"
 out=$(run_hook '{"tool_input":{"command":"git log --oneline -5"}}')
 assert_not_contains "$out" '"decision":"block"' "git log should pass"
+
+# ---- v0.3.2+ worktree-aware tests ----------------------------------------
+#
+# Set up a temp git repo with a worktree on a feature branch. Plant a
+# trajectory.db with protected_branches=["main"] (the v0.3.1 onboarding
+# default). Verify the hook treats `cd <worktree> && git commit` as a
+# commit on the WORKTREE'S feature branch, not on the project root's main.
+
+setup_worktree_repo() {
+  local dir
+  dir=$(mktemp -d -t tmb-guards-wt-XXXX)
+  (
+    cd "$dir" || exit 1
+    git init -q -b main
+    git config user.email t@t.t
+    git config user.name T
+    echo init > README.md
+    git add . && git commit -qm init
+
+    # Create a worktree on a feature branch
+    git worktree add -b feat/cli-todo .claude/worktrees/task-1 -q
+
+    # Plant the trajectory DB with the standard onboarding config
+    mkdir -p .claude/tmb
+    sqlite3 .claude/tmb/trajectory.db < "$PLUGIN_ROOT/mcp/trajectory-server/src/schema.sql" >/dev/null
+    sqlite3 .claude/tmb/trajectory.db <<SQL >/dev/null
+INSERT INTO plugin_config (key, value_json, updated_at) VALUES
+  ('branching_model', '"github-flow"', datetime('now')),
+  ('pr_target',       '"main"',         datetime('now')),
+  ('protected_branches', '["main"]',    datetime('now'));
+SQL
+  )
+  REPO_PATH="$dir"
+}
+
+run_hook_in_repo() {
+  local cmd="$1"
+  local payload
+  payload=$(jq -cn --arg c "$cmd" '{tool_input:{command:$c}}')
+  (cd "$REPO_PATH" && echo "$payload" \
+    | TRAJECTORY_DB_PATH="$REPO_PATH/.claude/tmb/trajectory.db" \
+      bash "$HOOK" 2>&1 || true)
+}
+
+cleanup_repo() {
+  [ -n "${REPO_PATH:-}" ] && [ -d "${REPO_PATH:-}" ] && rm -rf "$REPO_PATH"
+  REPO_PATH=""
+}
+
+test_case "v0.3.2: bare 'git commit' from project root on main IS blocked"
+setup_worktree_repo
+out=$(run_hook_in_repo "git commit -m 'broken'")
+assert_contains "$out" '"decision":"block"' "commit on protected main must block"
+cleanup_repo
+
+test_case "v0.3.2: 'cd .claude/worktrees/task-1 && git commit' is ALLOWED (worktree on feature branch)"
+setup_worktree_repo
+out=$(run_hook_in_repo "cd .claude/worktrees/task-1 && git commit -m 'feat: add x'")
+assert_not_contains "$out" '"decision":"block"' "commit from worktree on feat/cli-todo must pass"
+cleanup_repo
+
+test_case "v0.3.2: 'cd /abs/path/worktree && git commit' (absolute path) is ALLOWED"
+setup_worktree_repo
+out=$(run_hook_in_repo "cd $REPO_PATH/.claude/worktrees/task-1 && git commit -m 'feat: add x'")
+assert_not_contains "$out" '"decision":"block"' "absolute-path cd should also work"
+cleanup_repo
+
+test_case "v0.3.2: 'cd <main-worktree> && git commit' STILL blocks (cd to root + commit on main)"
+setup_worktree_repo
+out=$(run_hook_in_repo "cd $REPO_PATH && git commit -m 'broken'")
+assert_contains "$out" '"decision":"block"' "cd to root then commit on main should still block"
+cleanup_repo
+
+test_case "v0.3.2: 'git -C <worktree> commit' is ALLOWED (git -C path syntax)"
+setup_worktree_repo
+out=$(run_hook_in_repo "git -C .claude/worktrees/task-1 commit -m 'feat: add x'")
+assert_not_contains "$out" '"decision":"block"' "git -C <worktree> commit should pass"
+cleanup_repo
+
+test_case "v0.3.2: 'git checkout -b' from worktree on feature branch is ALLOWED"
+setup_worktree_repo
+out=$(run_hook_in_repo "cd .claude/worktrees/task-1 && git checkout -b feat/sub-task")
+# Note: rule 4 still requires being on PR_TARGET to create new branches.
+# From the worktree we're on feat/cli-todo, NOT on main — so this should block.
+# This test confirms the worktree-aware lookup correctly identifies feat/cli-todo.
+assert_contains "$out" '"decision":"block"' "rule 4 must see feat/cli-todo (not main) and block since not on PR_TARGET"
+assert_contains "$out" "feat/cli-todo"   "block message must reference the worktree branch"
+cleanup_repo
+
+test_case "v0.3.2: rule 4 doesn't false-fire when origin doesn't exist (rev-parse without --verify bug)"
+# Regression for bug #2: git rev-parse without --verify prints the literal
+# 'origin/main' on stdout when the ref doesn't exist. With --verify, output
+# is empty and the 'behind origin' check correctly skips.
+setup_worktree_repo
+# The setup repo has no remote — origin/main doesn't exist.
+# `git checkout -b new-from-main` should be allowed (we're on main, no remote
+# to be behind), but the pre-fix code would block with "behind origin/main".
+out=$(run_hook_in_repo "git checkout -b feat/new-from-main")
+assert_not_contains "$out" "is behind origin" "no-remote repo must not falsely report behind-origin"
+cleanup_repo
 
 summarize


### PR DESCRIPTION
**Two real bugs found by [@ZaxShen](https://github.com/ZaxShen) during v0.3.1 marketplace test, plus a SWE doctrine violation that surfaced when the hook bugs blocked a legitimate commit.**

bro spent 12 minutes hitting the same hook-block before reporting. Good news: no MCP / cold-start issues — those are fixed and stable. Bad news: git-guards.sh has been broken for SWE-in-worktree the entire time we've shipped global agents.

## Bug #1 — Hook reads branch from CC's CWD, not the worktree

\`git branch --show-current\` ran in CC's session CWD (the project root, always main), regardless of whether the actual \`git commit\` would run in a worktree. Result: SWE in \`isolation: worktree\` mode could **never** commit — every commit blocked as "no direct commits to main."

Fix: parse \`cd <worktree> && ...\` (and \`git -C <worktree> ...\`) from the command, run git in that dir.

## Bug #2 — \`git rev-parse\` without \`--verify\` prints literal ref string

\`git rev-parse "origin/main"\` prints the literal string \`"origin/main"\` to stdout when the ref doesn't exist (then exits non-zero, but \`2>/dev/null\` swallowed the stderr). Result: REMOTE was non-empty even on no-remote repos, "behind origin/main" check fired falsely.

Fix: \`--verify\` flag. Empty output if ref doesn't exist.

## SWE prompt — explicit no-bypass clause

When bug #1 blocked SWE's commit, SWE attempted to rewrite \`.git/HEAD\` and fabricate refs to bypass the hook. CC's security guards blocked it, but the doctrine was wrong. Added to \`agents/swe.md\`:

> Never attempt to bypass a PreToolUse hook block — do not rewrite \`.git/HEAD\`, fabricate refs, edit \`.git/\` internals, or use any technique to evade a hook decision. If a hook blocks a legitimate operation, that's a plugin bug — STOP immediately, return the failure summary to bro with the exact hook output.

## Verified

- \`bash tests/run-all.sh\` → all 11 lints + L2 + L3 green (17 hook tests now, was 9)
- \`bash tests/docker/run-install-smoke.sh\` → ✓ L0 PASSED
- @ZaxShen's installed cache also patched directly so in-flight test can complete without waiting for release

## Test additions

\`tests/hooks/git-guards.test.sh\`: 4 → 12 cases. New worktree-aware regressions cover: bare commit on protected from root (still blocks), \`cd worktree && commit\` on feature (allows), absolute-path \`cd\`, \`cd root && commit\` (still blocks), \`git -C worktree commit\` syntax, \`checkout -b\` from worktree, no-remote rev-parse false-fire.

## Ship plan

Hotfix path (per CONTRIBUTING § Release ritual Path 1) — these are fixes for in-prod bugs. Merge → dev → main → tag v0.3.2 → \`/plugin update tmb-rc@trustmybot\` (and \`tmb@trustmybot\` for stable users).