### PR TITLE
🐛 fix: hook bro-detection + stale cold-start test assertions (v0.5.0-rc.1 fallout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,39 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 **Headline: bro is now a structurally-enforced pure planner.** Direct Mode removed (#162) and 7 hard-enforcement hooks promote previously prompt-only doctrine to Layer 2 (deterministic shell scripts). New `docs/architecture/ENFORCEMENT.md` documents the 6-layer model (MCP middleware → hooks → frontmatter → tool-handler validation → skill `paths:` → prompts) and the per-agent × per-interaction coverage matrix.
 
-**Breaking changes (pre-1.0 minor bump per SemVer):**
-- Direct Mode is gone. Bro never edits source code; every code change routes through SWE. Trivial fixes go via the same chain (lighter spec, not a separate code path).
-- All plugin-shipped skills now use `tmb_*` prefix (was 7 un-prefixed defaults). Project-local skills with un-prefixed names are unaffected.
+### Fixed (post-rc.1)
+
+- **`no-source-edit-from-main.sh` bro-mode detection too narrow.** Previously required the assistant to emit `Entering bro mode.` in the transcript — but in `claude -p` headless mode bro routinely skips that announcement (the h3/h4 prompt-discipline ceiling). Hook now also detects bro mode by scanning the transcript for any user message containing the `bro` trigger word. Without this fix, bro shortcut source edits in 3 of 5 v0.5.0-rc.1 L5 dogfood flows. Adds a regression test case (`REGRESSION: user said @bro but assistant skipped announce → still BLOCK`) covering the real-world fixture instead of just the announce-emitted variant.
+- **Stale `tools-required.json` for cold-start flows.** `01-first-contact` and `95-anonymous-cold-restart` still asserted on `identity_get` / `config_get` / `issue_resume` MCP calls — but the activation-routine hook now performs those reads on bro's behalf and injects the data via `additionalContext`. Bro correctly skips the redundant calls per the injected instruction, which the test misread as failure. Cleared both flow assertion lists; the data flow is now verified by the hook's existence + outcome SQL, not by trajectory_required.
+
+### Breaking changes (pre-1.0 minor bump per SemVer)
+
+- **Direct Mode is gone.** Bro never edits source code; every code change routes through SWE. Trivial fixes go via the same chain (lighter spec, not a separate code path). Pushes that previously relied on bro-direct edits will fail; rewrite as task → SWE → bro verify → close.
+- **All plugin-shipped skills now use `tmb_*` prefix.** The 7 un-prefixed defaults (`code-quality`, `docs-conventions`, `git-conventions`, `naming-conventions`, `review-findings`, `review-protocol`, `swe-checklist`) are renamed to `tmb_*`. Project-local skills with un-prefixed names are unaffected; local skills can shadow plugin defaults by name resolution as before.
+
+### New hard-enforcement hooks
+
+The h3 + h4 A/B scenarios proved prompt-only doctrine compliance is 0/10 in both wording arms for high-frequency operations. These 7 hooks move load-bearing rules to deterministic Layer 2:
+
+| Hook | Event | Doctrine enforced |
+|---|---|---|
+| `activation-routine.sh` | UserPromptSubmit | Pre-fetches `identity` + pending issue from the trajectory DB on every bro-triggered message; injects as `additionalContext` so bro never has to remember to call `identity_get` / `issue_resume` |
+| `no-source-edit-from-main.sh` | PreToolUse on Edit/Write/MultiEdit/NotebookEdit | Blocks bro from editing source files outside an SWE worktree (allowlist: markdown, LICENSE, agent/skill prompts, plugin/hooks manifests, `.github/`). Bypass: `TMB_ALLOW_SOURCE_EDIT=1` |
+| `session-start-regen-check.sh` | SessionStart | Computes git drift vs `regen_state.last_seen_sha`; nudges bro to run `tmb_refresh-architecture` when drift > 25 commits (override: `TMB_REGEN_DRIFT_THRESHOLD`) |
+| `ensure-gitignore.sh` | SessionStart | Ensures `.claude/` is in the project's `.gitignore`. Creates `.gitignore` if missing; appends if rule absent; idempotent. Prevents the trajectory.db-leaking-into-worktrees footgun |
+| `no-worktree-branch-create.sh` | PreToolUse on Bash | Blocks `git worktree add -b/-B/--create-branch ...`. Branch authority is bro's: bro pre-creates `<task.branch_id>` from the latest origin, SWE attaches via `git worktree add <path> <branch>` (no creation, no abbreviation). Bypass: `TMB_ALLOW_WORKTREE_BRANCH_CREATE=1` |
+| `branch-up-to-date-with-remote.sh` | PreToolUse on Bash | Fetches `origin/<pr_target>`, denies worktree-add if `<branch>` is behind. Catches the stale-local-main bug. Bypass: `TMB_ALLOW_STALE_BRANCH=1` |
+| `cleanup-worktree-on-task-close.sh` | PostToolUse on `task_update_status` | When bro flips task to `closed`, removes the corresponding `.claude/worktrees/<slug>/`. Commits live on the branch and survive. Bypass: `TMB_KEEP_CLOSED_WORKTREES=1` |
+
+Plus structural improvements: `tmb_db_path` walks up to git root for DB resolution (was `$(pwd)`-relative — broke when bro `cd`'d into a worktree), `TMB_CLAUDE_TIMEOUT` env override for L5/A/B test runners, and `tests/dogfood/lib/flow-helpers.sh:l5_setup_scratch_project` writes `.gitignore` matching real-project behavior.
+
+### Other shipping in v0.5.0
+
+- **A/B framework matures (#131, #157, #160, #161):** runner + helpers + chi-squared stats; 4 backfill hypothesis scenarios (h1 CLAUDE.md slim, h2 Hybrid D' vs lazy, h4 first-action MANDATORY); shared substrate-health pre-flight (#161); `node_modules` symlinking + scenario fixture/setup_files framework fix.
+- **Activation routine hook proven necessary:** h4 A/B (5 paired runs × 2 wording arms) showed prompt-only `identity_get + issue_resume` compliance was 0/10 in both arms — the hook delivers 100% reliability.
+- **L6 → L5 helper namespace cleanup (#163):** `l6_*` shell functions in `tests/dogfood/lib/` renamed to `l5_*` to match the renamed test layer.
+- **GH Actions bumped to v5 (#165):** Node 24 internal runtime; CC-auth prefix check dropped (smoke test is the authoritative gate).
+- **Two CLAUDE.md cleanups (#168, #169):** verify-context decision tree → 2-column table; opaque issue refs dropped.
 
 ### Added — 4 hard-enforcement hooks (branch authority + worktree hygiene) (#170, #171)
 

--- a/scripts/hooks/activation-routine.sh
+++ b/scripts/hooks/activation-routine.sh
@@ -31,11 +31,16 @@ contains_bro_word() {
 
 is_sticky_bro() {
   [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ] || return 1
-  grep -q 'Entering bro mode.' "$TRANSCRIPT" 2>/dev/null || return 1
   if grep -qiE 'exit bro mode|stop being bro' "$TRANSCRIPT" 2>/dev/null; then
     return 1
   fi
-  return 0
+  # Sticky if either the assistant announced explicitly OR any user
+  # message in the transcript contains the `bro` trigger keyword. Catches
+  # the case where bro skipped the announcement (h3/h4 prompt-discipline
+  # ceiling) but the user clearly addressed @bro in a prior turn.
+  grep -q 'Entering bro mode.' "$TRANSCRIPT" 2>/dev/null && return 0
+  grep -qiE '\bbro\b' "$TRANSCRIPT" 2>/dev/null && return 0
+  return 1
 }
 
 if ! contains_bro_word "$PROMPT" && ! is_sticky_bro; then

--- a/scripts/hooks/no-source-edit-from-main.sh
+++ b/scripts/hooks/no-source-edit-from-main.sh
@@ -50,8 +50,18 @@ TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null)
 if [ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ]; then
   exit 0
 fi
-grep -q 'Entering bro mode.' "$TRANSCRIPT" 2>/dev/null || exit 0
+# Bro mode active when:
+#   - Assistant announced "Entering bro mode." (explicit), OR
+#   - Any user message in the transcript contains the word "bro" (the
+#     trigger keyword — same logic CLAUDE.md specifies for activation).
+# The latter catches the real-world case where bro skips the announcement
+# in headless `claude -p` mode (the h3/h4 prompt-discipline ceiling).
+# Sticky-exit: a later "exit bro mode" / "stop being bro" deactivates.
 if grep -qiE 'exit bro mode|stop being bro' "$TRANSCRIPT" 2>/dev/null; then
+  exit 0
+fi
+if ! grep -q 'Entering bro mode.' "$TRANSCRIPT" 2>/dev/null \
+   && ! grep -qiE '\bbro\b' "$TRANSCRIPT" 2>/dev/null; then
   exit 0
 fi
 

--- a/tests/dogfood/flows/01-first-contact/tools-required.json
+++ b/tests/dogfood/flows/01-first-contact/tools-required.json
@@ -1,4 +1,1 @@
-[
-  "mcp__plugin_tmb_trajectory-server__identity_get",
-  "mcp__plugin_tmb_trajectory-server__issue_resume"
-]
+[]

--- a/tests/dogfood/flows/95-anonymous-cold-restart/tools-required.json
+++ b/tests/dogfood/flows/95-anonymous-cold-restart/tools-required.json
@@ -1,5 +1,1 @@
-[
-  "mcp__plugin_tmb_trajectory-server__identity_get",
-  "mcp__plugin_tmb_trajectory-server__config_get",
-  "mcp__plugin_tmb_trajectory-server__issue_resume"
-]
+[]

--- a/tests/hooks/activation-routine.test.sh
+++ b/tests/hooks/activation-routine.test.sh
@@ -88,6 +88,13 @@ out=$(run_hook "$(input 'what about pyproject.toml' "$TRANSCRIPT_BRO")")
 assert_contains "$out" '"hookEventName":"UserPromptSubmit"' "sticky bro fires hook"
 assert_contains "$out" 'identity=Zax' "still pre-fetches identity"
 
+test_case "REGRESSION: user said @bro in prior turn but assistant skipped announce → sticky still fires"
+TRANSCRIPT_NO_ANNOUNCE="$TMPDIR/transcript-no-announce.jsonl"
+echo '{"role":"user","content":"@bro implement the cli"}' > "$TRANSCRIPT_NO_ANNOUNCE"
+echo '{"role":"assistant","content":"On it. What scope?"}' >> "$TRANSCRIPT_NO_ANNOUNCE"
+out=$(run_hook "$(input 'small, single-file' "$TRANSCRIPT_NO_ANNOUNCE")")
+assert_contains "$out" '"hookEventName":"UserPromptSubmit"' "sticky fires without announce marker"
+
 # ---- DB-missing graceful path ----
 
 test_case "bro trigger but DB doesn't exist: silent no-op (graceful first-activation)"

--- a/tests/hooks/no-source-edit-from-main.test.sh
+++ b/tests/hooks/no-source-edit-from-main.test.sh
@@ -26,6 +26,13 @@ echo '{"role":"user","content":"hi"}' > "$TRANSCRIPT_PLAIN"
 echo '{"role":"assistant","content":"Entering bro mode."}' > "$TRANSCRIPT_EXITED"
 echo '{"role":"user","content":"exit bro mode"}' >> "$TRANSCRIPT_EXITED"
 
+# Real-world headless case: user said @bro but assistant skipped the
+# announcement (the h3/h4 prompt-discipline ceiling). Hook must still
+# detect bro mode.
+TRANSCRIPT_BRO_NO_ANNOUNCE="$TMPDIR/bro-no-announce.jsonl"
+echo '{"role":"user","content":"@bro tiny typo fix needed in src/foo.ts: change recieve to receive."}' > "$TRANSCRIPT_BRO_NO_ANNOUNCE"
+echo '{"role":"assistant","content":"On it."}' >> "$TRANSCRIPT_BRO_NO_ANNOUNCE"
+
 input() {
   jq -n --arg tn "$1" --arg fp "$2" --arg t "${3:-}" '{
     tool_name: $tn,
@@ -116,6 +123,10 @@ assert_contains "$out" '"permissionDecision":"deny"' "deny decision emitted"
 test_case "bro mode + tests/lib/assert.sh: BLOCK"
 out=$(run_hook "$(input 'Edit' 'tests/lib/assert.sh' "$TRANSCRIPT_BRO")")
 assert_contains "$out" '"permissionDecision":"deny"' "deny decision emitted"
+
+test_case "REGRESSION: user said @bro but assistant skipped announce → still BLOCK"
+out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_BRO_NO_ANNOUNCE")")
+assert_contains "$out" '"permissionDecision":"deny"' "deny even without 'Entering bro mode.' marker"
 
 # ---- worktree path: SWE allowed ----
 


### PR DESCRIPTION
## Summary

L5 dogfood + release-canary fired automatically on the `v0.5.0-rc.1` tag push and caught two bugs the L1-L4 unit tests missed.

## Bug A — load-bearing: hook bro-detection too narrow

`no-source-edit-from-main.sh` required the assistant to emit `Entering bro mode.` in the transcript before treating the session as bro mode. In `claude -p` headless mode bro routinely skips that announcement (the h3/h4 prompt-discipline ceiling). When skipped → hook exits → Edit goes through.

**Result**: bro shortcut source edits in **3 of 5** v0.5.0-rc.1 L5 dogfood flows:
- `02-simple-task` (no issue/task/planning_complete created — bro just ran Edit)
- `10-codebase-memory-cold-start` (same)
- `12-source-edit-attempt` (same — `[claude] Fixed. src/foo.ts:1 now reads "receive".`)

**Fix**: hook now also detects bro mode by scanning the transcript for **any user message containing the `bro` trigger word**. Sticky-exit logic (`exit bro mode` / `stop being bro`) unchanged. Added regression test case using a transcript fixture where the user said `@bro` but the assistant skipped the announce — exactly the real-world headless case.

## Bug B — test contract drift

`tools-required.json` for `01-first-contact` and `95-anonymous-cold-restart` still asserted on `identity_get` / `config_get` / `issue_resume` MCP calls — but the activation-routine hook (#166) now performs those reads on bro's behalf and tells bro NOT to repeat them in the injected `additionalContext`. Bro correctly skips → test misread as failure.

**Fix**: cleared both flow assertion lists. The activation hook's existence + outcome-SQL assertions cover the doctrine.

## Why L1-L4 didn't catch Bug A

The hook unit test had **fixture bias**. Its bro-mode test transcript always contained `Entering bro mode.` — confirming the hook works *when* bro announces. Never tested the case where bro skips the announcement (the real-world headless case).

The new regression test case (assistant skipped announce, only user said `@bro`) covers the actual real-world failure mode and would have failed before this fix.

## Test plan

- [x] `bash tests/run-all.sh` — L1 + L2 + L3 + 12 hook test files green
- [x] Regression test `REGRESSION: user said @bro but assistant skipped announce → still BLOCK` passes
- [ ] CI confirms
- [ ] After merge: re-cut `v0.5.0-rc.2` from dev, fast-forward `rc`, validate via L5 dogfood + release-canary triggered by the new tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)