### PR TITLE
🐛 fix(claude.md): context-check is DB-first, codebase-on-demand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,13 @@ Single Human entry point, planner, and task gate. You discuss, design the implem
 
 **Don't guess. Don't fabricate. Don't be a yes-man.** Before you plan, decide, or answer a substantive question, run two checks:
 
-1. **Context check** — *do I have enough?* Pull from this priority order: codebase (Read / Glob / Grep / git), DB (MCP queries), web (WebFetch / WebSearch for upstream docs / specs / standards), then training-data fallback. If context is thin, **say so** and either ask the Human or run the lookup. Thin context → "I'm not sure, checking…" beats inventing an answer.
+1. **Context check** — *do I have enough?* The DB is this project's source of truth (`file_registry`, `ledger`, `discussions`, `tasks`, `docs/architecture/`). Query it FIRST. Then branch by state:
+   - **Git clean** → trust the DB index. Don't ad-hoc-browse the codebase.
+   - **Git dirty** → diff against the DB index; reach for `Read` / `Glob` / `Grep` only on the changed files.
+   - **First-time onboarding to an existing repo** OR **right after finishing system design of a new project** → run `tmb_project-prescan` (then `tmb_refresh-architecture` if architecture docs need regeneration) to populate / refresh the index. Don't ad-hoc this either — the scan skill is the canonical way.
+   - **Upstream specs / external standards / library docs** → web (`WebFetch` / `WebSearch`).
+   - **Training-data fallback** — last resort, flag it as such.
+   If context is thin after the lookup, **say so** and ask the Human. Thin context → *"I'm not sure, checking…"* beats inventing.
 2. **Standards check** — *is what I'm about to recommend the industry standard or the best way?* If you're not sure, do the lookup. If a domain expert (legal, security, perf, etc.) would handle it better than bro, propose `tmb_agent-creator` to spawn the specialist. Bro should be professional and competent across general SWE work; for genuinely specialized domains, escalate.
 
 When you're guessing, label it. Cite the source when relevant.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,9 @@ Single Human entry point, planner, and task gate. You discuss, design the implem
 
 **Don't guess. Don't fabricate. Don't be a yes-man.** Before you plan, decide, or answer a substantive question, run two checks:
 
-1. **Context check** — *do I have enough?* The DB is this project's source of truth (`file_registry`, `ledger`, `discussions`, `tasks`, `docs/architecture/`). Query it FIRST. Then branch by state:
-   - **Git clean** → trust the DB index. Don't ad-hoc-browse the codebase.
-   - **Git dirty** → diff against the DB index; reach for `Read` / `Glob` / `Grep` only on the changed files.
+1. **Context check** — *do I have enough?* The **TMB trajectory DB** (the SQLite file owned by the MCP trajectory server at `<project>/.claude/<plugin-name>/trajectory.db`, distinct from any database the user's project may have) is this project's source of truth for plugin state: `file_registry`, `ledger`, `discussions`, `tasks`, plus the auto-regenerated `docs/architecture/`. Query the trajectory DB FIRST via MCP tools. Then branch by state:
+   - **Git clean** → trust the trajectory DB's `file_registry` index. Don't ad-hoc-browse the codebase.
+   - **Git dirty** → diff against the trajectory DB index; reach for `Read` / `Glob` / `Grep` only on the changed files.
    - **First-time onboarding to an existing repo** OR **right after finishing system design of a new project** → run `tmb_project-prescan` (then `tmb_refresh-architecture` if architecture docs need regeneration) to populate / refresh the index. Don't ad-hoc this either — the scan skill is the canonical way.
    - **Upstream specs / external standards / library docs** → web (`WebFetch` / `WebSearch`).
    - **Training-data fallback** — last resort, flag it as such.
@@ -43,7 +43,7 @@ Two parallel MCP reads, then the welcome banner, then the actual ask:
 - `identity_get(agent='bro')` — name (or null = user hasn't reonboarded yet)
 - `issue_resume(agent='bro')` — pending work, if any
 
-Policy keys (`branching_model`, `pr_target`, `protected_branches`) are seeded at DB init by the schema — bro never writes them; fetch via `config_get` only when you need a specific value.
+Policy keys (`branching_model`, `pr_target`, `protected_branches`) are seeded at trajectory DB init by the schema — bro never writes them; fetch via `config_get` only when you need a specific value.
 
 ## Welcome banner (mandatory)
 


### PR DESCRIPTION
## What I got wrong in PR #130

The verify-context doctrine listed sources as **codebase → DB → web → training fallback**. User caught the design violation:

> bro should run scan skill to get trajectory in db and docs/architecture/ when 'onboarding to existing project' or 'after finish the system design of a new project'. When git status is clean, bro doesn't need to browse the whole codebase — bro has the index. When git status is not clean, bro need to compare uncommitted change with previous trajectory.

The DB IS the indexed state of the codebase (`file_registry`, ledger, discussions, tasks, plus the auto-regenerated architecture docs). Putting 'codebase' before 'DB' was backwards.

## Fix

Rewrote step 1 (Context check) to:

1. **DB first** — query `file_registry`, `ledger`, `discussions`, `tasks`, plus `docs/architecture/`
2. **Git clean** → trust the DB index, no ad-hoc browsing
3. **Git dirty** → diff vs DB index; `Read`/`Glob`/`Grep` only on changed files
4. **Onboarding new repo / post-system-design** → run `tmb_project-prescan` (and `tmb_refresh-architecture` if needed) — scan skills are the canonical way to populate/refresh the index
5. **Web** for upstream specs / standards
6. **Training-data fallback** — last, flagged

## Why this matters

Without this branching, bro would happily `Glob`/`Grep` the whole repo on every substantive question — defeating the entire reason file_registry exists. The doctrine now matches the DB-as-source-of-truth design (`docs/REFERENCE.md` says it: 'workflow state lives in SQLite trajectory DB, not on disk').

## Cost

CLAUDE.md: 103 → 109 lines (+6). Accuracy beats brevity here.