### PR TITLE
📚 docs: revert Linear-as-tracker banner — GitHub stays public tracker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,22 +2,17 @@
 
 Thanks for the interest. Public MIT-licensed plugin for Claude Code. Contributions welcome — issues, PRs, dogfood reports, all of it.
 
-## Where issues live
-
-**Linear is the active issue tracker** as of 2026-04-26. The full backlog + closed history is mirrored in the [TMB Plugin Linear project](https://linear.app/trustmybot/project/tmb-plugin-ef035f954ad7).
-
-- **File new issues in Linear.** Linear issue IDs look like `TRU-N`.
-- **GitHub issues are read-only.** All 50 historical GH issues are closed-as-migrated with redirects to their Linear counterparts. Do not file new GH issues.
-- **PR discussion stays on GitHub** — code review, CI, merges, releases all happen here.
-- Linear issue references in PR bodies use the form `TRU-N` (no `#` prefix). GitHub auto-renders as plain text.
-
 ## TL;DR
 
-1. Open (or find) a Linear issue (`TRU-N`) for the change.
-2. Branch off `dev` using `<type>/tru-<N>-<slug>` (see Branching).
+1. Open (or find) a GitHub issue for the change.
+2. Branch off `dev` using `<type>/<issue-number>-<slug>` (see Branching).
 3. Make the change + update or add tests.
 4. `bash tests/run-all.sh` — full suite must be green.
-5. Open a GitHub PR targeting `dev`. Reference the Linear issue in the body (e.g. `Resolves TRU-N`).
+5. Open a PR targeting `dev`. Reference the issue with `Closes #N`.
+
+## Label vocabulary
+
+This project uses Linear-native flat labels (`Bug`, `Feature`, `Install`, `Workflow`, `Priority: High`, etc.) — see [`docs/contributing/LABELS.md`](docs/contributing/LABELS.md) for the canonical list and [`docs/contributing/ENUMS.md`](docs/contributing/ENUMS.md) for the matching DB ENUM vocabulary. The label set is enforced by `tests/lint/labels-stable.sh`. When filing an issue, pick from the existing labels — adding a new label is a doctrine change.
 
 ## Branching
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ TMB turns Claude Code from a clever code-generator into a disciplined engineerin
 
 > **Multi-platform structure, Claude Code today.** TMB ships only the Claude Code adapter as of v0.1.2. Codex / Cursor / OpenCode / Gemini CLI dirs exist as **placeholders** — see [`docs/multi-platform.md`](docs/multi-platform.md). Adapters arrive when there's user demand.
 
-> **Issue tracking lives in Linear.** GitHub issues are no longer the active tracker — the full open backlog + closed history is mirrored in the [TMB Plugin Linear project](https://linear.app/trustmybot/project/tmb-plugin-ef035f954ad7). File new issues there. PR discussion stays on GitHub.
-
 ---
 
 ## Install


### PR DESCRIPTION
## Summary

Reverts the README banner + "Where issues live" section added in PR #105.

**Why**: Linear is internal-only (TMB team's workflow tool); public contributors shouldn't need a Linear account or be steered away from GitHub.

## Workflow going forward

- **Public contributors**: file GH issues normally — no Linear knowledge needed
- **TMB team**: mirrors internally to Linear via Linear's GitHub integration (auto-syncs issues, PRs, commits)
- **Label vocabulary**: still Linear-native style (`Bug`, `Feature`, `Install`, `Priority: High`, etc.) — that's about naming, not tracker choice. Kept in CONTRIBUTING.md as a brief pointer to `docs/contributing/LABELS.md`.

## What stays from the migration

- Linear workspace + project (`Trust My Bot` / `TMB Plugin`) — internal use
- 50 mirrored issues (TRU-5..TRU-54) — internal mirror, GH stays the source of truth going forward
- Linear-native label vocabulary (already on GH labels + LABELS.md doctrine)

## Side action

Re-opened the 13 GH issues I closed-as-migrated. Each got a clarifying comment: "Disregard the prior 'closed-as-migrated' note. GitHub remains the public tracker. TMB team mirrors internally to Linear (TRU-N) but contributors don't need a Linear account."

## Setup needed (you, in Linear UI — not API-accessible)

To make the GH→Linear auto-sync work going forward:

1. Go to Linear Settings → Integrations → GitHub
2. Connect `trustmybot/plugin` repo
3. Enable: "Create Linear issues from GitHub issues"
4. Optionally: enable PR auto-linking (PR titles with `TRU-N` link the PR to that issue)

Once enabled, every new GH issue auto-creates a TRU-N. PRs reference TRU-N and Linear surfaces them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)