### PR TITLE
🔧 chore: bump GH Actions to v5 (Node 24) + drop CC-auth prefix check

### DIFF
--- a/.github/actions/verify-cc-auth/action.yml
+++ b/.github/actions/verify-cc-auth/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     - name: Setup Node 22 (if not already)
       if: inputs.install-cc == 'true'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '22'
 
@@ -44,12 +44,6 @@ runs:
           echo "::error::Token contains $DIFF whitespace/newline char(s) — re-set with: TOKEN=\$(claude setup-token) && gh secret set CLAUDE_CODE_OAUTH_TOKEN --body \"\$TOKEN\""
           exit 1
         fi
-        # Sanity-check OAuth prefix
-        case "$TOKEN" in
-          sk-ant-oat-*) echo "Token has expected sk-ant-oat- prefix (OAuth)" ;;
-          sk-ant-api-*) echo "Token has sk-ant-api- prefix (API key — also valid)" ;;
-          *) echo "::warning::Token does not start with sk-ant-oat- or sk-ant-api- — unrecognized format" ;;
-        esac
 
     - name: Smoke-test auth with claude -p
       shell: bash

--- a/.github/workflows/ab-scenario.yml
+++ b/.github/workflows/ab-scenario.yml
@@ -31,7 +31,7 @@ jobs:
       AB_SCENARIO: ${{ github.event.inputs.scenario }}
       N_PAIRS: ${{ github.event.inputs.pairs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Verify CC auth (prerequisite)
         uses: ./.github/actions/verify-cc-auth
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload trajectory artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ab-${{ github.event.inputs.scenario }}-trajectory
           path: |

--- a/.github/workflows/l5-dogfood.yml
+++ b/.github/workflows/l5-dogfood.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Verify CC auth (prerequisite — fail-fast on broken token)
         uses: ./.github/actions/verify-cc-auth
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload trajectory dumps on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: l6-trajectory-dumps
           path: /tmp/tmb-l5-*/

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Verify CC auth (prerequisite — fail-fast before Docker build)
         uses: ./.github/actions/verify-cc-auth

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Node 22+ required: MCP server uses node:sqlite (stdlib) — added in 22,
       # behind --experimental-sqlite flag on 22.x, stable on 24+. The
       # ubuntu-latest runner ships Node 20 by default, which doesn't have
       # node:sqlite — would fail with ERR_UNKNOWN_BUILTIN_MODULE.
       - name: install Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: build install-smoke image
         # Strips local artifacts, runs `bun install`, asserts dist/index.js


### PR DESCRIPTION
## Summary

Two CI annotations from the h4 A/B run, both fixed:

### 1. Node.js 20 deprecation
`actions/checkout@v4`, `actions/setup-node@v4`, `actions/upload-artifact@v4` ship with the Node 20 internal runtime, which GitHub is forcing off **June 2, 2026** (5 weeks). Bumped all 6 call sites across `test.yml`, `l5-dogfood.yml`, `release-canary.yml`, `ab-scenario.yml`, and `actions/verify-cc-auth/action.yml` to v5 (Node 24 internal runtime).

This is purely about the **action runtime** — our project's own Node version (set explicitly to 22 in `actions/setup-node` and the verify-cc-auth helper) is unrelated to this bump.

### 2. CC-auth prefix check
`.github/actions/verify-cc-auth/` was warning on tokens that didn't start with `sk-ant-oat-` or `sk-ant-api-`. The actual `claude -p` smoke test in the same action is the authoritative gate — the prefix check is just diagnostic noise that breaks every time Anthropic adds a new token type. Dropped.

## Test plan
- [x] Local L1 + L2 + L3 pass
- [ ] CI confirms v5 actions run cleanly
- [ ] Next CC-invoking workflow run (l5-dogfood / ab-scenario) shows 0 annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)