### PR TITLE
🪶 refactor(tests): L5+L6 combined → Release canary, L5 manual → Manual smoke (fallback)

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -1,16 +1,22 @@
-name: L5+L6 combined (RC-only)
+name: Release canary (RC-only)
 
-# L5+L6 combined Docker test (#112). Builds a Docker image that simulates
-# CC's marketplace install path (`bun install --ignore-scripts`), then runs
-# L6 deterministic-trajectory flows against the marketplace-installed
-# plugin — catching BOTH install-path bugs and workflow doctrine bugs.
+# Release canary — the heaviest automated test layer (was 'L5+L6 combined' #112).
+# Builds a Docker image that simulates CC's marketplace install path
+# (`bun install --ignore-scripts`), then runs L6 deterministic-trajectory
+# flows against the marketplace-installed plugin — catching BOTH install-path
+# bugs and workflow doctrine bugs.
+#
+# This is the final automated gate before shipping. Renamed from the
+# numeric "L5+L6 combined" to a non-numeric name so future heavy layers
+# can slot in between L4 and Release canary without renumbering.
 #
 # Why RC-only: each run uses real Claude tokens (~$1-3 per full 4-flow
 # execution). Token-heavy tests run on RC tag pushes and manual dispatch
 # from dev/rc only — NOT on stable v* tags from main (main is already
 # validated upstream).
 #
-# Replaces manual L5 dogfood for everything except UX-only verification.
+# Replaces standalone manual L5 dogfood for everything except UX-only
+# verification (manual smoke remains as a fallback in tests/manual/).
 #
 # Security: no untrusted PR-injected strings flow into shell commands.
 # Plugin version is read from a known JSON file via jq.
@@ -24,7 +30,7 @@ on:
       - 'v*-rc.*'
 
 jobs:
-  l5-l6-combined:
+  release-canary:
     if: |
       (github.event_name == 'workflow_dispatch' && (github.ref_name == 'dev' || github.ref_name == 'rc')) ||
       (github.event_name == 'push' && contains(github.ref, '-rc.'))
@@ -45,12 +51,12 @@ jobs:
           echo "version=$VER" >> "$GITHUB_OUTPUT"
           echo "Building for plugin version: $VER"
 
-      - name: Build L5+L6 image (BuildKit secret for token)
+      - name: Build Release canary image (BuildKit secret for token)
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: tests/docker/l5-l6-combined.Dockerfile
-          tags: tmb-l5-l6-combined:${{ steps.version.outputs.version }}
+          file: tests/docker/release-canary.Dockerfile
+          tags: tmb-release-canary:${{ steps.version.outputs.version }}
           push: false
           load: true
           build-args: |
@@ -62,4 +68,4 @@ jobs:
         env:
           PLUGIN_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          echo "L5+L6 combined: install + workflow doctrine all green for v$PLUGIN_VERSION"
