### PR TITLE
🔒 fix(workflows): add 'permissions: contents: read' to l5-dogfood + release-canary

### DIFF
--- a/.github/workflows/l5-dogfood.yml
+++ b/.github/workflows/l5-dogfood.yml
@@ -24,6 +24,9 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   l5-dogfood:
     if: |

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -29,6 +29,9 @@ on:
     tags:
       - 'v*-rc.*'
 
+permissions:
+  contents: read
+
 jobs:
   release-canary:
     if: |


### PR DESCRIPTION
Caught by CodeQL on the v0.4.1 release PR #143:

```
Workflow does not contain permissions — l5-dogfood.yml / release-canary.yml
```

Both new workflows lacked the top-level `permissions:` block, so GITHUB_TOKEN gets the broad default scope. Read-only to repo contents is sufficient — both only `checkout` + run tests.

Blocks the v0.4.1 release until merged into dev.