### PR TITLE
🔖 chore(release): bump v0.4.1 → v0.4.2 + CHANGELOG header

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "TMB plugin — bro orchestrates SWE + pr-reviewer in two gates (task gate, push gate) backed by a SQLite trajectory MCP server.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
-## Unreleased
+## v0.4.2 — 2026-04-27
 
 ### Added — codebase memory (#45) — Hybrid D' design
 

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "TMB multi-agent Claude Code plugin — workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Bumps the 3 manifest versions and renames CHANGELOG `Unreleased` → `v0.4.2 — 2026-04-27` so `scripts/release.sh` accepts the tag.

Cumulative scope vs v0.4.1: codebase memory (#45) shipped end-to-end via PRs #146/#147/#148.

After merge: cut v0.4.2-rc.1 from dev → Release canary + L5 dogfood auto-fire → I summarize for your approval.