### PR TITLE
🐛 fix(bro): tighten activation routine + Direct Mode protocol; fix Task→Agent scorer mismatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,14 +38,20 @@ When you're guessing, label it. Cite the source when relevant.
 
 Every MCP call MUST include `agent: 'bro'`. Server rejects others. For forbidden-tool errors and `is_error: true` recovery: `tmb_mcp-error-handling`. Plugin agents: `swe` + `pr-reviewer` ship globally; consultants (`architect`, `cto`, `ceo`, `pm`) are templates instantiated per-project via `tmb_agent-creator`. Full agent model: `docs/AGENTS.md`.
 
-## Activation routine (every triggered message, no shortcuts)
+## Activation routine — MANDATORY on every triggered message
 
-Two parallel MCP reads, then the welcome banner, then the actual ask:
+**No exceptions. This routine fires on EVERY message you handle as bro — including casual ones like `@bro hi`, `@bro yo`, `@bro thanks`, `@bro cool`. The two MCP reads cost ~50ms total. Skipping them silently breaks the audit trail and the welcome-banner contract.**
 
-- `identity_get(agent='bro')` — name (or null = user hasn't reonboarded yet)
-- `issue_resume(agent='bro')` — pending work, if any
+If you find yourself thinking *"this message is too casual for the chain"* — that's a doctrine violation. Run it anyway.
 
-Policy keys (`branching_model`, `pr_target`, `protected_branches`) are seeded at trajectory DB init by the schema — bro never writes them; fetch via `config_get` only when you need a specific value.
+In your first response after activation, emit two parallel MCP reads BEFORE the welcome banner:
+
+- `identity_get(agent='bro')` — get the human's name (returns null if they haven't reonboarded yet — that's normal, not an error)
+- `issue_resume(agent='bro')` — pull pending work, if any
+
+Then emit the welcome banner. Then handle the actual ask.
+
+Policy keys (`branching_model`, `pr_target`, `protected_branches`) are seeded at trajectory DB init by the schema — bro never writes them; fetch via `config_get` only when you need a specific value (don't add to the activation routine).
 
 ## Welcome banner (mandatory)
 

--- a/skills/tmb_direct-mode/SKILL.md
+++ b/skills/tmb_direct-mode/SKILL.md
@@ -22,15 +22,17 @@ The narrow scope IS the discipline. If you find yourself extending Direct Mode "
 
 If any condition fails, **fall back to the default chain** — propose an issue + task + SWE spawn with a brief explanation to the Human.
 
-## Protocol
+## Protocol — ALL THREE STEPS ARE MANDATORY
 
-```
-Edit (file)
-  → Bash (git commit -m "chore: ...")
-  → ledger_log(agent='bro', event_type='direct_mode_used', summary='<one-line description of the fix>')
-```
+The skill is exactly three steps. **You MUST emit all three. The third is the audit trail and is the most commonly-skipped step — if you stop after step 2 you have committed code with no record that Direct Mode was used, indistinguishable from rogue bro behavior.**
 
-That's the whole skill. No `task_create_batch`. No `Task(subagent_type='swe', ...)`. No `planning_complete` ledger event. No bro verification step (the diff is small enough that bro reading it IS the verification).
+1. `Edit` (the file) — the actual fix
+2. `Bash (git commit -m "chore: ...")` — atomic commit with conventional-commit message
+3. `ledger_log(agent='bro', event_type='direct_mode_used', summary='<one-line description of the fix>')` — **NEVER SKIP THIS.** This is what distinguishes "bro intentionally used Direct Mode" from "bro freelanced an edit"
+
+Batch all three as parallel tool_use blocks in a single response when feasible (the ledger_log doesn't depend on the commit's exit code).
+
+That's the whole skill. No `task_create_batch`. No `Task(subagent_type='swe', ...)`. No `planning_complete` ledger event. No bro verification step (the diff is small enough that bro reading it IS the verification). But the `direct_mode_used` ledger event is **non-negotiable**.
 
 ## Examples
 

--- a/tests/dogfood/flows/02-simple-task/tools-required.json
+++ b/tests/dogfood/flows/02-simple-task/tools-required.json
@@ -1,5 +1,5 @@
 [
   "mcp__plugin_tmb_trajectory-server__issue_create",
   "mcp__plugin_tmb_trajectory-server__task_create_batch",
-  "Task"
+  "Agent"
 ]

--- a/tests/dogfood/flows/D-direct-mode/tools-forbidden.json
+++ b/tests/dogfood/flows/D-direct-mode/tools-forbidden.json
@@ -1,5 +1,5 @@
 [
   "mcp__plugin_tmb_trajectory-server__task_create_batch",
-  "Task",
+  "Agent",
   "mcp__plugin_tmb_trajectory-server__validation_record"
 ]


### PR DESCRIPTION
Three bugs surfaced by L6 dogfood on rc.3 (run [#24969960425](https://github.com/trustmybot/plugin/actions/runs/24969960425)):

## Bug 1 — Bro skips first-action chain on greetings

`@bro hi` produced no `identity_get` / `issue_resume` MCP calls in the trajectory, contradicting the documented routine. CLAUDE.md said *'every triggered message, no shortcuts'* but the imperative was in the section header — bro skimmed the body.

**Fix**: rewrote the section as **MANDATORY on every triggered message**, moved the no-shortcuts rule into the body, called out greetings explicitly (`@bro hi`, `@bro yo`, `@bro thanks`, `@bro cool`), quantified the cost (~50ms total), and made the consequence concrete (*'silently breaks the audit trail and the welcome-banner contract'*).

## Bug 2 — Direct Mode never wrote direct_mode_used ledger event

D-direct-mode trajectory showed Edit + Bash (correct) but no `ledger_log` call. The `tmb_direct-mode` skill listed all three steps but bro stopped after step 2.

**Fix**: rewrote 'Protocol' as **ALL THREE STEPS ARE MANDATORY** with the audit-trail rationale up-front and explicit *'NEVER SKIP THIS'* on step 3. Added a closing reminder that the ledger_log is non-negotiable.

## Bug 3 — Task vs Agent naming mismatch

CC's tool call `Task(subagent_type=...)` is captured by the PostToolUse hook as 'Agent', not 'Task'. Two scorer configs had the wrong expectation:

- `02-simple-task/tools-required.json`: 'Task' → 'Agent' (was false positive)
- `D-direct-mode/tools-forbidden.json`: 'Task' → 'Agent' (was false negative — would have let bro spawn SWE inside Direct Mode without flagging it)

## Why these are doctrine-compliance bugs

Bro is the LLM. CLAUDE.md and skill prompts are the only enforcement. Bugs 1 + 2 are stronger imperative rewrites; bug 3 is fixing the test to match reality. The L6 `trajectory_required` scorer is the regression guard if any of these slip back.

## Next

After merge → PR B (rename L6 → L5) → cut rc.4 → re-run Release canary + L5 dogfood.