### PR TITLE
🔍 fix(l6): upload-artifact include-hidden-files=true so trajectory.db survives

### DIFF
--- a/.github/workflows/l6-dogfood.yml
+++ b/.github/workflows/l6-dogfood.yml
@@ -59,3 +59,7 @@ jobs:
           name: l6-trajectory-dumps
           path: /tmp/tmb-l6-*/
           retention-days: 7
+          # The trajectory DB lives at .claude/tmb/trajectory.db — without
+          # this flag upload-artifact skips dot-prefixed paths and we lose
+          # the only useful diagnostic.
+          include-hidden-files: true


### PR DESCRIPTION
## Summary

Run [#24966708851](https://github.com/trustmybot/plugin/actions/runs/24966708851) confirmed `L6_KEEP_ARTIFACTS=1` worked — the per-flow scratch dirs survived the trap cleanup. But the uploaded \`l6-trajectory-dumps\` artifact contained only \`README.md\` files, no \`.claude/tmb/trajectory.db\`.

Root cause: \`actions/upload-artifact@v4\` defaults \`include-hidden-files\` to \`false\`. \`.claude/\` is dot-prefixed → the entire DB tree gets filtered out at upload.

Setting \`include-hidden-files: true\` so post-mortem can actually inspect the trajectory DB.

## Followup (separate PR — needs design)

The full run revealed deeper issues that the artifact will help diagnose:

- **01-onboarding** — bro tries \`AskUserQuestion\` (no human in headless \`-p\` → errors out). The onboarding flow contract assumes a human in the loop. Need either a headless-mode bypass in bro, or seed identity+config in the fixture so onboarding doesn't trigger.
- **02-simple-task** — bro proposes branch and stalls waiting for user "Yes, proceed". Same human-in-the-loop assumption.
- **D-direct-mode** — bro went the full planning flow for a 1-line typo fix instead of triggering Direct Mode. Doctrine bug in the prompt.
- **95-anonymous-cold-restart** — bro skipped the first-action chain entirely (no \`identity_get\`, \`config_get\`, \`issue_resume\`) and just responded "Hey I'm bro". Per CLAUDE.md these calls are mandatory.

These are separate from this PR — this one just unblocks observability.