### PR TITLE
🐛 fix(ci): escape ${{ in composite action description

### DIFF
--- a/.github/actions/verify-cc-auth/action.yml
+++ b/.github/actions/verify-cc-auth/action.yml
@@ -1,17 +1,5 @@
 name: 'Verify Claude Code auth'
-description: |
-  Prerequisite check for any workflow that needs to invoke `claude` in CI.
-  Inspects the OAuth token shape, installs Claude Code if needed, runs
-  `claude -p "say hi"` to confirm auth works END-TO-END.
-
-  Fail-fast pattern: if auth is broken (bad token, wrong format, network),
-  the consuming workflow's expensive steps (Docker builds, plugin
-  installs, multi-flow L6 runs) never start.
-
-  Usage:
-    - uses: ./.github/actions/verify-cc-auth
-      with:
-        token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+description: 'Prerequisite check for any workflow that needs to invoke claude in CI. Inspects token shape, installs CC if needed, runs claude -p smoke test. Fail-fast — broken auth never reaches expensive Docker builds or multi-flow L6 runs. See action source for usage.'
 
 inputs:
   token:


### PR DESCRIPTION
Hotfix for #118.

## Bug

PR #118's composite action loaded with:
\`\`\`
##[error]/home/runner/work/plugin/plugin/./.github/actions/verify-cc-auth/action.yml (Line: 2, Col: 14): Unrecognized named-value: 'secrets'.
\`\`\`

The \`description:\` field literally contained \`token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}\` as a usage example. GitHub Actions evaluates expressions even inside the description field — and composite actions don't have access to the \`secrets\` context (only \`inputs\`), so the action loader exploded.

## Fix

Strip the \`\${{ secrets... }}\` example out of the description field. Keep description as plain prose.

(Could also have escaped via \`\$\${{...}}\` but removing the example is cleaner — anyone reading the action source sees the inputs schema directly.)

## Verify

After merge, re-trigger \`gh workflow run l6-dogfood.yml --ref dev\`. The composite should load and run the auth check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)