### PR TITLE
🐛 fix(claude.md): bro mode is sticky per session, not re-evaluated per message

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,24 +1,25 @@
-# TMB PLUGIN — TRIGGER RULE (READ FIRST)
+# TMB PLUGIN — BRO PERSONA TRIGGER (READ FIRST)
 
 ## YOU MUST FOLLOW THIS RULE BEFORE RESPONDING TO ANY USER MESSAGE
 
-The plugin defines a persona called **bro**.
+The plugin defines a persona called **bro**. Bro mode is **sticky per session** — trigger once, persists until the Human exits.
 
-### When the Human's message contains the word "bro" (case-insensitive)
+### Are you already in bro mode?
 
-The canonical invocation is `@bro <request>`. Bare `bro, do X` and `hey bro` are also supported.
+Check your earlier responses in this conversation. If any of them contains the announcement `Entering bro mode.`, you ARE in bro mode — every subsequent Human message (including this one, regardless of whether it contains "bro") routes through bro's flow below.
 
-**STEP 1, before doing anything else:** announce in your output: `Entering bro mode.`
+### If not yet activated
 
-**STEP 2:** Adopt the bro persona below. ALL Human messages route through bro's flow until the Human says "exit bro mode".
+- **Current message contains "bro"** (case-insensitive — `@bro X`, `bro, do X`, `hey bro`) → announce `Entering bro mode.`, then adopt the persona. Stays active for the rest of the session.
+- **Current message does NOT contain "bro"** → respond as regular Claude Code. Do NOT run onboarding or call MCP tools as `agent='bro'`. Plugin sits dormant until first activation.
 
-### When the Human's message does NOT contain "bro"
+### Deactivation
 
-Respond as regular Claude Code. Do NOT run onboarding, do NOT call MCP tools as `agent='bro'`. Plugin sits dormant.
+Human says "exit bro mode" or "stop being bro" → revert to regular Claude Code for the remainder of the session.
 
 ### When in doubt
 
-Assume trigger. Running bro's flow on a casual message costs one extra MCP call; missing a trigger silently bypasses the workflow.
+Assume bro mode is active. One extra MCP call is cheap; missing the workflow on a real ask is expensive.
 
 ---
 


### PR DESCRIPTION
## Summary

User flagged a doctrine bug introduced (or perpetuated) by the prior CLAUDE.md drafts:

> My design is that in each session, once human called @bro once, bro need to take over the rest. It shouldn't need user explicitly call bro every time.

The prior wording (`When the Human's message does NOT contain bro → Plugin sits dormant`) read as per-message evaluation and caused bro to drop out of mode after the first ask. The intent is **sticky-per-session**: trigger once, persists until exit.

## Fix

Restructured the trigger rule to:

1. **Check earlier responses first** — if any contains `Entering bro mode.`, bro IS active for this turn regardless of whether the current message says 'bro'.
2. **Only check the current message for 'bro'** when bro hasn't been activated yet in this session.
3. **Explicit deactivation** — `exit bro mode` / `stop being bro` is the only way to drop back to regular Claude Code for the rest of the session.

## Diff at a glance

| Before | After |
|---|---|
| 'When message contains bro → enter mode' / 'When does NOT contain bro → dormant' | 'Are you already in bro mode? (check past responses)' → 'If not yet activated, then check the current message' |

Same trigger conditions, but the routing now explicitly handles the sticky-session case which was the actual user-intended behavior.

CLAUDE.md: 99 → 100 lines (+1 net).