### PR TITLE
🔧 chore(skills): propagate code-style rules + fix perf emoji

### DIFF
--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -12,6 +12,12 @@ Shared reference for all agents. Each agent uses these criteria at their stage:
 
 ---
 
+## Comments
+
+Code should be self-documenting. Avoid unnecessary comments.
+
+---
+
 ## Error Handling
 
 ### Design-time questions (bro)

--- a/skills/git-conventions/SKILL.md
+++ b/skills/git-conventions/SKILL.md
@@ -8,7 +8,7 @@ agent: bro, swe, pr-reviewer
 
 ## Commit Message Style
 
-Use Conventional Commits with an emoji prefix. Examples:
+Use Conventional Commits with an emoji prefix. Emoji per [gitmoji.dev](https://gitmoji.dev/) — the de facto standard:
 
 ```
 ✨ feat(api): add /users endpoint
@@ -16,9 +16,15 @@ Use Conventional Commits with an emoji prefix. Examples:
 📝 docs(readme): clarify install steps
 ♻️ refactor(parser): extract URL canonicalizer
 ✅ test(orders): cover refund path
-🔥 perf(query): batch N+1 lookups
+⚡ perf(query): batch N+1 lookups
 🔧 chore(ci): bump node version
+📦 build(deps): bump bun to 1.3
+👷 ci(workflow): add Node 22 matrix
+💄 style(button): align padding
+⏪ revert(api): roll back /users endpoint
 ```
+
+**Don't invent emoji.** If the type isn't covered above, look it up on gitmoji.dev — that's the authoritative source.
 
 ## Two review gates
 


### PR DESCRIPTION
## Summary

Two small fixes; no issue, no milestone (too small to track).

### Fix 1 — Propagate "no comments" rule to SWE

The "Code should be self-documenting. Avoid unnecessary comments." rule was only in plugin's CLAUDE.md (bro persona). SWE doesn't load CLAUDE.md, so it never saw the rule explicitly.

**Fix**: added the rule to the `code-quality` skill, which all three workflow agents (bro + swe + pr-reviewer) load. Now SWE inherits it.

### Fix 2 — Wrong emoji for `perf`

Our `git-conventions` skill listed `🔥 perf(query): ...` — but per [gitmoji.dev](https://gitmoji.dev/) (the authoritative source), 🔥 means "Remove code or files". Performance is ⚡.

**Fix**: changed example to `⚡ perf(query): batch N+1 lookups`. Added build/ci/style/revert examples so the common types are visible at a glance. Added a "don't invent emoji; gitmoji.dev is the source" note.

## Test plan

- [x] L1-L4 pass
- [ ] L0 (CI Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)