### PR TITLE
🔍 debug(l6): expose claude -p output to CI logs (#116)

### DIFF
--- a/tests/dogfood/flows/01-onboarding/run.sh
+++ b/tests/dogfood/flows/01-onboarding/run.sh
@@ -12,5 +12,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "empty"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/02-simple-task/run.sh
+++ b/tests/dogfood/flows/02-simple-task/run.sh
@@ -15,5 +15,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "onboarding-named"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/03-difficult-task/run.sh
+++ b/tests/dogfood/flows/03-difficult-task/run.sh
@@ -24,5 +24,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/04-agent-creator/run.sh
+++ b/tests/dogfood/flows/04-agent-creator/run.sh
@@ -24,5 +24,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/05-skill-creation/run.sh
+++ b/tests/dogfood/flows/05-skill-creation/run.sh
@@ -24,5 +24,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/06-push-gate/run.sh
+++ b/tests/dogfood/flows/06-push-gate/run.sh
@@ -24,5 +24,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/07-architecture-regen/run.sh
+++ b/tests/dogfood/flows/07-architecture-regen/run.sh
@@ -24,5 +24,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/08-swe-retry/run.sh
+++ b/tests/dogfood/flows/08-swe-retry/run.sh
@@ -24,5 +24,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/09-roundtable/run.sh
+++ b/tests/dogfood/flows/09-roundtable/run.sh
@@ -24,5 +24,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/32-team-config/run.sh
+++ b/tests/dogfood/flows/32-team-config/run.sh
@@ -24,5 +24,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/92-base-branch/run.sh
+++ b/tests/dogfood/flows/92-base-branch/run.sh
@@ -24,5 +24,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/94-arch-bootstrap/run.sh
+++ b/tests/dogfood/flows/94-arch-bootstrap/run.sh
@@ -24,5 +24,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/95-anonymous-cold-restart/run.sh
+++ b/tests/dogfood/flows/95-anonymous-cold-restart/run.sh
@@ -12,5 +12,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "onboarding-anonymous"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/96-halt-on-error/run.sh
+++ b/tests/dogfood/flows/96-halt-on-error/run.sh
@@ -24,5 +24,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/C-consultant/run.sh
+++ b/tests/dogfood/flows/C-consultant/run.sh
@@ -24,5 +24,5 @@ PROJECT=$(l6_setup_scratch_project)
 trap 'l6_cleanup_project "$PROJECT"' EXIT
 
 l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/D-direct-mode/run.sh
+++ b/tests/dogfood/flows/D-direct-mode/run.sh
@@ -17,5 +17,5 @@ l6_seed_db "$PROJECT" "onboarding-named"
 ( cd "$PROJECT" && echo "We recieve patches via PRs." > README.md
   git add . && git commit -qm "chore: add typo'd line" )
 
-l6_run_claude "$PROJECT" "$PROMPT" >/dev/null
+l6_run_claude "$PROJECT" "$PROMPT"
 l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/lib/flow-helpers.sh
+++ b/tests/dogfood/lib/flow-helpers.sh
@@ -36,14 +36,22 @@ l6_seed_db() {
 
 # l6_run_claude <project_dir> <prompt>: runs `claude -p` against the prompt
 # in the project, with TMB_DEBUG_TRAJECTORY=1, plugin loaded via --plugin-dir.
-# Returns exit code from claude.
+# Echoes claude's stdout + stderr to OUR stderr so CI logs capture them
+# (otherwise diagnosis is impossible — see issue #116). Always returns 0
+# so the test can score the trajectory regardless of claude's exit code.
 l6_run_claude() {
   local dir="$1" prompt="$2"
   (
     cd "$dir" || exit 1
     export TMB_DEBUG_TRAJECTORY=1
     export CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}"
-    timeout 180 claude --plugin-dir "$PLUGIN_ROOT" -p "$prompt" 2>&1 | tail -50 || true
+    echo "  ── claude invocation start ──" >&2
+    echo "  cwd: $dir" >&2
+    echo "  plugin-dir: $PLUGIN_ROOT" >&2
+    echo "  prompt: $prompt" >&2
+    timeout 180 claude --plugin-dir "$PLUGIN_ROOT" -p "$prompt" 2>&1 \
+      | sed 's/^/  [claude] /' >&2 || true
+    echo "  ── claude invocation end (exit was masked) ──" >&2
   )
 }
 

--- a/tests/dogfood/run-l6.sh
+++ b/tests/dogfood/run-l6.sh
@@ -36,6 +36,33 @@ for cmd in claude sqlite3 jq; do
   fi
 done
 
+# ----- Pre-flight diagnostics (issue #116) -----
+# First L6 run on dev (run id 24963880924) showed all 4 wired flows
+# producing 0 trajectory rows + 0 tokens. Adding cheap diagnostics here
+# to identify which layer breaks (auth / -p mode / plugin load / bro
+# trigger) BEFORE running the expensive flow tests.
+printf "\n=== Pre-flight: claude --version ===\n"
+claude --version 2>&1 | sed 's/^/  /' || echo "  ✗ claude --version failed"
+
+printf "\n=== Pre-flight: claude -p basic auth check ===\n"
+echo "  Calling: claude -p \"say hello in one word\" (no plugin, no env)"
+DIAG_OUT=$(timeout 30 claude -p "say hello in one word" 2>&1 | head -20)
+DIAG_RC=$?
+echo "$DIAG_OUT" | sed 's/^/  [output] /'
+echo "  exit code: $DIAG_RC"
+if [ -z "$DIAG_OUT" ]; then
+  echo "  ⚠️  empty output — auth likely silently failed"
+fi
+
+printf "\n=== Pre-flight: claude --plugin-dir loading check ===\n"
+echo "  Calling: claude --plugin-dir <root> -p \"say hi in one word\" (plugin loaded, no bro)"
+DIAG_OUT2=$(timeout 60 claude --plugin-dir "$PLUGIN_ROOT" -p "say hi in one word" 2>&1 | head -20)
+DIAG_RC2=$?
+echo "$DIAG_OUT2" | sed 's/^/  [output] /'
+echo "  exit code: $DIAG_RC2"
+
+printf "\n=== Pre-flight done ===\n"
+
 PASS=0
 FAIL=0
 FAILED_FLOWS=()


### PR DESCRIPTION
Diagnostic PR for #116. Doesn't fix the L6 failure — gathers info to identify which layer breaks.

## Problem (#116)

First L6 run on dev produced 0 trajectory rows + 0 tokens for all 4 wired flows. Runner suppressed claude's output via \`>/dev/null\` — we have no idea what claude was doing.

## What this PR adds

1. **Strip output suppression** from 16 flow scripts (\`l6_run_claude ... >/dev/null\` → \`l6_run_claude ...\`)
2. **Wrap claude output with \`[claude]\` prefix** on CI's stderr
3. **Pre-flight diagnostic steps** in \`run-l6.sh\`:
   - \`claude --version\` (binary present?)
   - \`claude -p "say hello in one word"\` (auth works in -p mode?)
   - \`claude --plugin-dir <root> -p "say hi in one word"\` (plugin loads in -p?)

## What we expect to learn

After CI runs this on dev, the logs will show:
- If pre-flight #1 fails → \`claude\` not installed in CI
- If pre-flight #2 fails → auth broken (token format / not recognized)
- If pre-flight #2 succeeds + #3 fails → \`--plugin-dir\` doesn't work in -p mode
- If both succeed but flows still fail → bro persona trigger not engaging in -p mode

Each finding has a different fix.

## Cost

~$0 if any pre-flight fails (no completion). ~$0.30 if all 3 pre-flights succeed + 4 wired flows run.

## After this

Based on the diagnostic output, follow-up PR (or comment on #116) to fix the broken layer. May lead to:
- L6 v3 with a different invocation pattern
- Falling back to L5+L6 combined Docker (which uses marketplace install path, not \`--plugin-dir\`)
- Documenting that L6 requires interactive mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)