### PR TITLE
✨ feat(workflow): three ergonomics fixes (#32 #92 #94)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Claude Code runtime artifacts (worktrees, session state)
 .claude/
+# Exception: shipped project-seed templates that downstream projects copy into
+# their own .claude/ — must be committed, not treated as runtime artifacts.
+!templates/project-seed/.claude/
+!templates/project-seed/.claude/**
 
 # Dogfood-generated artifacts when running CC inside this repo.
 # The plugin's own contributor docs live at docs/architecture/ — so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,37 @@ GH label migration applied: 17 labels → 25 (renames + 9 new K8s `area/*`). All
 
 This is the doctrine half of #38. The DB-side half (`issue_labels` table + 4 MCP tools to mirror GH labels into the trajectory DB) is gated on schema review and ships in a follow-up.
 
+### Workflow ergonomics — three small fixes
+
+#### Bro asks base branch + pulls before branching when remote exists (issue #92)
+
+`tmb_branch-id-proposal` now adds a Step 0: detect `git remote -v` non-empty → `AskUserQuestion` for base branch (pre-selecting `pr_target`) → `git pull origin <base> --ff-only` → then proceed to branch_id derivation. Prevents silently branching off stale `origin/main` in multi-developer repos. No remote configured → step skipped (no concern).
+
+#### Architecture docs bootstrap on small projects (issue #94)
+
+`tmb_lazy-regen-check` previously did nothing on first-ever session, waiting for the Human to manually request `/tmb refresh-architecture`. Tiny dogfood projects rarely cross the 25-commit threshold, so they never got `docs/trustmybot/architecture/auto/` populated.
+
+New behavior: on first-ever session, count source files (`git ls-files | exclude .claude/, node_modules/, dist/, etc.`):
+- 0 files → skip (empty repo)
+- ≤200 files → silent initial bootstrap (cheap, ensures docs/ exists for the first contributor)
+- >200 files → one-line nudge (full bootstrap on a large project can be slow; let Human opt in)
+
+#### Committed team config defaults (issue #32)
+
+Onboarding now reads `.claude/tmb/config.json` if committed:
+
+```json
+{
+  "branching_model": "github-flow",
+  "pr_target": "main",
+  "protected_branches": ["main"]
+}
+```
+
+Values pre-select matching radio options in `AskUserQuestion`, so each new dev confirms team conventions with a single click instead of answering from scratch. The committed file shares team defaults; per-developer DBs still store actual answers locally. Identity (`human_name`) is per-developer and never read from the file.
+
+Template at `templates/project-seed/.claude/tmb/config.example.json`.
+
 ---
 
 ## v0.3.2 — 2026-04-25

--- a/mcp/trajectory-server/docs/CONFIG_KEYS.md
+++ b/mcp/trajectory-server/docs/CONFIG_KEYS.md
@@ -25,3 +25,21 @@ Additional keys can be added to `plugin_config` without schema migration; the ta
 ## 4. Reading-the-Config Policy
 
 Readers MUST treat a missing key as "uninitialized; trigger onboarding flow" — NOT as "default to a safe value". Silent defaults hide configuration drift and mask missing onboarding steps. This is a deliberate design choice.
+
+## 5. Committed team config (optional, issue #32)
+
+A project may commit `.claude/tmb/config.json` to share defaults across developers:
+
+```json
+{
+  "branching_model": "github-flow",
+  "pr_target": "main",
+  "protected_branches": ["main"]
+}
+```
+
+Onboarding reads this file (if present) and **pre-selects matching radio options** in `AskUserQuestion`, so each new dev confirms with a single click instead of answering from scratch. The Human can still override locally; their per-developer DB stores their actual answer. The committed file is NOT auto-rewritten — it changes only when a developer edits it deliberately.
+
+The file lives in version control alongside the code; the per-developer trajectory DB at `.claude/tmb/trajectory.db` remains gitignored. Identity (`human_name`) is per-developer and NEVER read from the committed file.
+
+See `templates/project-seed/.claude/tmb/config.example.json` for a starter template.

--- a/skills/tmb_branch-id-proposal/SKILL.md
+++ b/skills/tmb_branch-id-proposal/SKILL.md
@@ -42,6 +42,50 @@ Format: `<type>/<slug>` where `<slug>` is lowercase alphanumeric + hyphens, max 
 
 ## Protocol
 
+### Step 0 — Base branch confirm + pull (only if git remote is configured)
+
+Before deriving the branch name, confirm the **base** the new branch should be created from. This is the #92 fix: when a remote exists, branching off whatever HEAD happens to point at silently breaks team workflows.
+
+1. Probe for a remote:
+   ```bash
+   REMOTES=$(git remote -v 2>/dev/null | awk '{print $1}' | sort -u)
+   ```
+   If empty → skip Step 0 entirely (no remote, no concern about being behind origin).
+
+2. Read the configured `pr_target` via `config_get(agent='bro', key='pr_target')` and the current branch via `git branch --show-current`.
+
+3. Render this `AskUserQuestion`:
+
+   ```
+   AskUserQuestion({
+     questions: [{
+       question: "Which branch should I create the new feature branch from?",
+       header: "Base branch",
+       multiSelect: false,
+       options: [
+         { label: `${pr_target} (pull origin/${pr_target} first)`,
+           description: `Default — matches your branching model.` },
+         // If current_branch != pr_target, include this option:
+         { label: `${current_branch} (stay on current branch)`,
+           description: `Branch from where you are now.` },
+         // Detect 1-3 other prominent local branches via:
+         //   git for-each-ref --format='%(refname:short)' refs/heads --sort=-committerdate | head -5
+         // Skip if the branch equals pr_target or current_branch (no duplicates).
+       ]
+       // Other lets the Human type any branch name (must exist locally or be fetchable).
+     }]
+   })
+   ```
+
+4. On the answer:
+   - If the chosen base is `${pr_target}` → run `git fetch origin ${pr_target} && git checkout ${pr_target} && git pull origin ${pr_target} --ff-only` before proceeding. This guarantees the new branch is created from latest origin/pr_target, not stale local state.
+   - If a non-pr_target base → switch to it but do NOT auto-pull (the Human picked it deliberately; bro asks before any pull).
+   - On any git error (merge conflict, dirty tree, network) → halt, surface the error to the Human, ask how to proceed. **Do not silently proceed.**
+
+5. Log the base-branch decision: `discussion_append(kind='note', body='Base branch: <chosen_base> (pulled: yes|no)')`.
+
+### Step 1 — Derive + propose branch_id
+
 1. Derive a candidate `branch_id` from the intent using the table above.
 2. Present both the candidate branch_id and the triage label to the Human via `AskUserQuestion` **before bro starts planning**.
 

--- a/skills/tmb_first-run-onboarding/SKILL.md
+++ b/skills/tmb_first-run-onboarding/SKILL.md
@@ -77,9 +77,11 @@ Onboarding completes ONLY after ALL of the following have succeeded AND a final 
 
 **Never narrate a rejection** — only report what the MCP tool actually returned. **Never skip a write** because you think it might fail. If a call errors, retry it. If it keeps erroring, surface the exact error to the Human and ask whether to retry or abort.
 
-## Step 0 — Probe local identity sources (read-only Bash)
+## Step 0 — Probe local identity sources + committed team config (read-only Bash)
 
-Before rendering the AskUserQuestion form, probe the local machine for a name the Human has already set themselves:
+Before rendering the AskUserQuestion form, probe two sources the Human has already set themselves.
+
+### 0a — Local git identity
 
 ```bash
 git config --get user.name   # user's own git identity
@@ -88,6 +90,31 @@ git config --get user.name   # user's own git identity
 Cache the result as `git_user_name` if non-empty. This is **user-set local config**, not CC environment metadata — safe to offer as a pre-populated option.
 
 Do NOT use CC's `# userEmail` / session-level env context to infer a name. That's external metadata the Human hasn't confirmed in this repo.
+
+### 0b — Committed team config (issue #32)
+
+```bash
+TEAM_CFG=".claude/tmb/config.json"
+if [ -f "$TEAM_CFG" ]; then
+  team_branching=$(jq -r '.branching_model // empty' "$TEAM_CFG" 2>/dev/null)
+  team_pr_target=$(jq -r '.pr_target // empty' "$TEAM_CFG" 2>/dev/null)
+  team_protected=$(jq -c '.protected_branches // empty' "$TEAM_CFG" 2>/dev/null)
+fi
+```
+
+If `.claude/tmb/config.json` exists, it's a **committed team-default**. The format:
+
+```json
+{
+  "branching_model": "github-flow",
+  "pr_target": "main",
+  "protected_branches": ["main"]
+}
+```
+
+Use the values to **pre-select the matching radio option** in each onboarding question (so the team default is one click away). The Human can still override locally; their local DB stores their actual answer. The committed file is unchanged unless they explicitly edit it.
+
+Identity (`human_name`) is NEVER read from the committed file — that's per-user.
 
 ## Step 1 — Welcome + name + branching + PR target (one batched AskUserQuestion call)
 

--- a/skills/tmb_lazy-regen-check/SKILL.md
+++ b/skills/tmb_lazy-regen-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tmb_lazy-regen-check
-description: Decide whether to run an incremental architecture regen at session start. Compares HEAD to the last regen cursor; under 25 commits → silent incremental; over 25 → one-line nudge to the user; first-ever session → silent skip.
+description: Decide whether to run an incremental architecture regen at session start. First-ever session on a non-empty project → silent initial bootstrap; under 25 commits since last regen → silent incremental; over 25 → one-line nudge.
 agent: bro
 allowed-tools: Bash, mcp__plugin_tmb_trajectory-server__regen_state_get, mcp__plugin_tmb_trajectory-server__ledger_log
 ---
@@ -18,8 +18,16 @@ Bro invokes this skill once per session — immediately before the pre-scan on t
 ## Procedure
 
 1. Call `regen_state_get(target='file_registry')` and `regen_state_get(target='changelog')`.
-2. If **both** return `null` (first-ever session — no regen has ever run), do NOTHING. A full initial regen may be expensive; wait for the Human to trigger it explicitly via "refresh architecture docs" or the `tmb_refresh-architecture` skill. Do not emit any output.
-3. Otherwise, take the SHA from whichever `regen_state` row has the more recent `last_regen_at` timestamp and run:
+2. If **both** return `null` (first-ever session — no regen has ever run): probe the project's source-file count to decide whether to bootstrap initial docs.
+   ```bash
+   # Count source files (excluding obvious non-source dirs)
+   N=$(git ls-files | grep -vE '^(\.claude/|node_modules/|dist/|build/|\.git/|docs/)' | wc -l | tr -d ' ')
+   ```
+   - If `N == 0` (empty repo) → do nothing, log skip to ledger.
+   - If `N <= 200` (small project, e.g. fresh dogfood scratch) → invoke `tmb_refresh-architecture` with `scope:'initial'` silently. The bootstrap is cheap on small projects and ensures `docs/trustmybot/architecture/auto/` exists for the first contributor / cold session. This addresses #94: tiny projects rarely cross the 25-commit threshold, so they used to never get docs.
+   - If `N > 200` → emit the one-line nudge: *"This project has N source files but no architecture docs yet. Run `/tmb refresh-architecture` to bootstrap them."* Don't auto-regen — full bootstrap on a 1000-file project can be slow.
+
+3. Otherwise (regen has run before), take the SHA from whichever `regen_state` row has the more recent `last_regen_at` timestamp and run:
    ```bash
    git log --oneline <last_seen_sha>..HEAD | wc -l
    ```

--- a/templates/project-seed/.claude/tmb/config.example.json
+++ b/templates/project-seed/.claude/tmb/config.example.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Commit this file as .claude/tmb/config.json to share team defaults across all developers. Onboarding pre-selects matching options for each new dev. Per-developer DBs (.claude/tmb/trajectory.db) remain gitignored. See plugin docs for the full key registry.",
+  "branching_model": "github-flow",
+  "pr_target": "main",
+  "protected_branches": ["main"]
+}


### PR DESCRIPTION
## Summary

Three independent workflow ergonomics fixes from cold-session dogfood. Each is small + isolated; bundled because they're all the same v0.4.1 milestone and touch onboarding/branching/regen skills.

## Issues addressed

### #92 — Bro asks base branch + pulls before branching when remote exists

`tmb_branch-id-proposal` adds a Step 0 (only when `git remote -v` returns non-empty):

1. `AskUserQuestion` for base branch — pre-selects `pr_target` from config
2. Other prominent local branches surfaced as options
3. On confirmation, `git fetch origin <base> && git checkout <base> && git pull origin <base> --ff-only` before proceeding to branch_id
4. Logs the choice via `discussion_append`

No-remote repos skip the step (no concern about being behind origin).

### #94 — Architecture docs bootstrap on small projects

`tmb_lazy-regen-check` previously did NOTHING on first-ever session. Tiny dogfood projects (≤25 commits) never crossed the threshold, so `docs/trustmybot/architecture/auto/` never existed.

New behavior on first-ever session:
- 0 source files → skip (empty repo)
- ≤200 source files → silent initial bootstrap
- >200 source files → one-line nudge (full bootstrap can be slow; opt-in)

Source-file count: `git ls-files | grep -vE '^(\.claude/|node_modules/|dist/|build/|\.git/|docs/)'`.

### #32 — Committed team config defaults

`.claude/tmb/config.json` is now read by onboarding (if present and committed):

```json
{
  "branching_model": "github-flow",
  "pr_target": "main",
  "protected_branches": ["main"]
}
```

Matching radio options pre-select. Per-developer DBs still store actual answers locally; the committed file is shared team convention. Identity (`human_name`) is per-developer and never read from the file.

Template ships at `templates/project-seed/.claude/tmb/config.example.json`. `.gitignore` whitelists the seed dir so the template can be committed even though the runtime `.claude/` is otherwise ignored.

## Test plan

- [x] L1 lint: 13 lints all pass
- [x] L2 unit: 245 unchanged
- [x] L3 hooks: 56/56
- [x] L4 workflow-sim: 14/14
- [ ] L0 install-smoke (CI runs in Docker)
- [ ] Manual dogfood after merge: confirm bootstrap fires on a fresh small project, base-branch question appears with remote, team config pre-selects

## Notes

- Skill changes only; no schema or MCP-tool changes. Schema review still gated for the codebase-memory PR (#45).
- Composes with PR A (bro doctrine refresh) — bro now also writes `bro_verification_pass` ledger event after the V3 verification per #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)