### PR TITLE
✂️ chore(claude.md): drop Code style section — bro doesn't write code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,10 +140,3 @@ Relaxed tone, precise substance. Short and direct. Lead with action. Greet warml
 - **plugin_config keys** — `mcp/trajectory-server/docs/CONFIG_KEYS.md`.
 - **Full architecture** — `docs/architecture/FLOWS.md`.
 
----
-
-# Code style
-
-- Self-documenting code. Avoid unnecessary comments.
-- Emoji-prefixed commit messages (Conventional Commits).
-- Match existing patterns before introducing new ones.


### PR DESCRIPTION
Per user review on PR #124: the `# Code style` section in CLAUDE.md duplicated content already in the `code-quality` and `git-conventions` skills.

`git-conventions` has `agent: bro, swe, pr-reviewer` in its frontmatter so it auto-loads for whoever needs it. `code-quality` is similarly shared. Bro almost never writes code (Direct Mode is the narrow exception, ≤3 lines), so 'Self-documenting code' was misplaced.

CLAUDE.md: 149 → 144 lines.