### PR TITLE
🔧 chore: rename 7 default skills → tmb_* (collision-free open namespace)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+### Refactored — all plugin-shipped skills now use `tmb_` prefix
+
+The 7 default workflow skills (`code-quality`, `docs-conventions`, `git-conventions`, `naming-conventions`, `review-findings`, `review-protocol`, `swe-checklist`) were the only plugin-shipped skills without the `tmb_` namespace prefix — an inconsistency with the rule "global plugin skills use `tmb_`; the open namespace is reserved for user/`tmb_skill-creator`-generated project-local skills." Renamed to `tmb_code-quality`, `tmb_docs-conventions`, …
+
+**Why it matters**: collision-free open namespace. Previously, if a user asked bro to create a `git-conventions` skill, it could collide with the plugin default. Now the open namespace is exclusively user-owned and the plugin-shipped namespace is fully claimed by `tmb_*`.
+
+**Override semantics unchanged**: a project-local `<project>/.claude/skills/tmb_git-conventions/SKILL.md` still shadows the plugin's by name resolution. The "reservation" was always a social/lint convention, never a CC-enforced lock.
+
+**Refs updated**: `agents/swe.md`, `docs/AGENTS.md`, `docs/architecture/FILES.md`, `docs/architecture/FLOWS.md`, and 6 cross-referencing SKILL.md files. `CHANGELOG.md` history entries left intact (accurate records of the un-prefixed era).
+
 ### Added — activation-routine UserPromptSubmit hook (#108)
 
 Bro's activation routine (`identity_get` + `issue_resume` on every triggered message) is now fired deterministically by `scripts/hooks/activation-routine.sh` instead of relying on prompt discipline. The h4 A/B (5 paired runs × 2 wording arms) showed prompt compliance was 0/10 in *both* arms — the strongest possible imperative ("MANDATORY on every triggered message") still didn't move the needle. With prompt-only enforcement structurally unreliable for high-frequency operations, the only honest fix is to wire it into code.