+          echo "Release canary: install + workflow doctrine all green for v$PLUGIN_VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+### Refactored — testing framework: `L5+L6 combined` → `Release canary`, `L5 manual dogfood` → `Manual smoke` (fallback)
+
+The numeric "L5+L6 combined" name was awkward (not a real layer, just a Docker-bundled superset) and constrained future insertion of heavy layers. Renamed to a non-numeric **Release canary** so future layers (e.g. A/B prompt eval — issue #131, perf canary, etc.) can slot in between L4 and Release canary without renumbering.
+
+Standalone "L5 manual dogfood" demoted to **Manual smoke** — a fallback used only for UX scenarios the automated layers can't model (e.g. live `AskUserQuestion` interactivity). The Release canary handles everything else automatically.
+
+Renamed files:
+
+- `.github/workflows/l5-l6-combined.yml` → `.github/workflows/release-canary.yml`
+- `tests/docker/l5-l6-combined.Dockerfile` → `tests/docker/release-canary.Dockerfile`
+- `tests/docker/run-l5-l6-combined.sh` → `tests/docker/run-release-canary.sh`
+- Workflow `name:` and job ID updated to `Release canary` / `release-canary`.
+- Image tag: `tmb-l5-l6-combined:<v>` → `tmb-release-canary:<v>`.
+
+Updated docs: `tests/README.md` (test pyramid + escalation chain), `CONTRIBUTING.md` ("CI scope" workflow table), `scripts/release.sh` (manual smoke gate framing).
+
 ### Refactored — defaults seeded by schema, not by bro
 
 The previous unreleased entry had bro silently writing 3 `plugin_config` rows + a `tmb_defaults_applied` ledger event on first contact. Per user follow-up: that's still bro doing work the system should do.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ No required-approvals (solo dev). Once a second maintainer joins, flip `required
 |---|---|---|---|
 | `test.yml` (L0–L4) | `push` to `dev`/`main`, `pull_request` to `dev`/`main` | dev, main, PRs | free |
 | `l6-dogfood.yml` | `workflow_dispatch` (dev/rc only), `push` tags `v*-rc.*`, `pull_request` labeled `L6` | RC tags + dev/rc dispatch | ~$1–3/run |
-| `l5-l6-combined.yml` | `workflow_dispatch` (dev/rc only), `push` tags `v*-rc.*` | RC tags + dev/rc dispatch | ~$1–3/run |
+| `release-canary.yml` (was `l5-l6-combined.yml`) | `workflow_dispatch` (dev/rc only), `push` tags `v*-rc.*` | RC tags + dev/rc dispatch | ~$1–3/run |
 
 Stable `v*` tags from main do **not** fire token-heavy tests — that validation already happened on the matching `v*-rc.*` cut. Spending tokens on a known-good cut is waste.
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -77,21 +77,25 @@ if ! grep -q "^## ${NEW_TAG} " CHANGELOG.md; then
   exit 1
 fi
 
-# L5 manual dogfood gate. The release script refuses to tag without an
-# explicit signed-off env var matching this exact version. See
-# tests/manual/scenarios.md for the checklist that produces this sign-off.
+# Manual smoke gate (formerly 'L5 manual dogfood'). The release script refuses
+# to tag without an explicit signed-off env var matching this exact version.
+# See tests/manual/scenarios.md for the checklist that produces this sign-off.
+#
+# Note: Release canary (was 'L5+L6 combined') replaces manual smoke for almost
+# everything. Manual smoke remains as a fallback for UX scenarios that the
+# automated layer can't model (e.g. interactive AskUserQuestion responses).
 #
 # Bypass for hotfix releases that don't change Claude-side behavior:
 # set BYPASS_DOGFOOD=1 with a justification in the commit log.
 if [ "${BYPASS_DOGFOOD:-0}" = "1" ]; then
-  printf "⚠️  L5 manual dogfood gate BYPASSED (BYPASS_DOGFOOD=1).\n"
+  printf "⚠️  Manual smoke gate BYPASSED (BYPASS_DOGFOOD=1).\n"
   printf "    This is acceptable for hotfix releases that don't touch Claude-side\n"
   printf "    behavior (agents/skills/CLAUDE.md). Document the bypass reason in the\n"
   printf "    release commit message.\n\n"
 elif [ "${MANUAL_DOGFOOD_PASSED:-}" = "$NEW_TAG" ]; then
-  printf "✓ L5 manual dogfood passed for %s (MANUAL_DOGFOOD_PASSED matches).\n\n" "$NEW_TAG"
+  printf "✓ Manual smoke passed for %s (MANUAL_DOGFOOD_PASSED matches).\n\n" "$NEW_TAG"
 else
-  printf "❌ Refusing to tag. L5 manual dogfood not signed off for %s.\n" "$NEW_TAG" >&2
+  printf "❌ Refusing to tag. Manual smoke not signed off for %s.\n" "$NEW_TAG" >&2
   printf "\n" >&2
   printf "   Walk through the checklist at tests/manual/scenarios.md, then re-run with:\n" >&2
   printf "     export MANUAL_DOGFOOD_PASSED=%s && bash scripts/release.sh\n" "$NEW_TAG" >&2

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,23 +13,25 @@ Each layer catches a different class of bug; skipping any layer means shipping a
 | **L2** | Unit — handler logic, synthetic args; no LLM, no protocol | `mcp/trajectory-server/src/test/*.test.ts` | Handler bugs, constraint violations, return-shape drift |
 | **L3** | Integration — real server subprocess + JSON-RPC stdio | [`mcp-integration/*.test.mjs`](./mcp-integration/), [`hooks/*.sh`](./hooks/) | Schema drift, missing `agent` param, protocol plumbing, role enforcement |
 | **L4** | Workflow simulation — MCP-only multi-step flows (no real Claude) | [`workflow-sim/*.test.mjs`](./workflow-sim/) | Workflow contract bugs at the MCP-call level |
-| **L5** | Manual dogfood — human-driven interactive Claude Code session | [`manual/`](./manual/) | UX regressions only catchable with a human |
 | **L6** | **Workflow-doctrine dogfood — multi-scorer (outcome + trajectory + cost)** against `--plugin-dir` source (issues #108, #110) | [`dogfood/`](./dogfood/) | Doctrine drift between FLOWS.md and reality, agent-prompt regressions, cold-start behavior |
-| **L5+L6 combined** | **Full marketplace install + workflow doctrine in one Docker image** — replaces manual L5 (issue #112) | [`docker/l5-l6-combined.Dockerfile`](./docker/) | Everything L0 catches PLUS everything L6 catches, against the as-shipped marketplace artifact. Release-only (token-heavy). |
+| **Release canary** | **Full marketplace install + workflow doctrine in one Docker image** — the final automated gate (was "L5+L6 combined", #112) | [`docker/release-canary.Dockerfile`](./docker/) | Everything L0 catches PLUS everything L6 catches, against the as-shipped marketplace artifact. RC-only (token-heavy). |
+| **Manual smoke** *(fallback)* | Human-driven interactive Claude Code session — only for UX scenarios the automated layers can't model (e.g. AskUserQuestion interactivity) | [`manual/`](./manual/) | UX regressions only catchable with a human in the loop |
 
 **Golden rule:** *Layer N green does not imply Layer N+1 green.* Layer 1 passed with 235 tests while a critical bug sat in production — the MCP schema stripped the `agent` parameter on every call, collapsing all role checks to `caller_role: 'unknown'`. Layer 2 would have caught that at the wire level in milliseconds. Always run all three before tagging a release.
 
 ## Testing philosophy — light to heavy, fail fast
 
-**Always start from the lightest test layer and only escalate when each preceding layer is green.** The pyramid orders by cost (latency + tokens + manual time) ascending: L0 → L1 → L2 → L3 → L4 → L6 (light, --plugin-dir) → L5+L6 combined (heavy, marketplace simulation in Docker) → L5 manual (last resort).
+**Always start from the lightest test layer and only escalate when each preceding layer is green.** The pyramid orders by cost (latency + tokens + manual time) ascending: L0 → L1 → L2 → L3 → L4 → L6 (light, `--plugin-dir`) → Release canary (heavy, marketplace simulation in Docker) → Manual smoke (last resort, fallback only).
 
 This applies to:
 
-- **PR review**: PRs that fail L1 don't pay the L2 cost. PRs that pass L1-L4 trigger L6 only when labeled. L5+L6-combined runs on tag pushes only.
-- **Release validation**: cut a release candidate → run L0 → L4 (every PR did this already) → run L6 light → only if green, run L5+L6 combined → only if green, cut stable.
+- **PR review**: PRs that fail L1 don't pay the L2 cost. PRs that pass L1-L4 trigger L6 only when labeled. Release canary runs on RC tag pushes only.
+- **Release validation**: cut an RC tag → L0 + L1-L4 (every PR did this already) → L6 light → if green, Release canary → if green, promote dev → main → cut stable.
 - **Investigating a regression**: bisect at the lightest layer that fails. If L1 catches it, don't run L4. If L2 catches it, don't run L6.
 
-**Why**: token cost matters (L5+L6 ≈ $1-3 per run; L6 light ≈ ~$0.20; L1-L4 ≈ free). Human time matters (manual L5 = 30-45 min; the rest is automated). Cheap signals first eliminates the need for expensive ones.
+**Why**: token cost matters (Release canary ≈ $1-3 per run; L6 light ≈ ~$0.20; L1-L4 ≈ free). Human time matters (manual smoke = 30-45 min; the rest is automated). Cheap signals first eliminates the need for expensive ones.
+
+**Insertion-friendly naming**: Release canary is non-numeric so future heavy layers (e.g. A/B prompt eval, perf canary) can slot in between L4 and Release canary without renumbering anything.
 
 **The escalation chain**:
 
@@ -38,9 +40,10 @@ PR opened → L0 + L1-L4 in CI (free, < 2 min)
    ↓ green
 PR labeled `L6` (optional) → L6 light in CI (~$0.20, ~3 min)
    ↓ green
-Tag pushed → L5+L6 combined in CI (~$1-3, ~10 min)
+RC tag pushed → Release canary in CI (~$1-3, ~10 min)
    ↓ green
-Release goes out — L5 manual only for genuinely-novel UX scenarios
+Promote RC → main → tag stable. Manual smoke only when an automated layer
+  genuinely can't model the scenario (very rare; document why).
 ```
 
 ## Layout

--- a/tests/docker/release-canary.Dockerfile
+++ b/tests/docker/release-canary.Dockerfile
@@ -1,4 +1,4 @@
-# L5+L6 combined — install-smoke + workflow doctrine, in one image (#112).
+# Release canary — install-smoke + workflow doctrine in one image (was L5+L6 combined, #112).
 #
 # Builds on top of the L0 install-smoke approach, then ALSO installs Claude
 # Code and runs the L6 deterministic-trajectory flows against the
@@ -11,12 +11,12 @@
 # Build (requires CLAUDE_CODE_OAUTH_TOKEN secret):
 #   docker buildx build \
 #     --secret id=cc_token,env=CLAUDE_CODE_OAUTH_TOKEN \
-#     -f tests/docker/l5-l6-combined.Dockerfile \
-#     -t tmb-l5-l6 \
+#     -f tests/docker/release-canary.Dockerfile \
+#     -t tmb-release-canary \
 #     .
 #
 # OR via wrapper:
-#   bash tests/docker/run-l5-l6-combined.sh
+#   bash tests/docker/run-release-canary.sh
 #
 # Build success = release shippable AND workflow doctrine intact.
 
@@ -78,4 +78,4 @@ RUN --mount=type=secret,id=cc_token \
     fi
 
 # Final marker
-RUN echo "✓ L5+L6 combined: install + workflow doctrine all green"
+RUN echo "✓ Release canary: install + workflow doctrine all green"

--- a/tests/docker/run-release-canary.sh
+++ b/tests/docker/run-release-canary.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Local convenience wrapper for the L5+L6 combined Docker test (#112).
+# Local convenience wrapper for the Release canary Docker test (formerly L5+L6 combined, #112).
 #
 # Usage:
 #   export CLAUDE_CODE_OAUTH_TOKEN=...    # required for the L6 piece
-#   bash tests/docker/run-l5-l6-combined.sh
+#   bash tests/docker/run-release-canary.sh
 #
 # Without the token: builds the image (L0 install assertions only),
 #   skips the L6 run with a notice. Useful for verifying install changes
@@ -26,7 +26,7 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
-IMAGE_TAG="tmb-l5-l6-combined:${VERSION}"
+IMAGE_TAG="tmb-release-canary:${VERSION}"
 
 if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
   printf "⚠️  CLAUDE_CODE_OAUTH_TOKEN not set — building install-only (L0 piece).\n"
@@ -34,7 +34,7 @@ if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
 
   DOCKER_BUILDKIT=1 docker build \
     --build-arg "PLUGIN_VERSION=${VERSION}" \
-    -f tests/docker/l5-l6-combined.Dockerfile \
+    -f tests/docker/release-canary.Dockerfile \
     -t "$IMAGE_TAG" \
     --progress=plain \
     .
@@ -44,10 +44,10 @@ else
   DOCKER_BUILDKIT=1 docker build \
     --secret id=cc_token,env=CLAUDE_CODE_OAUTH_TOKEN \
     --build-arg "PLUGIN_VERSION=${VERSION}" \
-    -f tests/docker/l5-l6-combined.Dockerfile \
+    -f tests/docker/release-canary.Dockerfile \
     -t "$IMAGE_TAG" \
     --progress=plain \
     .
 fi
 
-printf "\n✓ L5+L6 combined check passed.\n"
+printf "\n✓ Release canary check passed.\n"


### PR DESCRIPTION
## Summary

Per user direction: *'L5 shouldn't be manual test any more. We should rename it to the final layer. What name is proper as we may need to insert a layer before the final one?'*

Renamed the heaviest automated layer to **Release canary** (non-numeric, industry-standard term) so future heavy layers (A/B prompt eval — issue #131, perf canary, etc.) can slot between L4 and Release canary without renumbering.

Standalone **L5 manual dogfood** demoted to **Manual smoke** — fallback only.

## Files renamed

- `.github/workflows/l5-l6-combined.yml` → `release-canary.yml`
- `tests/docker/l5-l6-combined.Dockerfile` → `release-canary.Dockerfile`
- `tests/docker/run-l5-l6-combined.sh` → `run-release-canary.sh`

## Internal updates

- Workflow `name:` field → `Release canary (RC-only)`
- Job ID → `release-canary`
- Docker image tag → `tmb-release-canary:<v>`
- All inter-file references updated (Dockerfile/script comments, run wrappers)

## Doc updates

- **`tests/README.md`** — pyramid table reordered (Release canary above Manual smoke), escalation chain rewritten, new 'Insertion-friendly naming' note
- **`CONTRIBUTING.md`** — 'Workflow scope by trigger' table updated
- **`scripts/release.sh`** — Manual smoke gate framing rewritten (Release canary handles most cases; manual smoke only for genuine UX scenarios)
- **`CHANGELOG.md`** — Unreleased section entry

## Verification

- ✓ `bash tests/run-all.sh` → all L1-L3 layers green
- ✓ Remaining `L5+L6`/`l5-l6` text in repo is intentional historical breadcrumb ('was L5+L6 combined', 'formerly L5 manual dogfood')

## Next

Issue cleanup (#108, #110, #112, #116) coming as a separate task — they're shipped or essentially shipped, deserve closure with summary comments.