### PR TITLE
🐛 fix: no-source-edit-from-main worktree exemption uses target path, not $PWD

### DIFF
--- a/docs/architecture/RESPONSIBILITIES.md
+++ b/docs/architecture/RESPONSIBILITIES.md
@@ -2,7 +2,25 @@
 
 What each plugin-shipped agent is **actually** instructed to do, derived from the agent prompt files + the skills they're wired to. This is the **observable contract**, not the design intent: if it's not in this doc and not in a hook/skill, the agent isn't doing it.
 
+<<<<<<< Updated upstream
 Sources scanned:
+=======
+## Design philosophy
+
+The three roles split by **what each one can be trusted to do without making its own homework, and which one stays alive when something unexpected fires**:
+
+- **bro** is the persona — the main agent, holding most permissions and the full picture (system design + requirement alignment with the Human). **Bro does everything except coding** — including all MCP / DB operations (issues, tasks, discussions, ledger, audit, file_registry summaries). Bro is the only agent that talks to the Human, and the only one with the full `requireRoles` matrix unlocked.
+- **swe** does coding. Three reasons coding is split out:
+  1. **Token-heavy** — letting bro do it would pollute bro's strategic memory with low-level diff noise.
+  2. **No self-homework** — the whole point of separation is bro re-runs verification on SWE's output. The same agent that wrote the code can't be the one marking it.
+  3. **Subagents are fragile** — SWE runs as a CC subagent with a narrowed `tools:` allowlist, frontmatter `disallowedTools`, and a fresh context. Hook denies, permission rejections, MCP errors mid-task can cause a subagent to abort or thrash. Critical state writes (workflow status, summaries, audit) stay with bro, which is the **most permissioned + most resilient** layer — bro can recover, retry, escalate to the Human. SWE is intentionally narrow: one task per spawn, isolated worktree, atomic close, zero spec authority.
+- **pr-reviewer** is an **independent 3rd party**, more focused on git-diff against the spec than on the broader system. Can also pair with bro for integration testing — both have read access to `file_registry` and the whole codebase, so pr-reviewer can sanity-check claims about cross-cutting impact. pr-reviewer is structurally read-only on files (no Edit/Write tool) and is the only agent allowed to call `validation_record` — the formal sign-off the push gate consumes. Same subagent-fragility caveat as SWE: pr-reviewer doesn't own workflow state, only its own verdict.
+
+Everything below is how that philosophy materializes in the prompts, skills, hooks, and `requireRoles` middleware.
+
+## Sources scanned
+
+>>>>>>> Stashed changes
 - `CLAUDE.md` (bro persona, auto-loaded)
 - `agents/swe.md` (SWE prompt)
 - `agents/pr-reviewer.md` (pr-reviewer prompt)
@@ -13,7 +31,7 @@ Sources scanned:
 
 ## bro
 
-Source: **`CLAUDE.md`** (no `agents/bro.md` — bro is a persona on main Claude). Plus the `tmb_*` skills bro loads when triggered.
+Source: `**CLAUDE.md`** (no `agents/bro.md` — bro is a persona on main Claude). Plus the `tmb_*` skills bro loads when triggered.
 
 ### Persistent persona behaviors (every bro-mode message)
 
@@ -25,16 +43,18 @@ Source: **`CLAUDE.md`** (no `agents/bro.md` — bro is a persona on main Claude)
 
 ### Routing (CLAUDE.md ## Routing table)
 
-| Ask shape | bro's action |
-|---|---|
-| "Implement this" / any code change | Code-touching chain (planning → SWE spawn → bro verify → close) |
-| "Review before push" / `git push` blocked | `tmb_push-gate` |
-| "Get architect's / cto's / pm's opinion" | Check local agent file; spawn or `tmb_agent-creator` |
-| Domain role with no shipped template | `tmb_agent-creator` from-scratch + Human approval |
-| Configure / change settings | `tmb_reonboard` |
-| `refresh architecture docs` | `tmb_refresh-architecture` |
-| Disagree with Human's plan | `tmb_concerns-protocol` |
-| File reads / searches / git status | Direct (Read, Glob, Grep, Bash) |
+
+| Ask shape                                 | bro's action                                                    |
+| ----------------------------------------- | --------------------------------------------------------------- |
+| "Implement this" / any code change        | Code-touching chain (planning → SWE spawn → bro verify → close) |
+| "Review before push" / `git push` blocked | `tmb_push-gate`                                                 |
+| "Get architect's / cto's / pm's opinion"  | Check local agent file; spawn or `tmb_agent-creator`            |
+| Domain role with no shipped template      | `tmb_agent-creator` from-scratch + Human approval               |
+| Configure / change settings               | `tmb_reonboard`                                                 |
+| `refresh architecture docs`               | `tmb_refresh-architecture`                                      |
+| Disagree with Human's plan                | `tmb_concerns-protocol`                                         |
+| File reads / searches / git status        | Direct (Read, Glob, Grep, Bash)                                 |
+
 
 ### Code-touching chain (single source of truth: `tmb_planning-simple` / `tmb_planning-difficult`)
 
