### PR TITLE
🔖 chore(release): finalize CHANGELOG for v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
-## Unreleased
+## v0.4.1 — 2026-04-27
 
 ### Refactored — `L6 dogfood` → `L5 dogfood` (close the L4→L6 numbering gap)
 


### PR DESCRIPTION
Renames Unreleased → v0.4.1 — 2026-04-27 so scripts/release.sh accepts the tag. All three version manifests already at 0.4.1; no version bump needed.

Cumulative scope vs v0.4.0 documented in the CHANGELOG entry. Highlights:
- No-onboarding doctrine (modern-agent UX) + schema-seeded defaults
- Headless-fallback discipline + sticky bro mode + verify-context doctrine
- Test pyramid renames (L5+L6 combined → Release canary; L6 → L5)
- 5 new reactive skills, CLAUDE.md 268 → 109 lines
- Release canary Docker hardening
- 3 doctrine-bug iterations (LLM ceiling documented as follow-up)

After merge: dev → main PR → release.sh tags v0.4.1.