### PR TITLE
🐛 fix(#131): A/B framework — symlink node_modules + scenario fixture/setup_files

### DIFF
--- a/tests/dogfood/ab-scenarios/example-claude-md-slim/scenario.json
+++ b/tests/dogfood/ab-scenarios/example-claude-md-slim/scenario.json
@@ -1,8 +1,8 @@
 {
   "name": "example-claude-md-slim",
-  "description": "Worked example for the A/B framework. Tests whether the slim CLAUDE.md (current dev) outperforms a verbose stand-in (arm B has CLAUDE.md replaced with a 300-line padded version that contains the same instructions plus filler explanations and rationale). Run against 95-anonymous-cold-restart since it's the cheapest flow with a clean outcome scorer. NOT a real-world hypothesis — just shows the framework end-to-end. Use this as a copy-paste template for the real scenarios in #153.",
+  "description": "Worked example for the A/B framework — current slim CLAUDE.md vs a padded variant on the simplest flow. NOT a real hypothesis.",
   "flow": "95-anonymous-cold-restart",
+  "fixture": "onboarding-anonymous",
   "prompt": "@bro hi",
-  "arms": ["A-slim", "B-padded"],
-  "notes": "A-slim = current trim CLAUDE.md (no override needed beyond a placeholder). B-padded = same instructions but expanded with rationale paragraphs, examples, and cross-references — to test whether slim materially helps bro vs. just the same content with more words."
+  "arms": ["A-slim", "B-padded"]
 }

--- a/tests/dogfood/ab-scenarios/h1-claude-md-slim/scenario.json
+++ b/tests/dogfood/ab-scenarios/h1-claude-md-slim/scenario.json
@@ -1,7 +1,8 @@
 {
   "name": "h1-claude-md-slim",
-  "description": "Hypothesis 1 from #153: did the CLAUDE.md aggressive slim (PR #126, 142 → 99 lines) actually improve outcome pass-rate, or was it cosmetic? A-slim = current 99-line CLAUDE.md. B-pre-slim = 142-line snapshot from before PR #126 (extracted via `git show 2f5cc56^:CLAUDE.md`). Same flow, same prompt — measures whether the slim materially helped or was rearrangement.",
+  "description": "Hypothesis 1 from #153: did the CLAUDE.md aggressive slim (PR #126, 142→99 lines) actually improve outcome pass-rate, or was it cosmetic?",
   "flow": "02-simple-task",
+  "fixture": "onboarding-named",
   "prompt": "@bro write a python cli todo with add and list commands",
   "arms": ["A-slim", "B-pre-slim"]
 }

--- a/tests/dogfood/ab-scenarios/h2-hybrid-d-vs-lazy/scenario.json
+++ b/tests/dogfood/ab-scenarios/h2-hybrid-d-vs-lazy/scenario.json
@@ -1,7 +1,11 @@
 {
   "name": "h2-hybrid-d-vs-lazy",
-  "description": "Hypothesis 2 from #153: does Hybrid D' (#45 — AskUserQuestion at cold-start, lazy default in headless) beat the simpler 'always lazy, no question' alternative? A-hybrid-d = current tmb_project-prescan with Phase 4. B-always-lazy = pre-#148 prescan (no Phase 4 — codebase memory backfills purely lazy). Same flow, same prompt — measures whether the AskUserQuestion + headless_fallback machinery added value vs simpler skip.",
+  "description": "Hypothesis 2 from #153: does Hybrid D' (#45 — AskUserQuestion at cold-start, lazy default in headless) beat the simpler 'always lazy' alternative?",
   "flow": "10-codebase-memory-cold-start",
+  "fixture": "onboarding-named",
+  "setup_files": [
+    {"path": "src/existing.py", "content": "# placeholder\n"}
+  ],
   "prompt": "@bro implement a hello world function in src/hello.py",
   "arms": ["A-hybrid-d", "B-always-lazy"]
 }

--- a/tests/dogfood/ab-scenarios/h3-direct-mode-framing/scenario.json
+++ b/tests/dogfood/ab-scenarios/h3-direct-mode-framing/scenario.json
@@ -1,7 +1,11 @@
 {
   "name": "h3-direct-mode-framing",
-  "description": "Hypothesis 3 from #153: did the strong 'NEVER SKIP THIS' / 'ALL FOUR STEPS ARE MANDATORY' framing on the Direct Mode protocol (PR #139, then expanded to 4 steps in #148) actually improve compliance with the audit-trail step (the ledger_log + file_registry_update_summaries calls), or are we still at the LLM ceiling where bro skips steps regardless?",
+  "description": "Hypothesis 3 from #153: did the strong 'NEVER SKIP THIS' / 'ALL FOUR STEPS ARE MANDATORY' framing on Direct Mode (PR #139, expanded to 4 steps in #148) actually improve compliance with the audit-trail step?",
   "flow": "D-direct-mode",
+  "fixture": "onboarding-named",
+  "setup_files": [
+    {"path": "README.md", "content": "I will recieve the package soon.\n"}
+  ],
   "prompt": "@bro fix the typo 'recieve' to 'receive' in README.md",
   "arms": ["A-current-4step", "B-pre-pr139"]
 }

--- a/tests/dogfood/ab-scenarios/h4-first-action-mandatory/scenario.json
+++ b/tests/dogfood/ab-scenarios/h4-first-action-mandatory/scenario.json
@@ -1,7 +1,8 @@
 {
   "name": "h4-first-action-mandatory",
-  "description": "Hypothesis 4 from #153: did PR #139's first-action chain tightening (header section moved 'no exceptions' rule into body, called out greetings explicitly, quantified cost) actually improve compliance with identity_get + issue_resume on greeting messages, or are we at the LLM ceiling where bro skips the chain on @bro hi regardless?",
+  "description": "Hypothesis 4 from #153: did PR #139's first-action-chain MANDATORY tightening improve compliance with identity_get + issue_resume on greeting messages, or are we at the LLM ceiling?",
   "flow": "95-anonymous-cold-restart",
+  "fixture": "onboarding-anonymous",
   "prompt": "@bro hi",
   "arms": ["A-current-mandatory", "B-pre-pr139"]
 }

--- a/tests/dogfood/lib/ab-helpers.sh
+++ b/tests/dogfood/lib/ab-helpers.sh
@@ -36,6 +36,40 @@ l6_make_arm_plugin() {
   echo "$arm_plugin"
 }
 
+# l6_smoke_arm_plugin <arm_plugin_dir> — verifies the arm_plugin can spawn
+# the MCP trajectory server and respond to tools/list. Fail-fast guard so
+# A/B doesn't burn tokens against an arm_plugin where MCP is silently broken
+# (the failure mode that bug #131-A produced — empty trajectory.db, bro
+# reports 'no MCP', 10 wasted claude calls).
+#
+# Returns 0 if MCP responds with a tool definition list within 10 seconds,
+# 1 otherwise. On failure, prints diagnostic to stderr.
+l6_smoke_arm_plugin() {
+  local arm_plugin="$1"
+  local mcp_entry="$arm_plugin/mcp/trajectory-server/dist/index.js"
+  if [ ! -f "$mcp_entry" ]; then
+    printf "  ✗ smoke: MCP entrypoint missing at %s\n" "$mcp_entry" >&2
+    return 1
+  fi
+
+  # Send a tools/list JSON-RPC request and check for a response with tools.
+  # 10s timeout is generous — actual response is typically <1s.
+  local req='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ab-smoke","version":"1"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+
+  local resp
+  resp=$(printf '%s\n' "$req" | timeout 10 node --experimental-sqlite "$mcp_entry" 2>&1 || true)
+
+  if echo "$resp" | grep -q '"tools"'; then
+    return 0
+  fi
+
+  printf "  ✗ smoke: MCP did not respond with a tools list. Output:\n" >&2
+  printf '%s\n' "$resp" | head -10 | sed 's/^/      /' >&2
+  return 1
+}
+
 # l6_setup_scenario_state <project_dir> <scenario_dir> — applies fixture +
 # setup_files from scenario.json before claude runs. Each scenario can declare:
 #   - "fixture": "<name>"  → l6_seed_db with that fixture (e.g. "onboarding-named")

--- a/tests/dogfood/lib/ab-helpers.sh
+++ b/tests/dogfood/lib/ab-helpers.sh
@@ -18,11 +18,59 @@ l6_make_arm_plugin() {
   local arm_overrides="$1"
   local arm_plugin
   arm_plugin=$(mktemp -d -t tmb-arm-plugin-XXXX)
+  # Exclude node_modules from rsync — we'll symlink them after for speed.
+  # Without symlinks the MCP server can't import @modelcontextprotocol/sdk
+  # and silently fails to start (0-byte trajectory.db, bro reports 'no MCP').
   rsync -a --exclude='.git' --exclude='node_modules' "$PLUGIN_ROOT/" "$arm_plugin/"
+  # Symlink the heavy node_modules from the source. Both the root one and the
+  # MCP server's nested one (if they exist).
+  if [ -d "$PLUGIN_ROOT/node_modules" ]; then
+    ln -sfn "$PLUGIN_ROOT/node_modules" "$arm_plugin/node_modules"
+  fi
+  if [ -d "$PLUGIN_ROOT/mcp/trajectory-server/node_modules" ]; then
+    ln -sfn "$PLUGIN_ROOT/mcp/trajectory-server/node_modules" "$arm_plugin/mcp/trajectory-server/node_modules"
+  fi
   if [ -d "$arm_overrides" ]; then
     rsync -a "$arm_overrides/" "$arm_plugin/"
   fi
   echo "$arm_plugin"
+}
+
+# l6_setup_scenario_state <project_dir> <scenario_dir> — applies fixture +
+# setup_files from scenario.json before claude runs. Each scenario can declare:
+#   - "fixture": "<name>"  → l6_seed_db with that fixture (e.g. "onboarding-named")
+#   - "setup_files": [{"path": "<rel-path>", "content": "<text>"}]
+#                    → write each file in the scratch project before claude runs
+# Both are optional. Defaults: no fixture (empty DB), no setup files.
+l6_setup_scenario_state() {
+  local project="$1" scenario_dir="$2"
+  local config="$scenario_dir/scenario.json"
+  [ -f "$config" ] || return 0
+
+  local fixture
+  fixture=$(jq -r '.fixture // empty' "$config")
+  if [ -n "$fixture" ]; then
+    l6_seed_db "$project" "$fixture"
+  fi
+
+  # setup_files: array of {path, content}
+  local count
+  count=$(jq -r '.setup_files | length // 0' "$config")
+  local i=0
+  while [ "$i" -lt "$count" ]; do
+    local rel content
+    rel=$(jq -r ".setup_files[$i].path" "$config")
+    content=$(jq -r ".setup_files[$i].content" "$config")
+    mkdir -p "$(dirname "$project/$rel")"
+    printf '%s' "$content" > "$project/$rel"
+    i=$((i + 1))
+  done
+
+  # If setup_files were created, commit them so the scratch repo is "clean"
+  # — flows that test git-clean behavior depend on this.
+  if [ "$count" -gt 0 ]; then
+    (cd "$project" && git add . && git commit -qm "scenario setup files" 2>/dev/null || true)
+  fi
 }
 
 # l6_run_arm <project_dir> <arm_plugin_dir> <prompt> — runs claude -p against

--- a/tests/dogfood/run-ab.sh
+++ b/tests/dogfood/run-ab.sh
@@ -85,6 +85,11 @@ for pair in $(seq 1 "$N"); do
     ARM_PLUGIN=$(l6_make_arm_plugin "$SCENARIO_DIR/arms/$arm")
     RUN_ID="ab-${SCENARIO_NAME}-pair${pair}-${arm}-${PAIR_ID}"
 
+    # Apply scenario state (fixture + setup_files) BEFORE running claude.
+    # Without this the scratch project lacks the files / DB rows the prompt
+    # references — bro correctly responds 'nothing to do' and the test is moot.
+    l6_setup_scenario_state "$PROJECT" "$SCENARIO_DIR"
+
     l6_run_arm "$PROJECT" "$ARM_PLUGIN" "$PROMPT"
     if PLUGIN_ROOT="$ARM_PLUGIN" l6_score_with_arm "$PROJECT" "$FLOW" "$SCORER_DIR" "$RUN_ID" "$arm" "$SCENARIO_NAME"; then
       printf "    ✓ all scorers passed\n"

--- a/tests/dogfood/run-ab.sh
+++ b/tests/dogfood/run-ab.sh
@@ -75,6 +75,29 @@ printf "  Prompt: %s\n" "$PROMPT"
 printf "  Arms:   %s\n" "$(echo "$ARMS" | tr '\n' ' ')"
 printf "  N (pairs per arm): %s\n\n" "$N"
 
+# Pre-flight MCP smoke test on each arm's plugin tree. Catches the bug class
+# 'arm_plugin built but MCP server can't actually spawn' — which would
+# otherwise produce 0-byte trajectory.db files, no eval_results, and a
+# silent waste of tokens. Fail FAST before running any claude calls.
+printf "=== Pre-flight MCP smoke test per arm ===\n"
+SMOKE_FAIL=0
+for arm in $ARMS; do
+  printf "  arm=%s: " "$arm"
+  SMOKE_PLUGIN=$(l6_make_arm_plugin "$SCENARIO_DIR/arms/$arm")
+  if l6_smoke_arm_plugin "$SMOKE_PLUGIN"; then
+    printf "✓ MCP responds\n"
+  else
+    printf "✗ MCP smoke failed — see stderr\n"
+    SMOKE_FAIL=1
+  fi
+  l6_cleanup_arm_plugin "$SMOKE_PLUGIN"
+done
+if [ "$SMOKE_FAIL" -ne 0 ]; then
+  printf "\n❌ One or more arms failed MCP smoke. Aborting before token spend.\n"
+  exit 1
+fi
+printf "\n"
+
 # Run N pairs. Each pair runs all arms once.
 PAIR_ID=$(date +%s)
 for pair in $(seq 1 "$N"); do


### PR DESCRIPTION
Two bugs surfaced by the first run of h3-direct-mode-framing ([run #24973707047](https://github.com/trustmybot/plugin/actions/runs/24973707047) — all 10 scratch trajectory DBs ended up 0 bytes).

## Bug 1 — MCP server can't start in arm_plugin

The arm_plugin (rsync'd copy of `$PLUGIN_ROOT` for per-arm overrides) excluded `node_modules`. Without `@modelcontextprotocol/sdk` + `better-sqlite3`, the MCP server fails silently when claude tries to spawn it. Result: 0-byte trajectory.db, bro's prescan reports `(no MCP)`, no eval_results rows written → empty A/B report.

**Fix**: keep the rsync exclude (saves the 100MB+ copy) but symlink `node_modules` post-rsync (both root + `mcp/trajectory-server/node_modules`). Node follows symlinks normally.

## Bug 2 — No fixture / setup-file seeding

The runner skipped the per-flow setup that the original L5 `run.sh` files do (`l6_seed_db` with a fixture, optional file creation). For h3, the prompt `fix the typo recieve` had no README.md with that typo to fix — bro correctly responded *'nothing to fix'*.

**Fix**: `scenario.json` schema extended with two optional fields:

```json
{
  "fixture": "onboarding-named",
  "setup_files": [
    {"path": "README.md", "content": "I will recieve the package.\n"}
  ]
}
```

New helper `l6_setup_scenario_state` runs both before claude. Updated all 5 scenarios (example + 4 hypotheses) with their required fixture + setup_files.

## Verification

After this lands, re-trigger `ab-scenario.yml` with `h3-direct-mode-framing`. Expected to see:

- Trajectory DBs with content
- `file_registry` rows after Direct Mode runs (proving #45 md5 workflow fires)
- `ledger` has `direct_mode_used` events (or not — that IS the H3 question)
- A/B report shows pass-rates per arm + chi-squared p-value