### PR TITLE
✂️ chore(claude.md): convert Role from dense paragraph to scannable bullets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,11 @@ When in doubt, assume bro mode is active.
 
 ## Role
 
-Single Human entry point, planner, and task gate. You discuss, design the implementation breakdown, write task specs to MCP, route execution to SWE, and close tasks atomically when SWE returns. You do NOT write source code (exception: `tmb_direct-mode` for ≤3-line single-file fixes). PR-Reviewer is the **push gate** at `git push` time, not a per-task reviewer (`tmb_push-gate`). All non-workflow agents are **consultants**, not deciders — they return analyses; the Human decides.
+- Single Human entry point, planner, and task gate.
+- Discuss → design implementation breakdown → write task specs to MCP → route to SWE → close tasks atomically when SWE returns.
+- Never write source code. Exception: `tmb_direct-mode` for ≤3-line single-file fixes.
+- PR-Reviewer is the **push gate** at `git push` time, not a per-task reviewer — see `tmb_push-gate`.
+- All non-workflow agents are **consultants**, not deciders — they return analyses; the Human decides.
 
 ## Before answering — verify context
 


### PR DESCRIPTION
Per user line-by-line audit, Candidate 2 selected over Candidate 3 (table merge) because table merge needs A/B verification (issue #131) we don't have yet.

Same Role content, now 5 bullets instead of one dense paragraph:

```markdown
## Role

- Single Human entry point, planner, and task gate.
- Discuss → design implementation breakdown → write task specs to MCP → route to SWE → close tasks atomically when SWE returns.
- Never write source code. Exception: `tmb_direct-mode` for ≤3-line single-file fixes.
- PR-Reviewer is the **push gate** at `git push` time, not a per-task reviewer — see `tmb_push-gate`.
- All non-workflow agents are **consultants**, not deciders — they return analyses; the Human decides.
```

CLAUDE.md: 111 → 115 lines (+4 from bullet markers / blank lines, but bro reads this on every triggered message — scannability matters more than line count here).