### PR TITLE
🐛 fix(ci): wire TMB_CLAUDE_TIMEOUT=600 into l5-dogfood + release-canary

### DIFF
--- a/.github/workflows/l5-dogfood.yml
+++ b/.github/workflows/l5-dogfood.yml
@@ -53,6 +53,11 @@ jobs:
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           L5_KEEP_ARTIFACTS: '1'
+          # Default 180s is too tight for code-touching flows that spawn SWE
+          # (the full planning + SWE chain runs ~190s locally even on a clean
+          # path; v0.5.0-rc.2 had 3 flows fail because runs hit the 180s cap
+          # mid-SWE). 600s gives headroom without ballooning total CI time.
+          TMB_CLAUDE_TIMEOUT: '600'
         run: bash tests/dogfood/run-l5.sh
 
       - name: Upload trajectory dumps on failure

--- a/tests/docker/release-canary.Dockerfile
+++ b/tests/docker/release-canary.Dockerfile
@@ -76,6 +76,11 @@ USER node
 WORKDIR /plugin
 ENV TMB_DEBUG_TRAJECTORY=1
 ENV HOME=/home/node
+# Default 180s is too tight for code-touching flows that spawn SWE
+# (the full planning + SWE chain runs ~190s locally even on a clean path;
+# v0.5.0-rc.2 had 3 flows fail because runs hit the 180s cap mid-SWE).
+# 600s gives headroom without ballooning total CI time.
+ENV TMB_CLAUDE_TIMEOUT=600
 
 # The runner reads CLAUDE_CODE_OAUTH_TOKEN from env. BuildKit secrets are
 # mounted at /run/secrets/<id>; uid=1000 makes the file readable by node.


### PR DESCRIPTION
## Summary

\`v0.5.0-rc.2\` L5 dogfood + release-canary failed on 3 flows because runs hit the default 180s \`claude -p\` timeout mid-SWE chain. The full planning + SWE chain takes ~190s locally even on a clean path.

We added the \`TMB_CLAUDE_TIMEOUT\` env override in #172 and wired it through \`ab-scenario.yml\` in #177 — but missed \`l5-dogfood.yml\` and \`release-canary.Dockerfile\`. This PR fixes that gap.

## rc.2 failure pattern

| Flow | Wall-clock | Failure |
|---|---|---|
| 02-simple-task | 180.4s | SWE cut off before \`file_registry\` + \`last_verified_sha\` update |
| 10-codebase-memory-cold-start | 180.0s | Same — task creation incomplete |
| 11-codebase-memory-verify-on-drift | 180s | Same — md5 not refreshed |
| 12-source-edit-attempt | 180s in canary | \`planning_complete\` event missing |

(12 in L5 dogfood **passed outcome 3/3** — chain ran. Its trajectory_required failure is the separate #164 / #179 stream-json territory.)

## Changes

- \`.github/workflows/l5-dogfood.yml\` — adds \`TMB_CLAUDE_TIMEOUT: '600'\` to the run-l5 step env
- \`tests/docker/release-canary.Dockerfile\` — adds \`ENV TMB_CLAUDE_TIMEOUT=600\` before the L5-runner USER block

## Test plan

- [ ] CI confirms (the doc-only test workflow should pass instantly)
- [ ] After merge: cut v0.5.0-rc.3 → expect L5 dogfood to drop from 3 fails → 1 fail (the #164 trajectory_required one), and release-canary similarly
- [ ] Once we ship #179 (stream-json refactor), the remaining 1 fail goes away too

🤖 Generated with [Claude Code](https://claude.com/claude-code)