### PR TITLE
🔧 chore(ci): add timeout_per_call input to ab-scenario workflow

### DIFF
--- a/.github/workflows/ab-scenario.yml
+++ b/.github/workflows/ab-scenario.yml
@@ -18,6 +18,10 @@ on:
         description: 'N pairs per arm (default 5)'
         default: '5'
         required: false
+      timeout_per_call:
+        description: 'Per-claude-call timeout in seconds (default 180; raise for code-touching flows that spawn SWE)'
+        default: '180'
+        required: false
 
 permissions:
   contents: read
@@ -49,6 +53,7 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           L5_KEEP_ARTIFACTS: '1'
           N: ${{ env.N_PAIRS }}
+          TMB_CLAUDE_TIMEOUT: ${{ github.event.inputs.timeout_per_call }}
         run: |
           bash tests/dogfood/run-ab.sh "$AB_SCENARIO"
 


### PR DESCRIPTION
## Summary

Adds a \`timeout_per_call\` workflow_dispatch input (default 180s) to \`ab-scenario.yml\`. Plumbs through as \`TMB_CLAUDE_TIMEOUT\` env, which the helpers already honor (#172).

## Why

Default 180s is too tight for code-touching flows. h5 measured the full planning + SWE chain at ~190s locally; the prior CI h5 run had multiple arm A/B failures because runs hit the 180s cap mid-SWE.

## Test plan

- [ ] Workflow lints clean
- [ ] Once merged, dispatch with \`-f timeout_per_call=600\` and confirm the env propagates

🤖 Generated with [Claude Code](https://claude.com/claude-code)