### PR TITLE
🧪 ci: workflow_dispatch for A/B scenarios + merged DB report

### DIFF
--- a/.github/workflows/ab-scenario.yml
+++ b/.github/workflows/ab-scenario.yml
@@ -1,0 +1,92 @@
+name: A/B prompt-eval scenario (#131)
+
+# Manual-trigger workflow for the A/B framework. Takes a scenario name
+# (under tests/dogfood/ab-scenarios/) + a paired-runs count, runs both arms
+# against the same flow, uploads the trajectory DBs + the per-arm pass-rate
+# report as artifacts.
+#
+# Token-heavy. Restricted to dev/rc dispatch only — never PR-required.
+# Per-pair = 2 full claude -p invocations. Default N=5 → 10 calls per scenario.
+
+on:
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: 'Scenario name under tests/dogfood/ab-scenarios/ (e.g. h3-direct-mode-framing)'
+        required: true
+      pairs:
+        description: 'N pairs per arm (default 5)'
+        default: '5'
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  ab-run:
+    if: github.ref_name == 'dev' || github.ref_name == 'rc'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      AB_SCENARIO: ${{ github.event.inputs.scenario }}
+      N_PAIRS: ${{ github.event.inputs.pairs }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify CC auth (prerequisite)
+        uses: ./.github/actions/verify-cc-auth
+        with:
+          token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install plugin deps + build dist/
+        run: bun install --frozen-lockfile
+
+      - name: Run A/B scenario
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          L5_KEEP_ARTIFACTS: '1'
+          N: ${{ env.N_PAIRS }}
+        run: |
+          bash tests/dogfood/run-ab.sh "$AB_SCENARIO"
+
+      - name: Merge per-arm trajectory DBs into a single report DB
+        if: always()
+        run: |
+          mkdir -p /tmp/ab-report
+          REPORT_DB=/tmp/ab-report/merged.db
+          sqlite3 "$REPORT_DB" < mcp/trajectory-server/src/schema.sql
+          find /tmp -name 'trajectory.db' -path '*/.claude/tmb/*' 2>/dev/null | while read DB; do
+            echo "merging $DB"
+            sqlite3 "$DB" ".dump eval_results" 2>/dev/null \
+              | grep -E '^INSERT INTO eval_results' \
+              | sqlite3 "$REPORT_DB" || true
+            sqlite3 "$DB" ".dump file_registry" 2>/dev/null \
+              | grep -E '^INSERT INTO file_registry' \
+              | sqlite3 "$REPORT_DB" || true
+            sqlite3 "$DB" ".dump ledger" 2>/dev/null \
+              | grep -E '^INSERT INTO ledger' \
+              | sqlite3 "$REPORT_DB" || true
+          done
+          echo ""
+          echo "=== A/B report ==="
+          bash tests/dogfood/scripts/ab-report.sh "$AB_SCENARIO" --db "$REPORT_DB" || true
+          echo ""
+          echo "=== file_registry rows (md5 + summary inspection) ==="
+          sqlite3 -separator '|' "$REPORT_DB" "SELECT path, content_md5, substr(summary, 1, 60) FROM file_registry" || true
+          echo ""
+          echo "=== ledger events (audit trail) ==="
+          sqlite3 -separator '|' "$REPORT_DB" "SELECT event_type, substr(summary, 1, 80) FROM ledger ORDER BY id" || true
+
+      - name: Upload trajectory artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ab-${{ github.event.inputs.scenario }}-trajectory
+          path: |
+            /tmp/tmb-l5-*/
+            /tmp/ab-report/
+          retention-days: 14
+          include-hidden-files: true


### PR DESCRIPTION
Adds `.github/workflows/ab-scenario.yml` so the #131 A/B framework can be triggered from CI. Token from repo secret; no local OAuth needed.

## Inputs

- `scenario`: name from `tests/dogfood/ab-scenarios/` (e.g. `h3-direct-mode-framing`)
- `pairs`: N pairs per arm (default 5)

## Output (in the action log + uploaded artifact)

After the run, dumps three things:

1. **A/B report** — per-arm × per-scorer pass-rate + chi-squared p-value
2. **`file_registry` rows** — path + content_md5 + summary, for inspecting whether #45's md5 workflow actually populated
3. **`ledger` events** — audit trail (direct_mode_used, planning_complete, headless_fallback, etc.)

## Scope

- Dev/rc dispatch only (per existing token-heavy policy)
- Never PR-required
- L5_KEEP_ARTIFACTS=1 so scratch dirs survive
- 14d artifact retention