### PR TITLE
🔖 chore(release): bump v0.4.2 → v0.5.0 + CHANGELOG header

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "TMB plugin — bro orchestrates SWE + pr-reviewer in two gates (task gate, push gate) backed by a SQLite trajectory MCP server.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
-## Unreleased
+## v0.5.0 — 2026-04-27
+
+**Headline: bro is now a structurally-enforced pure planner.** Direct Mode removed (#162) and 7 hard-enforcement hooks promote previously prompt-only doctrine to Layer 2 (deterministic shell scripts). New `docs/architecture/ENFORCEMENT.md` documents the 6-layer model (MCP middleware → hooks → frontmatter → tool-handler validation → skill `paths:` → prompts) and the per-agent × per-interaction coverage matrix.
+
+**Breaking changes (pre-1.0 minor bump per SemVer):**
+- Direct Mode is gone. Bro never edits source code; every code change routes through SWE. Trivial fixes go via the same chain (lighter spec, not a separate code path).
+- All plugin-shipped skills now use `tmb_*` prefix (was 7 un-prefixed defaults). Project-local skills with un-prefixed names are unaffected.
 
 ### Added — 4 hard-enforcement hooks (branch authority + worktree hygiene) (#170, #171)
 

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "TMB multi-agent Claude Code plugin — workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Summary

Bumps 3 manifests `0.4.2 → 0.5.0` and folds CHANGELOG `## Unreleased` entries under `## v0.5.0 — 2026-04-27` with a headline + breaking-changes call-out.

## Why a minor bump (not patch)

This batch is well beyond a patch — it's the **bro-as-pure-planner** doctrine landing structurally:

**Breaking behavioral change:**
- **Direct Mode removed (#162).** Bro never edits source code. Every code change routes through SWE, no exceptions. Trivial fixes go via the same chain (lighter spec, not a separate code path).

**Breaking namespace change:**
- **All 7 default skills renamed to `tmb_*` prefix (#167)** — `code-quality` → `tmb_code-quality`, etc. Plugin-shipped skills are now name-locked under the `tmb_` reservation; the open namespace is exclusively for project-local user-created skills (no collision footgun).

**New structural enforcement (7 hooks, Layer 2):**
- `activation-routine.sh` (#166) — UserPromptSubmit pre-fetches `identity` + pending issue
- `no-source-edit-from-main.sh` (#169) — bro can't Edit source outside a worktree
- `session-start-regen-check.sh` (#169) — nudges architecture regen when stale
- `ensure-gitignore.sh` (#172) — `.claude/` always in project `.gitignore`
- `no-worktree-branch-create.sh` (#172) — branch authority is bro's
- `branch-up-to-date-with-remote.sh` (#172) — task branch must descend from latest origin/`pr_target`
- `cleanup-worktree-on-task-close.sh` (#172) — auto-removes worktrees when task closes

**New doc:**
- `docs/architecture/ENFORCEMENT.md` — 6-layer enforcement model + per-agent × per-interaction coverage matrix.

**Other improvements:**
- `tmb_db_path` walks up to git root (was `$(pwd)`-relative; broke when bro `cd`'d into a worktree)
- `TMB_CLAUDE_TIMEOUT` env override for L5/A/B test runners (was hard-coded 180s)
- A/B framework: substrate pre-flight (#161), bug fixes (#160), 4 backfill scenarios (#157)
- L6 → L5 helper namespace rename (#163)
- GH Actions bumped to v5 (Node 24 internal); CC-auth prefix check dropped (#165)

## Test plan

- [x] `bash tests/run-all.sh` — L1 + L2 + L3 + 12 hook test files all green
- [x] Local h5 dogfood (190s, full chain success) validated all 4 hooks from #172
- [ ] CI confirms
- [ ] After merge: cut `v0.5.0-rc.1` tag from dev, fast-forward `rc` branch, validate via `tmb-rc` channel before promoting to stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)