### PR TITLE
🔧 ci: publish ab-scenario.yml to main so workflow_dispatch resolves

### DIFF
--- a/.github/workflows/ab-scenario.yml
+++ b/.github/workflows/ab-scenario.yml
@@ -1,0 +1,92 @@
+name: A/B prompt-eval scenario (#131)
+
+# Manual-trigger workflow for the A/B framework. Takes a scenario name
+# (under tests/dogfood/ab-scenarios/) + a paired-runs count, runs both arms
+# against the same flow, uploads the trajectory DBs + the per-arm pass-rate
+# report as artifacts.
+#
+# Token-heavy. Restricted to dev/rc dispatch only — never PR-required.
+# Per-pair = 2 full claude -p invocations. Default N=5 → 10 calls per scenario.
+
+on:
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: 'Scenario name under tests/dogfood/ab-scenarios/ (e.g. h3-direct-mode-framing)'
+        required: true
+      pairs:
+        description: 'N pairs per arm (default 5)'
+        default: '5'
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  ab-run:
+    if: github.ref_name == 'dev' || github.ref_name == 'rc'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      AB_SCENARIO: ${{ github.event.inputs.scenario }}
+      N_PAIRS: ${{ github.event.inputs.pairs }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify CC auth (prerequisite)
+        uses: ./.github/actions/verify-cc-auth
+        with:
+          token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install plugin deps + build dist/
+        run: bun install --frozen-lockfile
+
+      - name: Run A/B scenario
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          L5_KEEP_ARTIFACTS: '1'
+          N: ${{ env.N_PAIRS }}
+        run: |
+          bash tests/dogfood/run-ab.sh "$AB_SCENARIO"
+
+      - name: Merge per-arm trajectory DBs into a single report DB
+        if: always()
+        run: |
+          mkdir -p /tmp/ab-report
+          REPORT_DB=/tmp/ab-report/merged.db
+          sqlite3 "$REPORT_DB" < mcp/trajectory-server/src/schema.sql
+          find /tmp -name 'trajectory.db' -path '*/.claude/tmb/*' 2>/dev/null | while read DB; do
+            echo "merging $DB"
+            sqlite3 "$DB" ".dump eval_results" 2>/dev/null \
+              | grep -E '^INSERT INTO eval_results' \
+              | sqlite3 "$REPORT_DB" || true
+            sqlite3 "$DB" ".dump file_registry" 2>/dev/null \
+              | grep -E '^INSERT INTO file_registry' \
+              | sqlite3 "$REPORT_DB" || true
+            sqlite3 "$DB" ".dump ledger" 2>/dev/null \
+              | grep -E '^INSERT INTO ledger' \
+              | sqlite3 "$REPORT_DB" || true
+          done
+          echo ""
+          echo "=== A/B report ==="
+          bash tests/dogfood/scripts/ab-report.sh "$AB_SCENARIO" --db "$REPORT_DB" || true
+          echo ""
+          echo "=== file_registry rows (md5 + summary inspection) ==="
+          sqlite3 -separator '|' "$REPORT_DB" "SELECT path, content_md5, substr(summary, 1, 60) FROM file_registry" || true
+          echo ""
+          echo "=== ledger events (audit trail) ==="
+          sqlite3 -separator '|' "$REPORT_DB" "SELECT event_type, substr(summary, 1, 80) FROM ledger ORDER BY id" || true
+
+      - name: Upload trajectory artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ab-${{ github.event.inputs.scenario }}-trajectory
+          path: |
+            /tmp/tmb-l5-*/
+            /tmp/ab-report/
+          retention-days: 14
+          include-hidden-files: true


### PR DESCRIPTION
GH Actions requires workflow files to exist on the **default branch** (main) for `gh workflow run --ref dev` to find them. PR #158 added `ab-scenario.yml` on dev only. Cherry-picking the same file to main so dispatch from dev/rc works.

Same admin-bypass path used for #115 (originally publishing the L6 + L5+L6 workflows to main).

The workflow itself only fires when `github.ref_name` is dev or rc, so publishing to main doesn't enable any production triggering.