### PR TITLE
🔧 chore: rename l6_* helpers → l5_* in dogfood test infrastructure

### DIFF
--- a/tests/dogfood/ab-scenarios/example-claude-md-slim/README.md
+++ b/tests/dogfood/ab-scenarios/example-claude-md-slim/README.md
@@ -18,7 +18,7 @@ example-claude-md-slim/
 
 1. `bash tests/dogfood/run-ab.sh example-claude-md-slim` reads `scenario.json`
 2. For each pair (default 5):
-   - Sets up a scratch project (per `l6_setup_scratch_project`)
+   - Sets up a scratch project (per `l5_setup_scratch_project`)
    - For arm `A-slim`: copies `$PLUGIN_ROOT` to a temp dir, overlays `arms/A-slim/` (empty → no override), runs `claude --plugin-dir <temp> -p "<prompt>"`, scores per `tests/dogfood/flows/95-anonymous-cold-restart/` configs, tags eval_results rows with `arm='A-slim', scenario='example-claude-md-slim'`
    - For arm `B-padded`: same but `arms/B-padded/CLAUDE.md` overrides the plugin's CLAUDE.md
 3. After all pairs: `bash tests/dogfood/scripts/ab-report.sh example-claude-md-slim` aggregates pass-rates per arm + chi-squared p-value per scorer

--- a/tests/dogfood/flows/01-first-contact/run.sh
+++ b/tests/dogfood/flows/01-first-contact/run.sh
@@ -8,9 +8,9 @@ FLOW_NAME="01-first-contact"
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 PROMPT="@bro hi"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "empty"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "empty"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/02-simple-task/run.sh
+++ b/tests/dogfood/flows/02-simple-task/run.sh
@@ -11,9 +11,9 @@ FLOW_NAME="02-simple-task"
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 PROMPT="@bro write a python cli todo"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "onboarding-named"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "onboarding-named"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/03-difficult-task/run.sh
+++ b/tests/dogfood/flows/03-difficult-task/run.sh
@@ -20,9 +20,9 @@ fi
 FLOW_NAME=$(basename "$HERE")
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "$FIXTURE"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/04-agent-creator/run.sh
+++ b/tests/dogfood/flows/04-agent-creator/run.sh
@@ -20,9 +20,9 @@ fi
 FLOW_NAME=$(basename "$HERE")
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "$FIXTURE"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/05-skill-creation/run.sh
+++ b/tests/dogfood/flows/05-skill-creation/run.sh
@@ -20,9 +20,9 @@ fi
 FLOW_NAME=$(basename "$HERE")
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "$FIXTURE"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/06-push-gate/run.sh
+++ b/tests/dogfood/flows/06-push-gate/run.sh
@@ -20,9 +20,9 @@ fi
 FLOW_NAME=$(basename "$HERE")
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "$FIXTURE"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/07-architecture-regen/run.sh
+++ b/tests/dogfood/flows/07-architecture-regen/run.sh
@@ -20,9 +20,9 @@ fi
 FLOW_NAME=$(basename "$HERE")
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "$FIXTURE"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/08-swe-retry/run.sh
+++ b/tests/dogfood/flows/08-swe-retry/run.sh
@@ -20,9 +20,9 @@ fi
 FLOW_NAME=$(basename "$HERE")
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "$FIXTURE"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/09-roundtable/run.sh
+++ b/tests/dogfood/flows/09-roundtable/run.sh
@@ -20,9 +20,9 @@ fi
 FLOW_NAME=$(basename "$HERE")
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "$FIXTURE"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/10-codebase-memory-cold-start/run.sh
+++ b/tests/dogfood/flows/10-codebase-memory-cold-start/run.sh
@@ -12,15 +12,15 @@ FLOW_NAME="10-codebase-memory-cold-start"
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 PROMPT="@bro implement a hello world function in src/hello.py"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
 # Seed an existing-repo state: identity exists (so onboarding doesn't fire),
 # git ls-files non-empty (so cold-start trigger fires), file_registry empty.
