### PR TITLE
📝 docs(#131 C): wire A/B framework into tests/README + CONTRIBUTING + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
+## Unreleased
+
+### Added — A/B prompt-eval framework (#131)
+
+Reach-for tool when shipping doctrine changes whose value is hard to verify by reading the prompt alone. Replaces "this should help compliance" guesswork with paired-run data + chi-squared significance testing.
+
+- **Schema** (#154): `eval_results.arm` (TEXT NOT NULL DEFAULT 'control') + `eval_results.scenario` (TEXT). Backward-compatible — existing single-arm L5 dogfood runs become 'control' rows automatically.
+- **Runner** `tests/dogfood/run-ab.sh`: takes a scenario name, runs N pairs (default 5), each pair runs every arm against the same flow + prompt + scratch project. Per-arm plugin trees built via rsync overlay (arm overrides layered on top of `$PLUGIN_ROOT`).
+- **Stats** `tests/dogfood/scripts/ab-report.sh`: per-arm × per-scorer pass-rate table + chi-squared (2x2 contingency, df=1) p-value. Pure awk math — no Python dep.
+- **Worked example** `tests/dogfood/ab-scenarios/example-claude-md-slim/`: current slim CLAUDE.md vs a padded variant on the 95-anonymous-cold-restart flow. Not a real hypothesis — proves the framework.
+- **Docs**: new `tests/README.md` row + section on when to write an A/B scenario; new `CONTRIBUTING.md` section with rule-of-thumb.
+
+Real hypothesis testing follows in #153 (CLAUDE.md slim, Hybrid D' vs lazy, Direct Mode 4-step framing, first-action chain MANDATORY).
+
 ## v0.4.2 — 2026-04-27
 
 ### Added — codebase memory (#45) — Hybrid D' design

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,16 @@ Stable `v*` tags from main do **not** fire token-heavy tests — that validation
 
 `verify-cc-auth` composite action runs as the first step of any CC-using workflow — fail-fast on broken token before Docker builds or multi-flow runs.
 
+## When to write an A/B prompt-eval scenario (#131)
+
+The A/B framework lives at `tests/dogfood/run-ab.sh`. Reach for it when shipping a doctrine change that's (a) prompt-only, (b) hard to verify by reading the prompt alone, and (c) you'd otherwise be guessing whether it helps.
+
+Rule of thumb: **if you find yourself writing "this should improve compliance" or "this should reduce token cost" in a PR description, write an A/B scenario instead of guessing.** Pre-existing examples of guesses worth measuring live in #153 (CLAUDE.md slim, Hybrid D' cold-start, Direct Mode 4-step framing, first-action chain MANDATORY).
+
+Skip A/B for: schema / MCP / hook changes (those land via L1–L4 with deterministic tests), small mechanical edits, or anything where the right outcome is obvious.
+
+Token cost: a scenario with 5 paired runs against 2 arms = 10 claude calls (~$0.50–$2 depending on flow size). Document the budget in the scenario's README.
+
 ## Writing code
 
 - Self-documenting code. Prefer deletion over addition.

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,7 @@ Each layer catches a different class of bug; skipping any layer means shipping a
 | **L4** | Workflow simulation — MCP-only multi-step flows (no real Claude) | [`workflow-sim/*.test.mjs`](./workflow-sim/) | Workflow contract bugs at the MCP-call level |
 | **L5** | **Workflow-doctrine dogfood — multi-scorer (outcome + trajectory + cost)** against `--plugin-dir` source (issues #108, #110) | [`dogfood/`](./dogfood/) | Doctrine drift between FLOWS.md and reality, agent-prompt regressions, cold-start behavior |
 | **Release canary** | **Full marketplace install + workflow doctrine in one Docker image** — the final automated gate (was "L5+L5 combined", #112) | [`docker/release-canary.Dockerfile`](./docker/) | Everything L0 catches PLUS everything L5 catches, against the as-shipped marketplace artifact. RC-only (token-heavy). |
+| **A/B prompt eval** *(opt-in, #131)* | Head-to-head comparison of doctrine variants (e.g. CLAUDE.md slim vs padded). Runs N pairs per arm against an L5 flow, computes per-arm pass-rate + chi-squared p-value | [`dogfood/run-ab.sh`](./dogfood/run-ab.sh) + [`dogfood/ab-scenarios/`](./dogfood/ab-scenarios/) | Whether a doctrine change actually moves the needle vs is just rearrangement; data for #150 ingredient slicing |
 | **Manual smoke** *(fallback)* | Human-driven interactive Claude Code session — only for UX scenarios the automated layers can't model (e.g. AskUserQuestion interactivity) | [`manual/`](./manual/) | UX regressions only catchable with a human in the loop |
 
 **Golden rule:** *Layer N green does not imply Layer N+1 green.* Layer 1 passed with 235 tests while a critical bug sat in production — the MCP schema stripped the `agent` parameter on every call, collapsing all role checks to `caller_role: 'unknown'`. Layer 2 would have caught that at the wire level in milliseconds. Always run all three before tagging a release.
@@ -31,7 +32,27 @@ This applies to:
 
 **Why**: token cost matters (Release canary ≈ $1-3 per run; L5 light ≈ ~$0.20; L1-L4 ≈ free). Human time matters (manual smoke = 30-45 min; the rest is automated). Cheap signals first eliminates the need for expensive ones.
 
-**Insertion-friendly naming**: Release canary is non-numeric so future heavy layers (e.g. A/B prompt eval, perf canary) can slot in between L4 and Release canary without renumbering anything.
+**Insertion-friendly naming**: Release canary is non-numeric so heavy layers slot in between L4 and Release canary without renumbering. The A/B prompt-eval layer (#131) lives at this tier — opt-in, not part of the auto-escalation chain.
+
+## When to use A/B prompt eval (#131)
+
+Reach for the A/B framework when you're about to ship a doctrine change ("tightening this CLAUDE.md section, hope it helps") and want data instead of vibes. Examples:
+
+- Compare two CLAUDE.md slim variants on the same flow + prompt → which one actually improves outcome pass-rate?
+- Compare the current Direct Mode 4-step protocol against an alternative formulation → does the strong "NEVER SKIP THIS" framing matter?
+- Compare Hybrid D' (cold-start AskUserQuestion + lazy default) against pure-lazy → did the question add value?
+
+Skip A/B for: small mechanical fixes (typos, lint), schema/MCP changes (those land via L1–L4), or anything where the right outcome is obvious without measurement.
+
+Run:
+
+```bash
+export CLAUDE_CODE_OAUTH_TOKEN=<token>
+N=10 bash tests/dogfood/run-ab.sh <scenario-name>
+bash tests/dogfood/scripts/ab-report.sh <scenario-name> --db <persisted-trajectory.db>
+```
+
+See `tests/dogfood/ab-scenarios/example-claude-md-slim/README.md` for the worked-example scenario layout.
 
 **The escalation chain**:
 


### PR DESCRIPTION
PR C of 3 implementing **#131**. Schema (#154) + runner (#155) already in dev. This is the docs/integration tail.

## What this adds

- **`tests/README.md`** — new row in the pyramid table for A/B + 'When to use A/B prompt eval' section with rule-of-thumb + run command
- **`CONTRIBUTING.md`** — new section 'When to write an A/B prompt-eval scenario (#131)' between 'Branch protection' and 'Writing code'
- **`CHANGELOG.md`** — new Unreleased entry summarizing the framework, pointing to #153 for real hypothesis testing

## Now unblocks #153

After this lands, #153 starts: 4 real hypothesis scenarios (CLAUDE.md slim, Hybrid D' vs lazy, Direct Mode 4-step framing, first-action chain MANDATORY). Each gets ≥10 paired runs and an ADR with the verdict.