### PR TITLE
🐛 fix(l6): grant headless permissions + preserve scratch dirs for artifact upload

### DIFF
--- a/.github/workflows/l6-dogfood.yml
+++ b/.github/workflows/l6-dogfood.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Run L6 dogfood flows
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          L6_KEEP_ARTIFACTS: '1'
         run: bash tests/dogfood/run-l6.sh
 
       - name: Upload trajectory dumps on failure

--- a/tests/dogfood/lib/flow-helpers.sh
+++ b/tests/dogfood/lib/flow-helpers.sh
@@ -39,6 +39,11 @@ l6_seed_db() {
 # Echoes claude's stdout + stderr to OUR stderr so CI logs capture them
 # (otherwise diagnosis is impossible — see issue #116). Always returns 0
 # so the test can score the trajectory regardless of claude's exit code.
+#
+# `--dangerously-skip-permissions` is required: in headless `-p` mode
+# claude blocks every tool call (Bash, Edit, MCP) until a human approves
+# them, and there is no human in the loop here. The scratch dir is a
+# fresh mktemp-d, so there's nothing to harm.
 l6_run_claude() {
   local dir="$1" prompt="$2"
   (
@@ -49,7 +54,7 @@ l6_run_claude() {
     echo "  cwd: $dir" >&2
     echo "  plugin-dir: $PLUGIN_ROOT" >&2
     echo "  prompt: $prompt" >&2
-    timeout 180 claude --plugin-dir "$PLUGIN_ROOT" -p "$prompt" 2>&1 \
+    timeout 180 claude --plugin-dir "$PLUGIN_ROOT" --dangerously-skip-permissions -p "$prompt" 2>&1 \
       | sed 's/^/  [claude] /' >&2 || true
     echo "  ── claude invocation end (exit was masked) ──" >&2
   )
@@ -77,8 +82,11 @@ l6_score_flow() {
 }
 
 # l6_cleanup_project <project_dir>: removes the scratch directory.
+# When L6_KEEP_ARTIFACTS=1, becomes a no-op so the workflow's
+# upload-artifact step can collect the trajectory DB after a failure.
 l6_cleanup_project() {
   local dir="$1"
+  [ "${L6_KEEP_ARTIFACTS:-0}" = "1" ] && return 0
   [ -n "$dir" ] && [ -d "$dir" ] && rm -rf "$dir"
 }
 


### PR DESCRIPTION
## Summary

Run [#24966477600](https://github.com/trustmybot/plugin/actions/runs/24966477600) confirmed L6 now reaches `claude -p` end-to-end (auth ✓), but all 4 wired flows fail with the same root cause: **headless mode blocks every tool call without permission grants.**

Smoking-gun output:
- `01-onboarding`: \`[claude] Hey! I need MCP tool permissions to check onboarding status. Could you approve those...\`
- `D-direct-mode`: \`[claude] The edit was blocked — you'll need to grant permission to write to /tmp/tmb-l6-sW2r/README.md\`

Two-fix:

1. **`--dangerously-skip-permissions`** added to \`l6_run_claude\`. CI uses a fresh \`mktemp\` scratch dir per flow — there's no production data to harm. Without this, bro can't even call \`identity_get\` to start the first-action chain.

2. **\`L6_KEEP_ARTIFACTS=1\`** set in the L6 workflow. The per-flow \`trap '... EXIT'\` was deleting \`/tmp/tmb-l6-*/\` before \`upload-artifact\` ran, producing \`No files were found with the provided path\`. \`l6_cleanup_project\` now no-ops when this env is set, so trajectory DBs survive for post-mortem.

## Test plan

- [ ] Re-run l6-dogfood.yml on dev after merge
- [ ] Confirm \`outcome\` scorers go from 0/N to ≥1/N for the 4 wired flows
- [ ] Confirm \`l6-trajectory-dumps\` artifact contains \`trajectory.db\` files
- [ ] Diagnose any remaining outcome failures from the artifact contents (separate PR)

Note: token capture (\`tokens_in\`/\`tokens_out\` columns) is still NULL in \`debug_trajectory\` — that's a feature gap (MCP server doesn't capture claude's per-call usage), tracked separately. Cost scorer reports 0 tokens until that lands.