-l6_seed_db "$PROJECT" "onboarding-named"
+l5_seed_db "$PROJECT" "onboarding-named"
 mkdir -p "$PROJECT/src"
 echo "# placeholder" > "$PROJECT/src/existing.py"
 (cd "$PROJECT" && git add . && git commit -qm "seed existing files")
 
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/11-codebase-memory-verify-on-drift/run.sh
+++ b/tests/dogfood/flows/11-codebase-memory-verify-on-drift/run.sh
@@ -12,10 +12,10 @@ FLOW_NAME="11-codebase-memory-verify-on-drift"
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 PROMPT="@bro fix the bug in src/foo.py"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "onboarding-named"
+l5_seed_db "$PROJECT" "onboarding-named"
 mkdir -p "$PROJECT/src"
 echo "def foo(): return 'v1'" > "$PROJECT/src/foo.py"
 (cd "$PROJECT" && git add . && git commit -qm "v1" && git rev-parse HEAD > /tmp/seed_head.$$)
@@ -36,6 +36,6 @@ VALUES ('last_verified_sha', '\"$SEED_HEAD\"', datetime('now'));
 # Simulate drift: edit the file on disk, don't commit
 echo "def foo(): return 'v2-modified'" > "$PROJECT/src/foo.py"
 
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
 rm -f /tmp/seed_head.$$

--- a/tests/dogfood/flows/32-team-config/run.sh
+++ b/tests/dogfood/flows/32-team-config/run.sh
@@ -20,9 +20,9 @@ fi
 FLOW_NAME=$(basename "$HERE")
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "$FIXTURE"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/92-base-branch/run.sh
+++ b/tests/dogfood/flows/92-base-branch/run.sh
@@ -20,9 +20,9 @@ fi
 FLOW_NAME=$(basename "$HERE")
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "$FIXTURE"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/94-arch-bootstrap/run.sh
+++ b/tests/dogfood/flows/94-arch-bootstrap/run.sh
@@ -20,9 +20,9 @@ fi
 FLOW_NAME=$(basename "$HERE")
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "$FIXTURE"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/95-anonymous-cold-restart/run.sh
+++ b/tests/dogfood/flows/95-anonymous-cold-restart/run.sh
@@ -8,9 +8,9 @@ FLOW_NAME="95-anonymous-cold-restart"
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 PROMPT="@bro hi"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "onboarding-anonymous"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "onboarding-anonymous"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/96-halt-on-error/run.sh
+++ b/tests/dogfood/flows/96-halt-on-error/run.sh
@@ -20,9 +20,9 @@ fi
 FLOW_NAME=$(basename "$HERE")
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "$FIXTURE"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/flows/C-consultant/run.sh
+++ b/tests/dogfood/flows/C-consultant/run.sh
@@ -20,9 +20,9 @@ fi
 FLOW_NAME=$(basename "$HERE")
 RUN_ID="${RUN_ID:-$(date +%s)-$RANDOM}"
 
-PROJECT=$(l6_setup_scratch_project)
-trap 'l6_cleanup_project "$PROJECT"' EXIT
+PROJECT=$(l5_setup_scratch_project)
+trap 'l5_cleanup_project "$PROJECT"' EXIT
 
-l6_seed_db "$PROJECT" "$FIXTURE"
-l6_run_claude "$PROJECT" "$PROMPT"
-l6_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"
+l5_seed_db "$PROJECT" "$FIXTURE"
+l5_run_claude "$PROJECT" "$PROMPT"
+l5_score_flow "$PROJECT" "$FLOW_NAME" "$HERE" "$RUN_ID"

--- a/tests/dogfood/lib/flow-helpers.sh
+++ b/tests/dogfood/lib/flow-helpers.sh
@@ -3,9 +3,9 @@
 
 set -uo pipefail
 
-# l6_setup_scratch_project: creates a fresh Docker-isolated scratch dir,
+# l5_setup_scratch_project: creates a fresh Docker-isolated scratch dir,
 # initializes git, sets test identity. Returns the absolute path on stdout.
