### PR TITLE
📚 docs: add Linear-as-active-tracker banner (TRU-17)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,22 @@
 
 Thanks for the interest. Public MIT-licensed plugin for Claude Code. Contributions welcome — issues, PRs, dogfood reports, all of it.
 
+## Where issues live
+
+**Linear is the active issue tracker** as of 2026-04-26. The full backlog + closed history is mirrored in the [TMB Plugin Linear project](https://linear.app/trustmybot/project/tmb-plugin-ef035f954ad7).
+
+- **File new issues in Linear.** Linear issue IDs look like `TRU-N`.
+- **GitHub issues are read-only.** All 50 historical GH issues are closed-as-migrated with redirects to their Linear counterparts. Do not file new GH issues.
+- **PR discussion stays on GitHub** — code review, CI, merges, releases all happen here.
+- Linear issue references in PR bodies use the form `TRU-N` (no `#` prefix). GitHub auto-renders as plain text.
+
 ## TL;DR
 
-1. Open (or find) a GitHub issue for the change.
-2. Branch off `dev` using `<type>/<issue-number>-<slug>` (see Branching).
+1. Open (or find) a Linear issue (`TRU-N`) for the change.
+2. Branch off `dev` using `<type>/tru-<N>-<slug>` (see Branching).
 3. Make the change + update or add tests.
 4. `bash tests/run-all.sh` — full suite must be green.
-5. Open a PR targeting `dev`. Reference the issue with `Closes #N`.
+5. Open a GitHub PR targeting `dev`. Reference the Linear issue in the body (e.g. `Resolves TRU-N`).
 
 ## Branching
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ TMB turns Claude Code from a clever code-generator into a disciplined engineerin
 
 > **Multi-platform structure, Claude Code today.** TMB ships only the Claude Code adapter as of v0.1.2. Codex / Cursor / OpenCode / Gemini CLI dirs exist as **placeholders** — see [`docs/multi-platform.md`](docs/multi-platform.md). Adapters arrive when there's user demand.
 
+> **Issue tracking lives in Linear.** GitHub issues are no longer the active tracker — the full open backlog + closed history is mirrored in the [TMB Plugin Linear project](https://linear.app/trustmybot/project/tmb-plugin-ef035f954ad7). File new issues there. PR discussion stays on GitHub.
+
 ---
 
 ## Install


### PR DESCRIPTION
## Summary

Closes the doctrine half of [TRU-17](https://linear.app/trustmybot/project/tmb-plugin-ef035f954ad7) (Linear migration tracking).

Migration completed today:
- All 50 GH issues mirrored to Linear (TRU-5 through TRU-54)
- All 13 open GH issues closed-as-migrated with redirects
- All 5 milestones mirrored

## Changes

- `README.md` — banner above install section pointing to Linear for issues
- `CONTRIBUTING.md` — new "Where issues live" section explaining the split:
  - Linear = active issue tracker (file new TRU-N issues there)
  - GitHub = PR discussion only (code review, CI, merges, releases)
  - PR body references use `TRU-N` format

## Why

User asked for Linear migration; PM cost was a stated bottleneck. Linear-primary minimizes ongoing tracking overhead vs dual-write. GitHub keeps its strength (PR review/CI) without competing as a tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)