@@ -45,26 +65,36 @@ Source: **`CLAUDE.md`** (no `agents/bro.md` — bro is a persona on main Claude)
 5. `task_create_batch` + spawn SWE with `task_id=<N>` + `ledger_log(planning_complete)`  [batched]
 6. SWE returns
 7. **bro verification (V1/V2/V3)**:
+<<<<<<< Updated upstream
    - V1 — files match the spec's `## Files`
    - V2 — re-run the spec's `## Verification` commands inside the worktree
    - V3 — each `## Success Criteria` bullet visibly met by the diff
 8. **bro updates file_registry summaries** — `file_registry_update_summaries(updates=[{path, summary, ...}], advance_verified_sha=<commit_sha>)` (#181 — server enforces bro-only; PreToolUse hook gates the next step)
+=======
+  - V1 — files match the spec's `## Files`
+  - V2 — re-run the spec's `## Verification` commands inside the worktree
+  - V3 — each `## Success Criteria` bullet visibly met by the diff
+8. **bro updates file_registry summaries** — `file_registry_update_summaries(updates=[{path, summary, ...}], advance_verified_sha=<commit_sha>)`. Server-enforced bro-only; a PreToolUse hook denies the next step if summaries are missing/stale.
+>>>>>>> Stashed changes
 9. `task_update_status(status='closed')` + `issue_close` (if last task on issue)
 
 ### Reactive skills (loaded on trigger only)
 
-| Trigger | Skill |
-|---|---|
-| AskUserQuestion errors / `TMB_HEADLESS=1` | `tmb_headless-fallback` |
-| MCP `is_error: true` | `tmb_mcp-error-handling` |
-| Push gate | `tmb_push-gate` |
-| Re-onboarding | `tmb_reonboard` |
-| Refresh arch docs | `tmb_refresh-architecture` |
-| Disagreement | `tmb_concerns-protocol` |
+
+| Trigger                                   | Skill                      |
+| ----------------------------------------- | -------------------------- |
+| AskUserQuestion errors / `TMB_HEADLESS=1` | `tmb_headless-fallback`    |
+| MCP `is_error: true`                      | `tmb_mcp-error-handling`   |
+| Push gate                                 | `tmb_push-gate`            |
+| Re-onboarding                             | `tmb_reonboard`            |
+| Refresh arch docs                         | `tmb_refresh-architecture` |
+| Disagreement                              | `tmb_concerns-protocol`    |
+
 
 ### Server-enforced bro privileges (Layer 1)
 
 Bro is the only agent allowed to call:
+
 - `task_create_batch`
 - `task_update_status` (shared with swe; bro for `closed`, swe for `completed`/`failed`)
 - `issue_create`, `issue_close`, `issue_resume`
@@ -75,6 +105,7 @@ Bro is the only agent allowed to call:
 
 ### Hooks fired on bro's behalf
 
+<<<<<<< Updated upstream
 | Hook | When | Effect |
 |---|---|---|
 | `activation-routine.sh` | UserPromptSubmit (bro mode) | Injects identity + pending issue as context |
@@ -85,6 +116,20 @@ Bro is the only agent allowed to call:
 | `branch-up-to-date-with-remote.sh` | PreToolUse Bash | Denies worktree-add to a branch behind `origin/<pr_target>` |
 | `require-summaries-before-task-close.sh` | PreToolUse `task_update_status` | Denies bro's `closed` call when summaries are missing/stale (#181) |
 | `cleanup-worktree-on-task-close.sh` | PostToolUse `task_update_status` | Removes worktree after bro closes task |
+=======
+
+| Hook                                     | When                             | Effect                                                                   |
+| ---------------------------------------- | -------------------------------- | ------------------------------------------------------------------------ |
+| `activation-routine.sh`                  | UserPromptSubmit (bro mode)      | Injects identity + pending issue as context                              |
+| `session-start-regen-check.sh`           | SessionStart                     | Nudges `tmb_refresh-architecture` if arch docs are stale                 |
+| `ensure-gitignore.sh`                    | SessionStart                     | Ensures `.claude/` in project's `.gitignore`                             |
+| `no-source-edit-from-main.sh`            | PreToolUse Edit/Write            | Denies bro source edits outside SWE worktree                             |
+| `no-worktree-branch-create.sh`           | PreToolUse Bash                  | Denies `git worktree add -b/-B` (branch authority is bro's pre-creation) |
+| `branch-up-to-date-with-remote.sh`       | PreToolUse Bash                  | Denies worktree-add to a branch behind `origin/<pr_target>`              |
+| `require-summaries-before-task-close.sh` | PreToolUse `task_update_status`  | Denies bro's `closed` call when summaries are missing/stale              |
+| `cleanup-worktree-on-task-close.sh`      | PostToolUse `task_update_status` | Removes worktree after bro closes task                                   |
+
+>>>>>>> Stashed changes
 
 ### Universal rules
 
@@ -112,6 +157,7 @@ Frontmatter: `model: sonnet`, `maxTurns: 55`, `tools: Read, Glob, Grep, Bash, Wr
 ### Atomic close (`#W4`)
 
 Batch in one response:
+
 1. Commit (using the spec's `## Commit` message)
 2. `task_update_status(agent='swe', status='completed', commit_sha)`
 
@@ -129,6 +175,7 @@ Batch in one response:
 ### Server-enforced SWE privileges (Layer 1)
 
 SWE is allowed to call:
+
 - `task_get` (shared with all agents)
 - `task_update_status` for `completed` / `failed` (bro owns `closed`)
 - `audit_log`, `ledger_log`
@@ -136,13 +183,15 @@ SWE is allowed to call:
 
 ### Hooks fired against SWE actions
 
-| Hook | When | Effect |
-|---|---|---|
-| `require-task-spec.sh` | PreToolUse Agent | Denies SWE spawn without valid `task_id` referencing a `pending`/`open` task with non-empty spec |
-| `create-worktree.sh` | WorktreeCreate | Branches from HEAD (workaround CC #27134/#44965) |
-| `git-guards.sh`, `git-push-guard.sh` | PreToolUse Bash | Universal git safety (no force-push to protected branches, no push without signed validation_attempts) |
-| `no-worktree-branch-create.sh` | PreToolUse Bash | Denies `git worktree add -b/-B` from anyone (SWE included) |
-| `branch-up-to-date-with-remote.sh` | PreToolUse Bash | Denies SWE attaching worktree to a stale branch |
+
+| Hook                                 | When             | Effect                                                                                                 |
+| ------------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------ |
+| `require-task-spec.sh`               | PreToolUse Agent | Denies SWE spawn without valid `task_id` referencing a `pending`/`open` task with non-empty spec       |
+| `create-worktree.sh`                 | WorktreeCreate   | Branches from HEAD (workaround CC #27134/#44965)                                                       |
+| `git-guards.sh`, `git-push-guard.sh` | PreToolUse Bash  | Universal git safety (no force-push to protected branches, no push without signed validation_attempts) |
+| `no-worktree-branch-create.sh`       | PreToolUse Bash  | Denies `git worktree add -b/-B` from anyone (SWE included)                                             |
+| `branch-up-to-date-with-remote.sh`   | PreToolUse Bash  | Denies SWE attaching worktree to a stale branch                                                        |
+
 
 ### Frontmatter constraints
 
@@ -164,6 +213,7 @@ Frontmatter: `model: opus`, `tools: Read, Glob, Grep, Bash, Task, mcp__plugin_tm
 ### Review work
 
 For each task:
+
 - Diff against the spec's `## Files`, `## Success Criteria`, `## Verification`
 - Mechanical review — delegate to `pr-review-toolkit:review-pr` if installed
 - Task-alignment checks:
@@ -179,16 +229,18 @@ For each task:
 
 ### Server-enforced pr-reviewer privileges (Layer 1)
 
-- **`validation_record`** — pr-reviewer is the ONLY agent allowed to write this. Bro/swe/consultants get rejected.
+- `**validation_record**` — pr-reviewer is the ONLY agent allowed to write this. Bro/swe/consultants get rejected.
 - `regen_state_set` (shared with architect, bro)
 - `issue_snapshot_md` (shared with architect)
 - `audit_log`, `discussion_append`
 
 ### Hooks fired against pr-reviewer actions
 
-| Hook | When | Effect |
-|---|---|---|
+
+| Hook                | When            | Effect                                                                                                                       |
+| ------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `git-push-guard.sh` | PreToolUse Bash | Bro spawns pr-reviewer because this hook denied `git push` until every unsigned task has a passing `validation_attempts` row |
+
 
 ### Frontmatter constraints
 
@@ -210,11 +262,13 @@ These are **templates** in `templates/agents/<name>.md`, instantiated per-projec
 ### Universal consultant constraints (Layer 1, server-enforced)
 
 Consultants **cannot write workflow state**:
+
 - ❌ `task_create_batch`, `task_update_status`, `issue_create`, `issue_close`
 - ❌ `validation_record`
 - ❌ `file_registry_update_summaries`
 
 They **can write analyses**:
+
 - ✅ `discussion_append(kind='analysis'|'concern')`
 - ✅ `ledger_log` (audit only)
 - ✅ Some get `regen_state_set` and `issue_snapshot_md` (architect specifically)
@@ -229,17 +283,19 @@ Bro spawns consultants for second opinions; consultants return their analysis as
 
 The authoritative source is `mcp/trajectory-server/src/middleware/agent-scope.ts` `requireRoles` declarations. Highlights:
 
-| Tool | bro | swe | pr-reviewer | consultants |
-|---|---|---|---|---|
-| `issue_create` / `issue_close` | ✓ | | | |
-| `task_create_batch` | ✓ | | | |
-| `task_update_status(closed)` | ✓ | | | |
-| `task_update_status(completed/failed)` | ✓ | ✓ | | |
-| `validation_record` | | | ✓ | |
-| `file_registry_update_summaries` | ✓ | | | |
-| `identity_set` / `identity_reset` | ✓ | | | |
-| `discussion_append` | ✓ (any kind) | ✓ (note/concern) | ✓ (any) | ✓ (analysis/concern) |
-| `ledger_log`, `audit_log`, `task_get` | ✓ | ✓ | ✓ | ✓ |
+
+| Tool                                   | bro          | swe              | pr-reviewer | consultants          |
+| -------------------------------------- | ------------ | ---------------- | ----------- | -------------------- |
+| `issue_create` / `issue_close`         | ✓            |                  |             |                      |
+| `task_create_batch`                    | ✓            |                  |             |                      |
+| `task_update_status(closed)`           | ✓            |                  |             |                      |
+| `task_update_status(completed/failed)` | ✓            | ✓                |             |                      |
+| `validation_record`                    |              |                  | ✓           |                      |
+| `file_registry_update_summaries`       | ✓            |                  |             |                      |
+| `identity_set` / `identity_reset`      | ✓            |                  |             |                      |
+| `discussion_append`                    | ✓ (any kind) | ✓ (note/concern) | ✓ (any)     | ✓ (analysis/concern) |
+| `ledger_log`, `audit_log`, `task_get`  | ✓            | ✓                | ✓           | ✓                    |
+
 
 ---
 

--- a/scripts/hooks/no-source-edit-from-main.sh
+++ b/scripts/hooks/no-source-edit-from-main.sh
@@ -65,12 +65,18 @@ if ! grep -q 'Entering bro mode.' "$TRANSCRIPT" 2>/dev/null \
   exit 0
 fi
 
-case "$PWD" in
-  *.claude/worktrees/*) exit 0 ;;
-esac
-
 TARGET=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.notebook_path // ""' 2>/dev/null)
 [ -n "$TARGET" ] || exit 0
+
+# Worktree exemption: any write whose target path lives inside
+# `.claude/worktrees/<slug>/...` is a legitimate SWE edit in its task
+# worktree — allow regardless of bro/SWE distinction. This MUST be a
+# target-path check, not a $PWD check: CC subagents inherit the parent's
+# CWD, so $PWD is always the project root for every hook invocation
+# (the previous $PWD-based check never matched and silently blocked SWE).
+case "$TARGET" in
+  */.claude/worktrees/*|.claude/worktrees/*) exit 0 ;;
+esac
 
 BASENAME=$(basename "$TARGET")
 

--- a/tests/hooks/no-source-edit-from-main.test.sh
+++ b/tests/hooks/no-source-edit-from-main.test.sh
@@ -130,14 +130,24 @@ assert_contains "$out" '"permissionDecision":"deny"' "deny even without 'Enterin
 
 # ---- worktree path: SWE allowed ----
 
-test_case "in worktree: pass even for source"
+test_case "REGRESSION: target inside .claude/worktrees/<slug>/ : PASS (SWE in worktree)"
+out=$(run_hook "$(input 'Edit' '.claude/worktrees/task-42/src/foo.ts' "$TRANSCRIPT_BRO")")
+assert_eq "" "$out" "worktree-targeted source edit allowed"
+
+test_case "REGRESSION: target with absolute worktree path: PASS"
+out=$(run_hook "$(input 'Write' '/tmp/proj/.claude/worktrees/task-42/src/index.ts' "$TRANSCRIPT_BRO")")
+assert_eq "" "$out" "absolute worktree path allowed"
+
+test_case "REGRESSION: target outside any worktree, even when CWD pretends: BLOCK"
 PWD_ORIG=$PWD
 WORKTREE_DIR="$TMPDIR/.claude/worktrees/task-42"
 mkdir -p "$WORKTREE_DIR"
 cd "$WORKTREE_DIR"
+# CWD is a worktree, but TARGET is outside → must still block (the previous
+# $PWD-based check would have allowed; the new target-based check correctly blocks)
 out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_BRO")")
 cd "$PWD_ORIG"
-assert_eq "" "$out" "worktree edits pass"
+assert_contains "$out" '"permissionDecision":"deny"' "non-worktree target blocked even from worktree CWD"
 
 # ---- DB-missing graceful path ----
 


### PR DESCRIPTION
## Summary

**Real bug surfaced by bro itself in the v0.5.0-rc.4 + rc.5 L5 dogfood logs** — bro literally diagnosed the broken hook line during a test run and ephemerally patched it on the CI runner (which is why rc.4 passed). Patch never made it into the repo. Fixing it here.

## Bug

`scripts/hooks/no-source-edit-from-main.sh` worktree exemption was:
```bash
case "$PWD" in
  *.claude/worktrees/*) exit 0 ;;
esac
```

But CC subagents inherit the parent agent's CWD — `$PWD` is **always** the project root for every hook invocation, regardless of which agent triggered it. The `$PWD`-based check therefore **never matched**, and the hook silently blocked SWE's legitimate worktree edits along with bro's source edits.

## Fix

Switch to a target-path check. If the target file lives inside `.claude/worktrees/<slug>/...` (relative or absolute), allow regardless of caller's CWD — that's a SWE write into its task worktree.

## Audit of all 11 hooks for similar PATH/PWD bugs

Only `no-source-edit-from-main.sh` was broken.

| Hook | `$PWD` use | Status |
|---|---|---|
| `no-source-edit-from-main.sh` line 68 | Worktree-detection via `$PWD` | **🐛 fixed in this PR** |
| `git-guards.sh` | Has `cmd_cwd()` helper that explicitly parses `cd <worktree> && ...` from SWE's Bash command | ✓ Safe |
| `activation-routine.sh`, `debug-trajectory.sh`, `session-start-regen-check.sh` | `$PWD/.claude/...` for DB path fallback — works because `$PWD === project root` | ✓ Safe |
| `cleanup-worktree-on-task-close.sh`, `no-worktree-branch-create.sh`, `require-summaries-before-task-close.sh` | `$PWD` only as fallback when `git rev-parse` fails | ✓ Safe |
| `branch-up-to-date-with-remote.sh`, `git-push-guard.sh`, `require-task-spec.sh`, `create-worktree.sh`, `ensure-gitignore.sh` | No `$PWD` use OR uses `tmb_db_path` (already fixed in #172 to walk up to git root) | ✓ Safe |

## Tests

3 new regression cases:
- target inside `.claude/worktrees/<slug>/`: **PASS** (SWE in worktree)
- absolute worktree path: **PASS**
- target OUTSIDE any worktree even when CWD is in one: **BLOCK** (previous `$PWD`-based check would have wrongly allowed this)

All 11 hook test files green.

## Test plan

- [x] `bash tests/run-all.sh` green
- [ ] CI confirms
- [ ] After merge: cut v0.5.0-rc.6 → expect SWE writes in worktrees no longer falsely blocked → all flows pass without bro needing to ephemerally patch the hook on the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)