### PR TITLE
🔒 ci: restrict L6/L5+L6 token-heavy tests to RC tags + dev/rc dispatch

### DIFF
--- a/.github/workflows/l5-l6-combined.yml
+++ b/.github/workflows/l5-l6-combined.yml
@@ -1,13 +1,14 @@
-name: L5+L6 combined (release-only)
+name: L5+L6 combined (RC-only)
 
 # L5+L6 combined Docker test (#112). Builds a Docker image that simulates
 # CC's marketplace install path (`bun install --ignore-scripts`), then runs
 # L6 deterministic-trajectory flows against the marketplace-installed
 # plugin — catching BOTH install-path bugs and workflow doctrine bugs.
 #
-# Why release-only: each run uses real Claude tokens (~$1-3 per full
-# 4-flow execution). Per user policy: token-heavy tests run on tag
-# pushes and manual dispatch only, NOT on every PR.
+# Why RC-only: each run uses real Claude tokens (~$1-3 per full 4-flow
+# execution). Token-heavy tests run on RC tag pushes and manual dispatch
+# from dev/rc only — NOT on stable v* tags from main (main is already
+# validated upstream).
 #
 # Replaces manual L5 dogfood for everything except UX-only verification.
 #
@@ -20,10 +21,13 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - 'v*'
+      - 'v*-rc.*'
 
 jobs:
   l5-l6-combined:
+    if: |
+      (github.event_name == 'workflow_dispatch' && (github.ref_name == 'dev' || github.ref_name == 'rc')) ||
+      (github.event_name == 'push' && contains(github.ref, '-rc.'))
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/l6-dogfood.yml
+++ b/.github/workflows/l6-dogfood.yml
@@ -3,13 +3,14 @@ name: L6 dogfood (deterministic trajectory)
 # L6 runs real Claude Code through pre-seeded TMB flows and asserts the
 # resulting MCP/tool trajectory matches FLOWS.md. Issue #108.
 #
-# Triggers:
-#   - manual via workflow_dispatch (always available)
-#   - tag pushes (every release gets a green/red signal)
+# Triggers (token-heavy: ~$1-3 per full run, restricted to pre-prod refs):
+#   - workflow_dispatch from `dev` or `rc` only (not main — main is
+#     post-validation, no test budget should be spent there)
+#   - RC tag pushes matching `v*-rc.*` (every RC cut gets a green/red signal)
 #   - PR labeled `L6` (opt-in for risky doctrine changes)
 #
-# Skipped on forks where the secret isn't available — the secret-presence
-# check fails-soft instead of breaking the run.
+# Stable `v*` tags from main do NOT trigger this — main is validated
+# upstream on dev/rc, and stable cuts are already-known-good.
 #
 # Security note: untrusted PR-injected strings (titles, bodies, etc.) are
 # never interpolated into shell commands. Only secrets and trusted runner
@@ -19,13 +20,16 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - 'v*'
+      - 'v*-rc.*'
   pull_request:
     types: [labeled]
 
 jobs:
   l6-dogfood:
-    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'L6' }}
+    if: |
+      (github.event_name == 'workflow_dispatch' && (github.ref_name == 'dev' || github.ref_name == 'rc')) ||
+      (github.event_name == 'push' && contains(github.ref, '-rc.')) ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'L6')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,32 @@ When a change could plausibly break users (the v0.2.0/v0.3.0 install-path class,
 
 Path 1 is for fixes that don't need cold-start verification (e.g. doc-only releases). Path 2 is for everything else — especially anything touching install behavior, schema, or agent doctrine. **The v0.2.0 and v0.3.0 breakages happened because we shipped install-path changes via Path 1 with no real-world install verification.** Going forward, anything in those categories MUST go through `tmb-rc` first.
 
+## Branch protection + CI scope
+
+GitHub-side guardrails that match the doctrine above. The intent is "validation budget gets spent on dev/rc; main is already-known-good."
+
+### Branch protection (applied via `gh api`)
+
+| Branch | PR required | Status checks required | Force push | Delete | Why |
+|---|---|---|---|---|---|
+| `main` | ✓ | `lint + MCP unit + integration + hooks`, `L0 install-smoke (cold-start Docker)` | blocked | blocked | Production tip. Only path in is `dev → main` PR. Tags live here forever. |
+| `rc` | ✗ (fast-forward only) | — | allowed (force-with-lease) | blocked | Floating ref onto immutable RC tags. The release ritual rewrites it; protect the ref name from accidental delete. |
+| `dev` | ✗ | `lint + MCP unit + integration + hooks`, `L0 install-smoke (cold-start Docker)` (on PRs only) | blocked | blocked | Integration trunk. Direct doctrine pushes allowed (solo dev velocity), but force-push and delete blocked to prevent history loss. |
+
+No required-approvals (solo dev). Once a second maintainer joins, flip `required_approving_review_count: 1` on `main` + `rc`.
+
+### Workflow scope by trigger
+
+| Workflow | Triggers | Branches/refs | Cost |
+|---|---|---|---|
+| `test.yml` (L0–L4) | `push` to `dev`/`main`, `pull_request` to `dev`/`main` | dev, main, PRs | free |
+| `l6-dogfood.yml` | `workflow_dispatch` (dev/rc only), `push` tags `v*-rc.*`, `pull_request` labeled `L6` | RC tags + dev/rc dispatch | ~$1–3/run |
+| `l5-l6-combined.yml` | `workflow_dispatch` (dev/rc only), `push` tags `v*-rc.*` | RC tags + dev/rc dispatch | ~$1–3/run |
+
+Stable `v*` tags from main do **not** fire token-heavy tests — that validation already happened on the matching `v*-rc.*` cut. Spending tokens on a known-good cut is waste.
+
+`verify-cc-auth` composite action runs as the first step of any CC-using workflow — fail-fast on broken token before Docker builds or multi-flow runs.
+
 ## Writing code
 
 - Self-documenting code. Prefer deletion over addition.


### PR DESCRIPTION
## Summary

- Stable `v*` tags from `main` no longer trigger token-heavy L6 / L5+L6 workflows (~\$1–3/run each). That validation already happened on the matching `v*-rc.*` cut — spending tokens on a known-good cut is waste.
- Trigger matrix tightened on both `l6-dogfood.yml` and `l5-l6-combined.yml`:
  - `push` tags: `'v*'` → `'v*-rc.*'`
  - `workflow_dispatch`: job-level `if` gate restricts to `github.ref_name == 'dev' || 'rc'`
- `l6-dogfood.yml` keeps the PR-labeled `L6` opt-in for risky doctrine changes.
- `l5-l6-combined.yml` workflow name updated `release-only` → `RC-only` to match actual scope.
- New `Branch protection + CI scope` section in `CONTRIBUTING.md` codifies the workflow trigger matrix and the upcoming branch protection rules (applied separately via `gh api`).

## Why now

User policy: \"Token heavy tests only allow on dev or rc prefix? Not main since main is the final prod. Main shouldn't need any test because everything must test on dev branch.\" This PR matches CI to that policy.

## Test plan

- [x] YAML parses (workflow file edit, no syntax change)
- [ ] Confirm next stable v* tag from main does NOT fire l6-dogfood / l5-l6-combined
- [ ] Confirm next v*-rc.* tag DOES fire both
- [ ] Confirm `gh workflow run l6-dogfood.yml --ref dev` succeeds; `--ref main` is no-op (job skipped)