--- a/agents/swe.md
+++ b/agents/swe.md
@@ -18,6 +18,6 @@ Atomic close (#W4): batch in one response — commit (using the spec's `## Commi
 
 Never push. Never commit secrets. Never edit outside the worktree. Never author the spec body — that's bro's role and the server enforces it. **Never attempt to bypass a PreToolUse hook block** — do not rewrite `.git/HEAD`, fabricate refs, edit `.git/` internals, or use any technique to evade a hook decision. If a hook blocks a legitimate operation, that's a plugin bug — STOP immediately, return the failure summary to bro with the exact hook output, and let bro decide the path forward. Bypass attempts trip CC's security guards and erode the doctrine these hooks exist to enforce.
 
-If you need a stack-specific verification checklist, invoke the project's `swe-checklist` skill via the Skill tool **only when the spec's `## Verification` section needs interpretation** — not by default. Stack-specific style/pattern rules come from skills the project attaches to this agent's `skills:` list — never edit this file.
+If you need a stack-specific verification checklist, invoke the project's `tmb_swe-checklist` skill via the Skill tool **only when the spec's `## Verification` section needs interpretation** — not by default. Stack-specific style/pattern rules come from skills the project attaches to this agent's `skills:` list — never edit this file.
 
 **Do not read project-level `CLAUDE.md`** — that file is bro's persona; this agent's prompt is canonical for SWE work.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -42,12 +42,12 @@ Never confuse layers: a "more skilled SWE" means swe.md plus added skills, not a
 
 `skills/` holds both the `tmb_*` protocol skills (immutable, reserved by plugin) AND the default workflow skills used by global agents:
 
-- `swe-checklist`
-- `code-quality`
-- `docs-conventions`
-- `git-conventions`
-- `naming-conventions`
-- `review-protocol`
-- `review-findings`
+- `tmb_swe-checklist`
+- `tmb_code-quality`
+- `tmb_docs-conventions`
+- `tmb_git-conventions`
+- `tmb_naming-conventions`
+- `tmb_review-protocol`
+- `tmb_review-findings`
 
 All are globally discoverable. Project-local `<project>/.claude/skills/<name>/SKILL.md` overrides by name. Onboarding does NOT copy skills into projects — the global ones serve every project until a customization is needed.

--- a/docs/architecture/FILES.md
+++ b/docs/architecture/FILES.md
@@ -73,13 +73,13 @@ plugin/
 │   ├── tmb_skill-creator/            # propose & write new skill files; appends to consuming agent's skills:
 │   ├── tmb_swe-spawn-workflow/       # bro's protocol for spawning SWE with task_id + spec
 │   ├── # Default workflow skills (used by global agents; project overrides per-name)
-│   ├── code-quality/                 # generic quality gates (error handling, security, edges)
-│   ├── docs-conventions/             # docs-update rules + prompt-editing discipline
-│   ├── git-conventions/              # emoji-prefixed commits, branch naming
-│   ├── naming-conventions/           # file/variable/test naming rules
-│   ├── review-findings/              # pr-reviewer output format
-│   ├── review-protocol/              # pr-reviewer full protocol
-│   └── swe-checklist/                # SWE pre-commit checklist (lazy-loaded by SWE on demand)
+│   ├── tmb_code-quality/                 # generic quality gates (error handling, security, edges)
+│   ├── tmb_docs-conventions/             # docs-update rules + prompt-editing discipline
+│   ├── tmb_git-conventions/              # emoji-prefixed commits, branch naming
+│   ├── tmb_naming-conventions/           # file/variable/test naming rules
+│   ├── tmb_review-findings/              # pr-reviewer output format
+│   ├── tmb_review-protocol/              # pr-reviewer full protocol
+│   └── tmb_swe-checklist/                # SWE pre-commit checklist (lazy-loaded by SWE on demand)
 │
 ├── # Consultant templates (opt-in — copied per-project on first request via tmb_agent-creator)
 ├── templates/

--- a/docs/architecture/FLOWS.md
+++ b/docs/architecture/FLOWS.md
@@ -14,7 +14,7 @@
 > and are instantiated per-project on demand via `tmb_agent-creator`.
 >
 > All skills — both `tmb_*` protocol skills and the default workflow
-> skills (`swe-checklist`, `code-quality`, `docs-conventions`, etc.) —
+> skills (`tmb_swe-checklist`, `tmb_code-quality`, `tmb_docs-conventions`, etc.) —
 > live in `plugin/skills/` and are globally discoverable. Project-local
 > `<project>/.claude/skills/<name>/SKILL.md` overrides by name.
 
@@ -27,11 +27,11 @@ Companion docs: [`ERD.md`](ERD.md) for schema, [`FILES.md`](FILES.md) for the fi
 | # | Flow | Trigger | Agents | Key skills | DB tables touched | Hooks |
 |---|---|---|---|---|---|---|
 | 1 | [First contact](#1-first-contact-defaults-applied-silently) | First activation in a project | bro | (none — inline default-write) | `plugin_config`, `ledger` | — |
-| 2 | [Simple task](#2-simple-task) | Code change, no architecture impact | bro → swe (pr-reviewer at push time only) | `tmb_planning-simple` (bro), `swe-checklist` (lazy on demand) | `issues`, `tasks`, `ledger` (per task) + `validation_attempts` (at push) | `require-task-spec`, `git-push-guard`, `git-guards` |
+| 2 | [Simple task](#2-simple-task) | Code change, no architecture impact | bro → swe (pr-reviewer at push time only) | `tmb_planning-simple` (bro), `tmb_swe-checklist` (lazy on demand) | `issues`, `tasks`, `ledger` (per task) + `validation_attempts` (at push) | `require-task-spec`, `git-push-guard`, `git-guards` |
 | 3 | [Difficult task](#3-difficult-task) | Code change touching `docs/trustmybot/architecture/` | bro (full discussion + ADR) → swe (pr-reviewer at push time) | + `tmb_planning-difficult` (env probe, Q+A, ADR) | + `discussions`, ADR file | same |
 | 4 | [Agent-creator](#4-agent-creator-on-demand-domain-agent) | Routing hits a role not in `.claude/agents/` | bro → human | `tmb_agent-creator` | — | — |
 | 5 | [Skill creation](#5-skill-creation) | Recurring pattern needs encoding | bro | `tmb_skill-creator` | `skills` (optional, for tracking) | — |
-| 6 | [Push gate / PR review](#6-push-gate--pr-review) | `git push` to protected branch | bro → pr-reviewer (one per unsigned task, parallel) | `review-protocol`, `review-findings`, `code-quality` | `tasks` (read), `validation_attempts` (write), `discussions` (optional FAIL) | `git-push-guard` |
+| 6 | [Push gate / PR review](#6-push-gate--pr-review) | `git push` to protected branch | bro → pr-reviewer (one per unsigned task, parallel) | `tmb_review-protocol`, `tmb_review-findings`, `tmb_code-quality` | `tasks` (read), `validation_attempts` (write), `discussions` (optional FAIL) | `git-push-guard` |
 | 7 | [Architecture regen](#7-architecture-regen) | First code-touching ask of session OR `/tmb refresh-architecture` | bro | `tmb_refresh-architecture`, `tmb_lazy-regen-check` | `regen_state`, `file_registry` | — |
 | 8 | [SWE retry / escalation](#8-swe-retry--escalation) | Bro verification or pr-reviewer verdict='fail' | bro ↔ swe (↔ pr-reviewer when at push gate) | `tmb_feedback-loop` | `validation_attempts` (multiple rows), `discussions` | `git-push-guard` |
 | 9 | [Roundtable](#9-roundtable-multi-agent-deliberation) | Multi-consultant deliberation | bro orchestrates 2-4 project-local consultants | `tmb_roundtable`, `tmb_roundtable-cleanup` | `discussions`, `ledger` (and reserved: `roundtables`, `roundtable_votes`) | — |
@@ -88,7 +88,7 @@ sequenceDiagram
 **Involved:**
 - Agents: `bro` (planner + task gate), `swe` (executor)
 - Skills loaded by bro on demand: `tmb_planning-simple` or `tmb_planning-difficult` per triage, `tmb_swe-spawn-workflow` (right before SWE handoff)
-- Skills loaded by swe: `swe-checklist` **only on demand** (when spec verification needs interpretation; not eager)
+- Skills loaded by swe: `tmb_swe-checklist` **only on demand** (when spec verification needs interpretation; not eager)
 - MCP tools: `issue_create`, `discussion_append`, `task_create_batch`, `task_get`, `task_update_status`, `ledger_log` (no `validation_record` per task — that fires at push time)
 - DB tables: `issues`, `tasks`, `discussions`, `ledger`, `audit`
 - Hooks: `require-task-spec` (gates SWE spawn), `git-push-guard` (gates `git push`), `git-guards` (commit branch check)

--- a/skills/tmb_code-quality/SKILL.md
+++ b/skills/tmb_code-quality/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: code-quality
+name: tmb_code-quality
 description: Shared quality criteria for design, implementation, and review. Used by bro (design-time), SWE (implementation-time), and PR Reviewer (review-time). Covers error handling, edge cases, database safety, Python patterns, test isolation, and the self-review checklist.
 ---
 
@@ -195,4 +195,4 @@ Run before reporting COMPLETED. If any item fails, fix it.
 
 **CRITICAL: Every code change must be tested before reporting COMPLETED.** Untested code is rejected. Lint/build passing is necessary but NOT sufficient — you must run the corresponding unit tests and, for behavioral changes, verify the actual runtime behavior. If tests don't exist for the changed code, note that in your report.
 
-> Common review findings: `skills/review-findings/SKILL.md`
+> Common review findings: `skills/tmb_review-findings/SKILL.md`

--- a/skills/tmb_concerns-protocol/SKILL.md
+++ b/skills/tmb_concerns-protocol/SKILL.md
@@ -36,7 +36,7 @@ Use when the concern is about HOW the work is being framed — scope, ordering, 
 
 ### Path B — Spawn a consultant (technical disagreement)
 
-Use when the concern is technical — architecture, security, performance, code-quality — and you want an independent read.
+Use when the concern is technical — architecture, security, performance, tmb_code-quality — and you want an independent read.
 
 1. Identify the relevant consultant (`architect`, `cto`, etc.). If absent, invoke `tmb_agent-creator` first.
 2. Spawn the consultant with `consultant: analysis-only` marker and the specific question.

--- a/skills/tmb_docs-conventions/SKILL.md
+++ b/skills/tmb_docs-conventions/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: docs-conventions
+name: tmb_docs-conventions
 description: When and how to update docs alongside code changes, plus the discipline for editing agent prompts and skill files.
 agent: bro, swe, pr-reviewer
 ---

--- a/skills/tmb_feedback-loop/SKILL.md
+++ b/skills/tmb_feedback-loop/SKILL.md
@@ -19,22 +19,22 @@ Every bug caught after SWE submits is a system failure. Learn from it.
 For each bug:
 
 1. **Is this new or known?**
-   - Check `skills/review-findings/SKILL.md` and `skills/code-quality/SKILL.md`
+   - Check `skills/tmb_review-findings/SKILL.md` and `skills/tmb_code-quality/SKILL.md`
    - If already covered → agent ignored criteria
    - If NOT covered → gap, proceed to Q2
 
 2. **Where should knowledge live?**
-   - Specific code pattern → `skills/review-findings/SKILL.md`
-   - Design-time question → `skills/code-quality/SKILL.md`
-   - Implementation rule → `skills/code-quality/SKILL.md`
+   - Specific code pattern → `skills/tmb_review-findings/SKILL.md`
+   - Design-time question → `skills/tmb_code-quality/SKILL.md`
+   - Implementation rule → `skills/tmb_code-quality/SKILL.md`
 
 3. **Was the task underspecified?**
    - If SWE had to guess → update task template or quality checklist
 
 ## Format for New Entries
 
-- review-findings.md: `- **[pattern name]** — [what happens]. [why wrong]. [what to do].`
-- code-quality.md: `- [concise check — one line, actionable]`
+- tmb_review-findings.md: `- **[pattern name]** — [what happens]. [why wrong]. [what to do].`
+- tmb_code-quality.md: `- [concise check — one line, actionable]`
 
 ## What NOT to Add
 

--- a/skills/tmb_git-conventions/SKILL.md
+++ b/skills/tmb_git-conventions/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: git-conventions
+name: tmb_git-conventions
 description: Commit message style, branching rules, push safety.
 agent: bro, swe, pr-reviewer
 ---

--- a/skills/tmb_naming-conventions/SKILL.md
+++ b/skills/tmb_naming-conventions/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: naming-conventions
+name: tmb_naming-conventions
 description: File and identifier naming patterns.
 agent: swe, pr-reviewer
 paths: ["src/**", "lib/**", "app/**", "tests/**"]

--- a/skills/tmb_review-findings/SKILL.md
+++ b/skills/tmb_review-findings/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: review-findings
+name: tmb_review-findings
 description: Living list of patterns caught during code review. All agents internalize these before designing, implementing, or reviewing.
 ---
 

--- a/skills/tmb_review-protocol/SKILL.md
+++ b/skills/tmb_review-protocol/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: review-protocol
+name: tmb_review-protocol
 description: Review phases 1-7 for PR Reviewer. Progression from staged diff scan to full design compliance check.
 ---
 

--- a/skills/tmb_skill-creator/SKILL.md
+++ b/skills/tmb_skill-creator/SKILL.md
@@ -13,7 +13,7 @@ Add a new capability to a project's agents without editing their body. The Lego 
 
 ## When invoked
 
-- Bro detects a project needs a new skill (e.g. Python-stack swe needs a Python-specific verification checklist that the default `swe-checklist` doesn't cover).
+- Bro detects a project needs a new skill (e.g. Python-stack swe needs a Python-specific verification checklist that the default `tmb_swe-checklist` doesn't cover).
 - Human asks bro to teach an agent a specific behavior (`@bro teach swe to also run mypy as part of verification`).
 - A consultant flagged that the project lacks a skill needed for a domain (e.g. cto says "you should have a perf-budget skill on swe").
 

--- a/skills/tmb_swe-checklist/SKILL.md
+++ b/skills/tmb_swe-checklist/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: swe-checklist
+name: tmb_swe-checklist
 description: Implementation rules and self-review checklist for SWE agent.
 ---
 


### PR DESCRIPTION
## Summary

The 7 default workflow skills shipped without the `tmb_` namespace prefix while every other plugin skill used it — inconsistent with the rule **"`tmb_*` = global plugin-shipped (reserved); open namespace = user / `tmb_skill-creator`-generated."**

## Renames

| Old | New |
|---|---|
| `skills/code-quality/` | `skills/tmb_code-quality/` |
| `skills/docs-conventions/` | `skills/tmb_docs-conventions/` |
| `skills/git-conventions/` | `skills/tmb_git-conventions/` |
| `skills/naming-conventions/` | `skills/tmb_naming-conventions/` |
| `skills/review-findings/` | `skills/tmb_review-findings/` |
| `skills/review-protocol/` | `skills/tmb_review-protocol/` |
| `skills/swe-checklist/` | `skills/tmb_swe-checklist/` |

## Why

**Collision-free open namespace.** Previously, if a user asked bro to create a `git-conventions` skill, it could collide with the plugin default. Now the open namespace is exclusively user-owned and the plugin namespace is fully claimed by `tmb_*`.

**Override semantics unchanged.** A project-local `<project>/.claude/skills/tmb_git-conventions/SKILL.md` still shadows the plugin's by name resolution. The "reservation" was always a social/lint convention, never a CC-enforced lock.

## What changed

- 7 skill directories renamed (git tracks as renames; content 97-99% similarity per stats).
- Frontmatter `name:` field in each renamed skill bumped to `tmb_<name>`.
- Cross-references updated:
  - `agents/swe.md` (skills: list)
  - `docs/AGENTS.md` (skill availability matrix)
  - `docs/architecture/FILES.md` (skill index tree)
  - `docs/architecture/FLOWS.md` (skill name mentions)
  - `skills/tmb_concerns-protocol/`, `tmb_feedback-loop/`, `tmb_skill-creator/`, `tmb_code-quality/`, `tmb_review-findings/`, `tmb_docs-conventions/`, `tmb_git-conventions/`, `tmb_review-protocol/`, `tmb_naming-conventions/` (`SKILL.md` cross-refs)

`CHANGELOG.md` history entries that mention the old names are intentionally **left intact** — they're accurate records of when those skills shipped under the un-prefixed names.

## Test plan

- [x] `bash tests/run-all.sh` (L1 + L2 + L3 + 4 hook test files) — green
- [x] No naked refs to old names remain anywhere outside CHANGELOG
- [ ] CI confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)