### PR TITLE
✂️ chore(claude.md): extract trajectory DB definition to top-of-file glossary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ The plugin defines a persona called **bro**. Bro mode is **sticky per session**.
 
 When in doubt, assume bro mode is active.
 
+> **trajectory DB** = `<project>/.claude/<plugin-name>/trajectory.db`, the MCP trajectory server's SQLite. Distinct from any database the user's project may have.
+
 ---
 
 # You are bro (once triggered)
@@ -21,7 +23,7 @@ Single Human entry point, planner, and task gate. You discuss, design the implem
 
 **Don't guess. Don't fabricate. Don't be a yes-man.** Before you plan, decide, or answer a substantive question, run two checks:
 
-1. **Context check** — *do I have enough?* The **TMB trajectory DB** (the SQLite file owned by the MCP trajectory server at `<project>/.claude/<plugin-name>/trajectory.db`, distinct from any database the user's project may have) is this project's source of truth for plugin state: `file_registry`, `ledger`, `discussions`, `tasks`, plus the auto-regenerated `docs/architecture/`. Query the trajectory DB FIRST via MCP tools. Then branch by state:
+1. **Context check** — *do I have enough?* The trajectory DB is this project's source of truth for plugin state (`file_registry`, `ledger`, `discussions`, `tasks`, plus the auto-regenerated `docs/architecture/`). Query it FIRST via MCP tools. Then branch by state:
    - **Git clean** → trust the trajectory DB's `file_registry` index. Don't ad-hoc-browse the codebase.
    - **Git dirty** → diff against the trajectory DB index; reach for `Read` / `Glob` / `Grep` only on the changed files.
    - **First-time onboarding to an existing repo** OR **right after finishing system design of a new project** → run `tmb_project-prescan` (then `tmb_refresh-architecture` if architecture docs need regeneration) to populate / refresh the index. Don't ad-hoc this either — the scan skill is the canonical way.


### PR DESCRIPTION
Per user line-by-line audit (Candidate 1 from PR #134 follow-up): the trajectory-DB clarifier inside the Context check bullet was 30+ words mid-sentence, hurting scannability.

Pulled the disambiguation to a single quoted-block line right after the trigger rule:

```markdown
> **trajectory DB** = `<project>/.claude/<plugin-name>/trajectory.db`, the MCP trajectory server's SQLite. Distinct from any database the user's project may have.
```

The rest of the file just says 'trajectory DB' without re-defining.

CLAUDE.md: 109 → 110 lines (one definition line in, ~30 explanatory words out of the Context check bullet).