-l6_setup_scratch_project() {
+l5_setup_scratch_project() {
   local dir
   dir=$(mktemp -d -t tmb-l5-XXXX)
   (
@@ -20,9 +20,9 @@ l6_setup_scratch_project() {
   echo "$dir"
 }
 
-# l6_seed_db <project_dir> <fixture_name>: applies a SQL fixture to the
+# l5_seed_db <project_dir> <fixture_name>: applies a SQL fixture to the
 # project's trajectory.db. Fixture must exist at tests/dogfood/fixtures/<name>.sql.
-l6_seed_db() {
+l5_seed_db() {
   local dir="$1" fixture="$2"
   local fixture_path="$L5_DOGFOOD_DIR/fixtures/${fixture}.sql"
   if [ ! -f "$fixture_path" ]; then
@@ -34,7 +34,7 @@ l6_seed_db() {
   sqlite3 "$dir/.claude/tmb/trajectory.db" < "$fixture_path"
 }
 
-# l6_run_claude <project_dir> <prompt>: runs `claude -p` against the prompt
+# l5_run_claude <project_dir> <prompt>: runs `claude -p` against the prompt
 # in the project, with TMB_DEBUG_TRAJECTORY=1, plugin loaded via --plugin-dir.
 # Echoes claude's stdout + stderr to OUR stderr so CI logs capture them
 # (otherwise diagnosis is impossible — see issue #116). Always returns 0
@@ -44,7 +44,7 @@ l6_seed_db() {
 # claude blocks every tool call (Bash, Edit, MCP) until a human approves
 # them, and there is no human in the loop here. The scratch dir is a
 # fresh mktemp-d, so there's nothing to harm.
-l6_run_claude() {
+l5_run_claude() {
   local dir="$1" prompt="$2"
   (
     cd "$dir" || exit 1
@@ -60,7 +60,7 @@ l6_run_claude() {
   )
 }
 
-# l6_score_flow <project_dir> <flow_name> <scorer_dir> <run_id>: runs all
+# l5_score_flow <project_dir> <flow_name> <scorer_dir> <run_id>: runs all
 # v2 scorers against the project's trajectory DB. Returns 0 only if every
 # scorer that's mandated for the flow passes. Issue #110.
 #
@@ -69,22 +69,22 @@ l6_run_claude() {
 #   2. trajectory_required — required tools were called (any order)
 #   3. trajectory_forbidden — forbidden tools were NOT called
 #   4. cost              — observational unless cost-budget says fail_above_max
-l6_score_flow() {
+l5_score_flow() {
   local project="$1" flow="$2" scorer_dir="$3" run_id="$4"
   local total_fail=0
 
-  l6_score_outcome              "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
-  l6_score_trajectory_required  "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
-  l6_score_trajectory_forbidden "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
-  l6_score_cost                 "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
+  l5_score_outcome              "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
+  l5_score_trajectory_required  "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
+  l5_score_trajectory_forbidden "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
+  l5_score_cost                 "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
 
   return "$total_fail"
 }
 
-# l6_cleanup_project <project_dir>: removes the scratch directory.
+# l5_cleanup_project <project_dir>: removes the scratch directory.
 # When L5_KEEP_ARTIFACTS=1, becomes a no-op so the workflow's
 # upload-artifact step can collect the trajectory DB after a failure.
-l6_cleanup_project() {
+l5_cleanup_project() {
   local dir="$1"
   [ "${L5_KEEP_ARTIFACTS:-0}" = "1" ] && return 0
   [ -n "$dir" ] && [ -d "$dir" ] && rm -rf "$dir"

--- a/tests/dogfood/lib/scorers.sh
+++ b/tests/dogfood/lib/scorers.sh
@@ -14,8 +14,8 @@
 
 set -uo pipefail
 
-# l6_record_score <db_path> <run_id> <flow> <scorer> <pass:0|1> <value> <explanation>
-l6_record_score() {
+# l5_record_score <db_path> <run_id> <flow> <scorer> <pass:0|1> <value> <explanation>
+l5_record_score() {
   local db="$1" run_id="$2" flow="$3" scorer="$4" pass="$5" value="$6" explanation="$7"
   sqlite3 "$db" <<SQL 2>/dev/null || true
 INSERT INTO eval_results (run_id, flow_name, scorer_name, pass, value, explanation, created_at)
@@ -31,18 +31,18 @@ VALUES (
 SQL
 }
 
-# l6_score_outcome <project_dir> <flow> <scorer_dir> <run_id>
+# l5_score_outcome <project_dir> <flow> <scorer_dir> <run_id>
 # Runs scorer_dir/outcome.sql against the project DB. Each row returned must
 # have a 'pass' column (1 or 0); all rows must pass for the scorer to pass.
 # Each row may also have an 'explanation' column.
-l6_score_outcome() {
+l5_score_outcome() {
   local project="$1" flow="$2" scorer_dir="$3" run_id="$4"
   local db="$project/.claude/tmb/trajectory.db"
   local sql_path="$scorer_dir/outcome.sql"
 
   if [ ! -f "$sql_path" ]; then
     echo "  ⊘ outcome scorer skipped: $sql_path not found"
-    l6_record_score "$db" "$run_id" "$flow" "outcome" 1 "" "no-config"
+    l5_record_score "$db" "$run_id" "$flow" "outcome" 1 "" "no-config"
     return 0
   fi
 
@@ -51,7 +51,7 @@ l6_score_outcome() {
   results=$(sqlite3 -separator '|' "$db" < "$sql_path" 2>&1)
   if [ -z "$results" ]; then
     echo "  ✗ outcome scorer: SQL returned no rows (expected ≥1 assertion)"
-    l6_record_score "$db" "$run_id" "$flow" "outcome" 0 "no-rows" "outcome.sql produced no assertion rows"
+    l5_record_score "$db" "$run_id" "$flow" "outcome" 0 "no-rows" "outcome.sql produced no assertion rows"
     return 1
   fi
 
@@ -67,20 +67,20 @@ l6_score_outcome() {
 
   if [ "$passed" -eq "$total" ] && [ "$total" -gt 0 ]; then
     echo "  ✓ outcome: $passed/$total assertions passed"
-    l6_record_score "$db" "$run_id" "$flow" "outcome" 1 "${passed}/${total}" "all assertions passed"
+    l5_record_score "$db" "$run_id" "$flow" "outcome" 1 "${passed}/${total}" "all assertions passed"
     return 0
   else
     echo "  ✗ outcome: $passed/$total assertions passed; failed: $failed_descs" >&2
-    l6_record_score "$db" "$run_id" "$flow" "outcome" 0 "${passed}/${total}" "$failed_descs"
+    l5_record_score "$db" "$run_id" "$flow" "outcome" 0 "${passed}/${total}" "$failed_descs"
     return 1
   fi
 }
 
-# l6_score_trajectory_required <project_dir> <flow> <scorer_dir> <run_id>
+# l5_score_trajectory_required <project_dir> <flow> <scorer_dir> <run_id>
 # Reads scorer_dir/tools-required.json (a JSON array of tool/MCP names).
 # Asserts every listed tool was called at least once (superset semantics
 # per LangSmith docs). Order-agnostic.
-l6_score_trajectory_required() {
+l5_score_trajectory_required() {
   local project="$1" flow="$2" scorer_dir="$3" run_id="$4"
   local db="$project/.claude/tmb/trajectory.db"
   local req_path="$scorer_dir/tools-required.json"
@@ -103,19 +103,19 @@ l6_score_trajectory_required() {
 
   if [ -z "$missing" ]; then
     echo "  ✓ trajectory_required: all required tools called"
-    l6_record_score "$db" "$run_id" "$flow" "trajectory_required" 1 "" "all required tools present"
+    l5_record_score "$db" "$run_id" "$flow" "trajectory_required" 1 "" "all required tools present"
     return 0
   else
     echo "  ✗ trajectory_required: missing tools: $missing" >&2
-    l6_record_score "$db" "$run_id" "$flow" "trajectory_required" 0 "missing" "$missing"
+    l5_record_score "$db" "$run_id" "$flow" "trajectory_required" 0 "missing" "$missing"
     return 1
   fi
 }
 
-# l6_score_trajectory_forbidden <project_dir> <flow> <scorer_dir> <run_id>
+# l5_score_trajectory_forbidden <project_dir> <flow> <scorer_dir> <run_id>
 # Reads scorer_dir/tools-forbidden.json. Asserts none of the listed tools
 # were called (subset/safety check).
-l6_score_trajectory_forbidden() {
+l5_score_trajectory_forbidden() {
   local project="$1" flow="$2" scorer_dir="$3" run_id="$4"
   local db="$project/.claude/tmb/trajectory.db"
   local forb_path="$scorer_dir/tools-forbidden.json"
@@ -138,20 +138,20 @@ l6_score_trajectory_forbidden() {
 
   if [ -z "$present" ]; then
     echo "  ✓ trajectory_forbidden: no forbidden tools called"
-    l6_record_score "$db" "$run_id" "$flow" "trajectory_forbidden" 1 "" "no forbidden tools present"
+    l5_record_score "$db" "$run_id" "$flow" "trajectory_forbidden" 1 "" "no forbidden tools present"
     return 0
   else
     echo "  ✗ trajectory_forbidden: forbidden tools called: $present" >&2
-    l6_record_score "$db" "$run_id" "$flow" "trajectory_forbidden" 0 "violations" "$present"
+    l5_record_score "$db" "$run_id" "$flow" "trajectory_forbidden" 0 "violations" "$present"
     return 1
   fi
 }
 
-# l6_score_cost <project_dir> <flow> <scorer_dir> <run_id>
+# l5_score_cost <project_dir> <flow> <scorer_dir> <run_id>
 # Reads scorer_dir/cost-budget.json with {max_tokens_total, max_latency_ms_p99,
 # fail_above_max}. Reports tokens + latency from debug_trajectory; fails only
 # if hard cap exceeded AND fail_above_max=true.
-l6_score_cost() {
+l5_score_cost() {
   local project="$1" flow="$2" scorer_dir="$3" run_id="$4"
   local db="$project/.claude/tmb/trajectory.db"
   local budget_path="$scorer_dir/cost-budget.json"
@@ -168,7 +168,7 @@ l6_score_cost() {
   if [ ! -f "$budget_path" ]; then
     # No budget config — purely observational.
     echo "  ⊘ cost (observational): $explanation"
-    l6_record_score "$db" "$run_id" "$flow" "cost" 1 "$total_tokens" "$explanation"
+    l5_record_score "$db" "$run_id" "$flow" "cost" 1 "$total_tokens" "$explanation"
     return 0
   fi
 
@@ -187,17 +187,17 @@ l6_score_cost() {
 
   if [ -z "$violation" ]; then
     echo "  ✓ cost: within budget — $explanation"
-    l6_record_score "$db" "$run_id" "$flow" "cost" 1 "$total_tokens" "$explanation"
+    l5_record_score "$db" "$run_id" "$flow" "cost" 1 "$total_tokens" "$explanation"
     return 0
   fi
 
   if [ "$fail_above" = "true" ]; then
     echo "  ✗ cost: budget exceeded$violation" >&2
-    l6_record_score "$db" "$run_id" "$flow" "cost" 0 "$total_tokens" "$explanation $violation"
+    l5_record_score "$db" "$run_id" "$flow" "cost" 0 "$total_tokens" "$explanation $violation"
     return 1
   else
     echo "  ⚠ cost: soft-warn budget exceeded$violation"
-    l6_record_score "$db" "$run_id" "$flow" "cost" 1 "$total_tokens" "$explanation $violation (soft)"
+    l5_record_score "$db" "$run_id" "$flow" "cost" 1 "$total_tokens" "$explanation $violation (soft)"
     return 0
   fi
 }


### PR DESCRIPTION
## Summary

- L6 was renamed to L5 (#118 closed the L4→L6 numbering gap), but the shell-helper namespace still carried the old `l6_` prefix. This sweeps the dogfood infrastructure to match the actual layer name.
- 22 files, 152 call sites/definitions, **no behavior change**.

## What changed

Renamed `l6_*` → `l5_*` across:

- `tests/dogfood/lib/{flow-helpers,ab-helpers,scorers}.sh` — function definitions (the actual helpers).
- `tests/dogfood/run-ab.sh` — call sites.
- `tests/dogfood/flows/*/run.sh` (17 flows) — call sites.
- `tests/dogfood/ab-scenarios/example-claude-md-slim/README.md` — prose reference to a helper name.

`CHANGELOG.md` history mentions of L6 are **left intact** — they're accurate historical records of when those layers existed under that name.

## Test plan

- [x] `bash tests/run-all.sh` (L1 + L2 + L3) passes locally
- [ ] CI confirms no other call site missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)