### PR TITLE
🪝 feat(#108): activation-routine UserPromptSubmit hook (DB → context, deterministic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+### Added — activation-routine UserPromptSubmit hook (#108)
+
+Bro's activation routine (`identity_get` + `issue_resume` on every triggered message) is now fired deterministically by `scripts/hooks/activation-routine.sh` instead of relying on prompt discipline. The h4 A/B (5 paired runs × 2 wording arms) showed prompt compliance was 0/10 in *both* arms — the strongest possible imperative ("MANDATORY on every triggered message") still didn't move the needle. With prompt-only enforcement structurally unreliable for high-frequency operations, the only honest fix is to wire it into code.
+
+**The hook**:
+- Triggers on `UserPromptSubmit` when bro mode is active (current prompt contains `bro` case-insensitively, OR transcript shows a prior `Entering bro mode.` line with no later `exit bro mode`).
+- Reads `identity.human_name` + the latest open `issues` row from the trajectory DB (no MCP roundtrip — direct sqlite3 read).
+- Emits `additionalContext` JSON for CC's UserPromptSubmit hook protocol, pre-fetching the data into the model's context.
+- Silent no-op when the DB doesn't exist yet (first activation in a fresh project — bro falls back to calling MCP tools the old way; future messages in that project then have the DB available).
+
+**Doctrine consequence**: CLAUDE.md `## Activation routine` section reworded — bro now consumes the injected context instead of being told to call MCP tools first. Compliance becomes 10/10 mechanically.
+
 ### Removed — Direct Mode (#108)
 
 Bro is now a pure planner: every code change goes through SWE, no exceptions. The `tmb_direct-mode` skill, the matching L4 workflow-sim test, the L5 D-direct-mode flow, and the h3-direct-mode-framing A/B scenario are all gone. The `direct_mode_used` event_type is dropped from `ledger.event_type` enum.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,20 +39,15 @@ When you're guessing, label it. Cite the source when relevant.
 
 Every MCP call MUST include `agent: 'bro'`. Server rejects others. For forbidden-tool errors and `is_error: true` recovery: `tmb_mcp-error-handling`. Plugin agents: `swe` + `pr-reviewer` ship globally; consultants (`architect`, `cto`, `ceo`, `pm`) are templates instantiated per-project via `tmb_agent-creator`. Full agent model: `docs/AGENTS.md`.
 
-## Activation routine — MANDATORY on every triggered message
+## Activation routine — pre-fetched by hook
 
-**No exceptions. This routine fires on EVERY message you handle as bro — including casual ones like `@bro hi`, `@bro yo`, `@bro thanks`, `@bro cool`. The two MCP reads cost ~50ms total. Skipping them silently breaks the audit trail and the welcome-banner contract.**
+Identity + pending issue are read deterministically by the `activation-routine.sh` UserPromptSubmit hook on every bro-triggered message. The hook injects them as `additionalContext` like:
 
-If you find yourself thinking *"this message is too casual for the chain"* — that's a doctrine violation. Run it anyway.
+> `[tmb activation routine — pre-fetched by hook] identity=<name>; pending=#N: <objective>. Use this to compose the welcome banner; do NOT also call identity_get / issue_resume — they would be redundant duplicate reads.`
 
-In your first response after activation, emit two parallel MCP reads BEFORE the welcome banner:
+Use that injected context to compose the welcome banner. **Do not** also call `identity_get` / `issue_resume` yourself — they're redundant after the hook ran. (If the hook silently no-op'd because the trajectory DB doesn't exist yet — first activation in a fresh project — fall back to calling them via MCP.)
 
-- `identity_get(agent='bro')` — get the human's name (returns null if they haven't reonboarded yet — that's normal, not an error)
-- `issue_resume(agent='bro')` — pull pending work, if any
-
-Then emit the welcome banner. Then handle the actual ask.
-
-Policy keys (`branching_model`, `pr_target`, `protected_branches`) are seeded at trajectory DB init by the schema — bro never writes them; fetch via `config_get` only when you need a specific value (don't add to the activation routine).
+Policy keys (`branching_model`, `pr_target`, `protected_branches`) are seeded at trajectory DB init by the schema — bro never writes them; fetch via `config_get` only when you need a specific value.
 
 ## Welcome banner (mandatory)
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/activation-routine.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "WorktreeCreate": [
       {
         "matcher": "",

--- a/scripts/hooks/activation-routine.sh
+++ b/scripts/hooks/activation-routine.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Activation-routine hook (#108).
+#
+# Pre-fetches identity + pending issue from the trajectory DB on every
+# bro-triggered UserPromptSubmit, and injects them as additionalContext.
+# Bro composes the welcome banner from the injected data instead of relying
+# on prompt-only doctrine to call identity_get + issue_resume — h4 A/B
+# proved that ceiling is 0/10 in both wording arms.
+#
+# Bro mode active when:
+#   - current prompt contains the word "bro" (case-insensitive), OR
+#   - the transcript shows a prior "Entering bro mode." line AND no later
+#     "exit bro mode" / "stop being bro".
+#
+# Silent no-op when:
+#   - not in bro mode
+#   - DB doesn't exist yet (first activation in a fresh project)
+#   - sqlite3 / jq missing
+# Capture failures must never break the user's session.
+
+set -uo pipefail
+
+INPUT=$(cat)
+
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // ""' 2>/dev/null)
+TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null)
+
+contains_bro_word() {
+  echo "$1" | grep -qiE '\bbro\b'
+}
+
+is_sticky_bro() {
+  [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ] || return 1
+  grep -q 'Entering bro mode.' "$TRANSCRIPT" 2>/dev/null || return 1
+  if grep -qiE 'exit bro mode|stop being bro' "$TRANSCRIPT" 2>/dev/null; then
+    return 1
+  fi
+  return 0
+}
+
+if ! contains_bro_word "$PROMPT" && ! is_sticky_bro; then
+  exit 0
+fi
+
+DB_PATH="${TRAJECTORY_DB_PATH:-}"
+if [ -z "$DB_PATH" ]; then
+  PLUGIN_NAME="tmb"
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; then
+    PLUGIN_NAME=$(jq -r '.name // "tmb"' "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null || echo "tmb")
+  fi
+  DB_PATH="$PWD/.claude/$PLUGIN_NAME/trajectory.db"
+fi
+
+[ -f "$DB_PATH" ] || exit 0
+command -v sqlite3 >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+IDENTITY=$(sqlite3 "$DB_PATH" "SELECT human_name FROM identity LIMIT 1;" 2>/dev/null)
+PENDING=$(sqlite3 -separator $'\x1f' "$DB_PATH" "SELECT id, objective FROM issues WHERE status='open' ORDER BY id DESC LIMIT 1;" 2>/dev/null)
+
+if [ -n "$IDENTITY" ]; then
+  IDENTITY_LINE="identity=${IDENTITY}"
+else
+  IDENTITY_LINE="identity=<unset> (use anonymous greeting)"
+fi
+
+if [ -n "$PENDING" ]; then
+  PENDING_ID="${PENDING%%$'\x1f'*}"
+  PENDING_OBJ="${PENDING#*$'\x1f'}"
+  PENDING_LINE="pending=#${PENDING_ID}: ${PENDING_OBJ}"
+else
+  PENDING_LINE="pending=<none>"
+fi
+
+CONTEXT="[tmb activation routine — pre-fetched by hook] ${IDENTITY_LINE}; ${PENDING_LINE}. Use this to compose the welcome banner; do NOT also call identity_get / issue_resume — they would be redundant duplicate reads."
+
+jq -nc --arg ctx "$CONTEXT" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: $ctx
+  }
+}'

--- a/tests/hooks/activation-routine.test.sh
+++ b/tests/hooks/activation-routine.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Tests for scripts/hooks/activation-routine.sh.
+# Hook contract: on UserPromptSubmit, when bro mode is active, read
+# identity + pending issue from trajectory.db and emit additionalContext
+# JSON. Silent no-op otherwise.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../lib/assert.sh"
+PLUGIN_ROOT="$(cd "$HERE/../.." && pwd)"
+HOOK="$PLUGIN_ROOT/scripts/hooks/activation-routine.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+DB="$TMPDIR/trajectory.db"
+TRANSCRIPT_BRO="$TMPDIR/transcript-bro.jsonl"
+TRANSCRIPT_EXITED="$TMPDIR/transcript-exited.jsonl"
+TRANSCRIPT_PLAIN="$TMPDIR/transcript-plain.jsonl"
+
+export TRAJECTORY_DB_PATH="$DB"
+
+sqlite3 "$DB" "
+  CREATE TABLE identity (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    human_name TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  );
+  CREATE TABLE issues (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    objective TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'open',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+"
+
+echo '{"role":"assistant","content":"Entering bro mode."}' > "$TRANSCRIPT_BRO"
+echo '{"role":"assistant","content":"Entering bro mode."}' > "$TRANSCRIPT_EXITED"
+echo '{"role":"user","content":"exit bro mode"}' >> "$TRANSCRIPT_EXITED"
+echo '{"role":"user","content":"hello"}' > "$TRANSCRIPT_PLAIN"
+
+input() {
+  jq -n --arg p "$1" --arg t "${2:-}" '{prompt:$p, transcript_path:$t}'
+}
+
+run_hook() {
+  echo "$1" | bash "$HOOK" 2>&1 || true
+}
+
+# ---- non-bro paths: silent no-op ----
+
+test_case "plain prompt + no transcript: silent no-op"
+out=$(run_hook "$(input 'just a normal claude question')")
+assert_eq "" "$out" "no output"
+
+test_case "plain prompt + plain transcript: silent no-op"
+out=$(run_hook "$(input 'still just regular work' "$TRANSCRIPT_PLAIN")")
+assert_eq "" "$out" "no output"
+
+test_case "word brother (or similar) does not false-trigger via \\bbro\\b"
+out=$(run_hook "$(input 'my brother said hi')")
+assert_eq "" "$out" "no output for substring match"
+
+test_case "transcript had bro mode but user later exited: no-op"
+out=$(run_hook "$(input 'normal followup' "$TRANSCRIPT_EXITED")")
+assert_eq "" "$out" "no output once bro mode exited"
+
+# ---- bro trigger paths: emit additionalContext ----
+
+test_case "@bro greeting + empty DB state (no identity, no pending): emit unset/none"
+out=$(run_hook "$(input '@bro hi')")
+assert_contains "$out" '"hookEventName":"UserPromptSubmit"' "JSON has correct event name"
+assert_contains "$out" 'identity=<unset>' "identity reported as unset"
+assert_contains "$out" 'pending=<none>' "pending reported as none"
+
+test_case "@bro greeting + identity row present: emit human name"
+sqlite3 "$DB" "INSERT INTO identity (id, human_name, created_at, updated_at) VALUES (1, 'Zax', datetime('now'), datetime('now'));"
+out=$(run_hook "$(input '@bro hi')")
+assert_contains "$out" 'identity=Zax' "identity reported with name"
+
+test_case "@bro greeting + pending issue: emit issue id + objective"
+sqlite3 "$DB" "INSERT INTO issues (objective, status) VALUES ('Wire activation routine hook', 'open');"
+out=$(run_hook "$(input '@bro continue')")
+assert_contains "$out" 'pending=#1: Wire activation routine hook' "pending issue rendered"
+
+test_case "sticky bro mode (transcript has Entering bro mode., no exit): non-bro prompt still triggers"
+out=$(run_hook "$(input 'what about pyproject.toml' "$TRANSCRIPT_BRO")")
+assert_contains "$out" '"hookEventName":"UserPromptSubmit"' "sticky bro fires hook"
+assert_contains "$out" 'identity=Zax' "still pre-fetches identity"
+
+# ---- DB-missing graceful path ----
+
+test_case "bro trigger but DB doesn't exist: silent no-op (graceful first-activation)"
+rm -f "$DB"
+out=$(run_hook "$(input '@bro hi')")
+assert_eq "" "$out" "no output when DB missing"


### PR DESCRIPTION
## Summary

Wires bro's activation routine (`identity_get + issue_resume`) into a `UserPromptSubmit` hook so it fires deterministically on every bro-triggered message instead of relying on prompt-only doctrine (which the h4 A/B proved is 0/10 in both wording arms).

**Core invention rationale:** DB-as-memory is one of the two core inventions; if a hook works, we use the hook.

## What changed

### `scripts/hooks/activation-routine.sh` (new)
- Triggers on `UserPromptSubmit` when bro mode is active:
  - current prompt contains the word `bro` (case-insensitive, `\bbro\b` so `brother` doesn't false-trigger), **OR**
  - transcript shows a prior `Entering bro mode.` line with no later `exit bro mode` / `stop being bro`.
- Reads `identity.human_name` + latest open `issues` row directly from the trajectory DB (no MCP roundtrip — pure reads, ~5ms).
- Emits `additionalContext` JSON per CC's UserPromptSubmit hook protocol — pre-fetches the data into the model's context.
- Silent no-op on:
  - non-bro prompts
  - missing trajectory DB (first activation in a fresh project — bro then falls back to calling MCP tools the old way; future messages have the DB available)
  - missing `sqlite3` / `jq`

### `hooks/hooks.json`
Adds the new `UserPromptSubmit` matcher block.

### `CLAUDE.md`
The `## Activation routine` section is reworded. Old version: "MANDATORY — call `identity_get` + `issue_resume` first." New version: "consume the `[tmb activation routine — pre-fetched by hook]` `additionalContext`; do NOT also call the MCP tools (redundant)." The MCP tools stay callable on demand.

### `tests/hooks/activation-routine.test.sh` (new)
12 assertions covering:
- Silent no-op on plain prompts (with and without transcript)
- Word `brother` does NOT false-trigger
- `exit bro mode` correctly suppresses sticky activation
- `@bro hi` with empty DB emits `identity=<unset>`, `pending=<none>`
- `@bro hi` with identity row emits the human name
- `@bro hi` with pending issue emits `pending=#N: <objective>`
- Sticky bro mode: non-bro prompt + transcript with `Entering bro mode.` still fires
- Missing DB: silent no-op (graceful first-activation fallback)

### `CHANGELOG.md`
New `## Unreleased` entry documenting the hook + the doctrine consequence.

## Test plan

- [x] `bash tests/hooks/activation-routine.test.sh` — 12/12 pass
- [x] `bash tests/run-all.sh` — full L1+L2+L3 still green; "All 4 hook test files passed" (was 3)
- [ ] CI confirms

## Follow-on (not in this PR)

- Once #165 (action versions + token-prefix) merges and this lands, run h1 (CLAUDE.md slim) + h2 (Hybrid D' vs lazy) A/B to close out #153 with the hook live.
- Cut v0.4.3 stable bundling: #160, #161, #162, #163, #165, this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)