### PR TITLE
📝 docs(RESPONSIBILITIES): clean rewrite (design philosophy + drop noise + fix conflict markers)

### DIFF
--- a/docs/architecture/RESPONSIBILITIES.md
+++ b/docs/architecture/RESPONSIBILITIES.md
@@ -2,9 +2,6 @@
 
 What each plugin-shipped agent is **actually** instructed to do, derived from the agent prompt files + the skills they're wired to. This is the **observable contract**, not the design intent: if it's not in this doc and not in a hook/skill, the agent isn't doing it.
 
-<<<<<<< Updated upstream
-Sources scanned:
-=======
 ## Design philosophy
 
 The three roles split by **what each one can be trusted to do without making its own homework, and which one stays alive when something unexpected fires**:
@@ -20,7 +17,6 @@ Everything below is how that philosophy materializes in the prompts, skills, hoo
 
 ## Sources scanned
 
->>>>>>> Stashed changes
 - `CLAUDE.md` (bro persona, auto-loaded)
 - `agents/swe.md` (SWE prompt)
 - `agents/pr-reviewer.md` (pr-reviewer prompt)
@@ -31,7 +27,7 @@ Everything below is how that philosophy materializes in the prompts, skills, hoo
 
 ## bro
 
-Source: `**CLAUDE.md`** (no `agents/bro.md` — bro is a persona on main Claude). Plus the `tmb_*` skills bro loads when triggered.
+Source: **`CLAUDE.md`** (no `agents/bro.md` — bro is a persona on main Claude). Plus the `tmb_*` skills bro loads when triggered.
 
 ### Persistent persona behaviors (every bro-mode message)
 
@@ -43,18 +39,16 @@ Source: `**CLAUDE.md`** (no `agents/bro.md` — bro is a persona on main Claude)
 
 ### Routing (CLAUDE.md ## Routing table)
 
-
-| Ask shape                                 | bro's action                                                    |
-| ----------------------------------------- | --------------------------------------------------------------- |
-| "Implement this" / any code change        | Code-touching chain (planning → SWE spawn → bro verify → close) |
-| "Review before push" / `git push` blocked | `tmb_push-gate`                                                 |
-| "Get architect's / cto's / pm's opinion"  | Check local agent file; spawn or `tmb_agent-creator`            |
-| Domain role with no shipped template      | `tmb_agent-creator` from-scratch + Human approval               |
-| Configure / change settings               | `tmb_reonboard`                                                 |
-| `refresh architecture docs`               | `tmb_refresh-architecture`                                      |
-| Disagree with Human's plan                | `tmb_concerns-protocol`                                         |
-| File reads / searches / git status        | Direct (Read, Glob, Grep, Bash)                                 |
-
+| Ask shape | bro's action |
+|---|---|
+| "Implement this" / any code change | Code-touching chain (planning → SWE spawn → bro verify → close) |
+| "Review before push" / `git push` blocked | `tmb_push-gate` |
+| "Get architect's / cto's / pm's opinion" | Check local agent file; spawn or `tmb_agent-creator` |
+| Domain role with no shipped template | `tmb_agent-creator` from-scratch + Human approval |
+| Configure / change settings | `tmb_reonboard` |
+| `refresh architecture docs` | `tmb_refresh-architecture` |
+| Disagree with Human's plan | `tmb_concerns-protocol` |
+| File reads / searches / git status | Direct (Read, Glob, Grep, Bash) |
 
 ### Code-touching chain (single source of truth: `tmb_planning-simple` / `tmb_planning-difficult`)
 
@@ -62,34 +56,25 @@ Source: `**CLAUDE.md`** (no `agents/bro.md` — bro is a persona on main Claude)
 2. `tmb_branch-id-proposal` (open MCP issue + propose branch_id)
 3. `tmb_planning-simple` OR `tmb_planning-difficult`
 4. **bro pre-creates the task branch from `origin/<pr_target>`** (after fetching) — `git fetch origin && git branch <task.branch_id> origin/<pr_target>`
-5. `task_create_batch` + spawn SWE with `task_id=<N>` + `ledger_log(planning_complete)`  [batched]
+5. `task_create_batch` + spawn SWE with `task_id=<N>` + `ledger_log(planning_complete)` [batched]
 6. SWE returns
 7. **bro verification (V1/V2/V3)**:
-<<<<<<< Updated upstream
    - V1 — files match the spec's `## Files`
    - V2 — re-run the spec's `## Verification` commands inside the worktree
    - V3 — each `## Success Criteria` bullet visibly met by the diff
-8. **bro updates file_registry summaries** — `file_registry_update_summaries(updates=[{path, summary, ...}], advance_verified_sha=<commit_sha>)` (#181 — server enforces bro-only; PreToolUse hook gates the next step)
-=======
-  - V1 — files match the spec's `## Files`
-  - V2 — re-run the spec's `## Verification` commands inside the worktree
-  - V3 — each `## Success Criteria` bullet visibly met by the diff
 8. **bro updates file_registry summaries** — `file_registry_update_summaries(updates=[{path, summary, ...}], advance_verified_sha=<commit_sha>)`. Server-enforced bro-only; a PreToolUse hook denies the next step if summaries are missing/stale.
->>>>>>> Stashed changes
 9. `task_update_status(status='closed')` + `issue_close` (if last task on issue)
 
 ### Reactive skills (loaded on trigger only)
 
-
-| Trigger                                   | Skill                      |
-| ----------------------------------------- | -------------------------- |
-| AskUserQuestion errors / `TMB_HEADLESS=1` | `tmb_headless-fallback`    |
-| MCP `is_error: true`                      | `tmb_mcp-error-handling`   |
-| Push gate                                 | `tmb_push-gate`            |
-| Re-onboarding                             | `tmb_reonboard`            |
-| Refresh arch docs                         | `tmb_refresh-architecture` |
-| Disagreement                              | `tmb_concerns-protocol`    |
-
+| Trigger | Skill |
+|---|---|
+| AskUserQuestion errors / `TMB_HEADLESS=1` | `tmb_headless-fallback` |
+| MCP `is_error: true` | `tmb_mcp-error-handling` |
+| Push gate | `tmb_push-gate` |
+| Re-onboarding | `tmb_reonboard` |
+| Refresh arch docs | `tmb_refresh-architecture` |
+| Disagreement | `tmb_concerns-protocol` |
 
 ### Server-enforced bro privileges (Layer 1)
 
@@ -98,14 +83,13 @@ Bro is the only agent allowed to call:
 - `task_create_batch`
 - `task_update_status` (shared with swe; bro for `closed`, swe for `completed`/`failed`)
 - `issue_create`, `issue_close`, `issue_resume`
-- `file_registry_update_summaries` (#181)
+- `file_registry_update_summaries`
 - `identity_set`, `identity_reset`
 - `discussion_append` for `kind='intent'/'note'`
 - `regen_state_set` (shared with architect, pr-reviewer)
 
 ### Hooks fired on bro's behalf
 
-<<<<<<< Updated upstream
 | Hook | When | Effect |
 |---|---|---|
 | `activation-routine.sh` | UserPromptSubmit (bro mode) | Injects identity + pending issue as context |
@@ -114,22 +98,8 @@ Bro is the only agent allowed to call:
 | `no-source-edit-from-main.sh` | PreToolUse Edit/Write | Denies bro source edits outside SWE worktree |
 | `no-worktree-branch-create.sh` | PreToolUse Bash | Denies `git worktree add -b/-B` (branch authority is bro's pre-creation) |
 | `branch-up-to-date-with-remote.sh` | PreToolUse Bash | Denies worktree-add to a branch behind `origin/<pr_target>` |
-| `require-summaries-before-task-close.sh` | PreToolUse `task_update_status` | Denies bro's `closed` call when summaries are missing/stale (#181) |
+| `require-summaries-before-task-close.sh` | PreToolUse `task_update_status` | Denies bro's `closed` call when summaries are missing/stale |
 | `cleanup-worktree-on-task-close.sh` | PostToolUse `task_update_status` | Removes worktree after bro closes task |
-=======
-
-| Hook                                     | When                             | Effect                                                                   |
-| ---------------------------------------- | -------------------------------- | ------------------------------------------------------------------------ |
-| `activation-routine.sh`                  | UserPromptSubmit (bro mode)      | Injects identity + pending issue as context                              |
-| `session-start-regen-check.sh`           | SessionStart                     | Nudges `tmb_refresh-architecture` if arch docs are stale                 |
-| `ensure-gitignore.sh`                    | SessionStart                     | Ensures `.claude/` in project's `.gitignore`                             |
-| `no-source-edit-from-main.sh`            | PreToolUse Edit/Write            | Denies bro source edits outside SWE worktree                             |
-| `no-worktree-branch-create.sh`           | PreToolUse Bash                  | Denies `git worktree add -b/-B` (branch authority is bro's pre-creation) |
-| `branch-up-to-date-with-remote.sh`       | PreToolUse Bash                  | Denies worktree-add to a branch behind `origin/<pr_target>`              |
-| `require-summaries-before-task-close.sh` | PreToolUse `task_update_status`  | Denies bro's `closed` call when summaries are missing/stale              |
-| `cleanup-worktree-on-task-close.sh`      | PostToolUse `task_update_status` | Removes worktree after bro closes task                                   |
-
->>>>>>> Stashed changes
 
 ### Universal rules
 
@@ -157,11 +127,10 @@ Frontmatter: `model: sonnet`, `maxTurns: 55`, `tools: Read, Glob, Grep, Bash, Wr
 ### Atomic close (`#W4`)
 
 Batch in one response:
-
 1. Commit (using the spec's `## Commit` message)
 2. `task_update_status(agent='swe', status='completed', commit_sha)`
 
-**SWE does NOT call `file_registry_update_summaries`** — that's bro's responsibility during verification (#181, server-enforced).
+**SWE does NOT call `file_registry_update_summaries`** — that's bro's responsibility during verification (server-enforced).
 
 ### Forbidden
 
@@ -175,7 +144,6 @@ Batch in one response:
 ### Server-enforced SWE privileges (Layer 1)
 
 SWE is allowed to call:
-
 - `task_get` (shared with all agents)
 - `task_update_status` for `completed` / `failed` (bro owns `closed`)
 - `audit_log`, `ledger_log`
@@ -183,19 +151,17 @@ SWE is allowed to call:
 
 ### Hooks fired against SWE actions
 
-
-| Hook                                 | When             | Effect                                                                                                 |
-| ------------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------ |
-| `require-task-spec.sh`               | PreToolUse Agent | Denies SWE spawn without valid `task_id` referencing a `pending`/`open` task with non-empty spec       |
-| `create-worktree.sh`                 | WorktreeCreate   | Branches from HEAD (workaround CC #27134/#44965)                                                       |
-| `git-guards.sh`, `git-push-guard.sh` | PreToolUse Bash  | Universal git safety (no force-push to protected branches, no push without signed validation_attempts) |
-| `no-worktree-branch-create.sh`       | PreToolUse Bash  | Denies `git worktree add -b/-B` from anyone (SWE included)                                             |
-| `branch-up-to-date-with-remote.sh`   | PreToolUse Bash  | Denies SWE attaching worktree to a stale branch                                                        |
-
+| Hook | When | Effect |
+|---|---|---|
+| `require-task-spec.sh` | PreToolUse Agent | Denies SWE spawn without valid `task_id` referencing a `pending`/`open` task with non-empty spec |
+| `create-worktree.sh` | WorktreeCreate | Branches from HEAD (workaround CC #27134/#44965) |
+| `git-guards.sh`, `git-push-guard.sh` | PreToolUse Bash | Universal git safety (no force-push to protected branches, no push without signed validation_attempts) |
+| `no-worktree-branch-create.sh` | PreToolUse Bash | Denies `git worktree add -b/-B` from anyone (SWE included) |
+| `branch-up-to-date-with-remote.sh` | PreToolUse Bash | Denies SWE attaching worktree to a stale branch |
 
 ### Frontmatter constraints
 
-- `isolation: worktree` — CC creates an isolated git worktree for the spawn (separate from the bro-created task-branch worktree; #174 follow-up to retire the duplicate)
+- `isolation: worktree` — CC creates an isolated git worktree for the spawn
 - `tools:` allowlist — explicit; no broad wildcards
 
 ---
@@ -213,7 +179,6 @@ Frontmatter: `model: opus`, `tools: Read, Glob, Grep, Bash, Task, mcp__plugin_tm
 ### Review work
 
 For each task:
-
 - Diff against the spec's `## Files`, `## Success Criteria`, `## Verification`
 - Mechanical review — delegate to `pr-review-toolkit:review-pr` if installed
 - Task-alignment checks:
@@ -229,18 +194,16 @@ For each task:
 
 ### Server-enforced pr-reviewer privileges (Layer 1)
 
-- `**validation_record**` — pr-reviewer is the ONLY agent allowed to write this. Bro/swe/consultants get rejected.
+- **`validation_record`** — pr-reviewer is the ONLY agent allowed to write this. Bro/swe/consultants get rejected.
 - `regen_state_set` (shared with architect, bro)
 - `issue_snapshot_md` (shared with architect)
 - `audit_log`, `discussion_append`
 
 ### Hooks fired against pr-reviewer actions
 
-
-| Hook                | When            | Effect                                                                                                                       |
-| ------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Hook | When | Effect |
+|---|---|---|
 | `git-push-guard.sh` | PreToolUse Bash | Bro spawns pr-reviewer because this hook denied `git push` until every unsigned task has a passing `validation_attempts` row |
-
 
 ### Frontmatter constraints
 
@@ -262,13 +225,11 @@ These are **templates** in `templates/agents/<name>.md`, instantiated per-projec
 ### Universal consultant constraints (Layer 1, server-enforced)
 
 Consultants **cannot write workflow state**:
-
 - ❌ `task_create_batch`, `task_update_status`, `issue_create`, `issue_close`
 - ❌ `validation_record`
 - ❌ `file_registry_update_summaries`
 
 They **can write analyses**:
-
 - ✅ `discussion_append(kind='analysis'|'concern')`
 - ✅ `ledger_log` (audit only)
 - ✅ Some get `regen_state_set` and `issue_snapshot_md` (architect specifically)
@@ -283,19 +244,17 @@ Bro spawns consultants for second opinions; consultants return their analysis as
 
 The authoritative source is `mcp/trajectory-server/src/middleware/agent-scope.ts` `requireRoles` declarations. Highlights:
 
-
-| Tool                                   | bro          | swe              | pr-reviewer | consultants          |
-| -------------------------------------- | ------------ | ---------------- | ----------- | -------------------- |
-| `issue_create` / `issue_close`         | ✓            |                  |             |                      |
-| `task_create_batch`                    | ✓            |                  |             |                      |
-| `task_update_status(closed)`           | ✓            |                  |             |                      |
-| `task_update_status(completed/failed)` | ✓            | ✓                |             |                      |
-| `validation_record`                    |              |                  | ✓           |                      |
-| `file_registry_update_summaries`       | ✓            |                  |             |                      |
-| `identity_set` / `identity_reset`      | ✓            |                  |             |                      |
-| `discussion_append`                    | ✓ (any kind) | ✓ (note/concern) | ✓ (any)     | ✓ (analysis/concern) |
-| `ledger_log`, `audit_log`, `task_get`  | ✓            | ✓                | ✓           | ✓                    |
-
+| Tool | bro | swe | pr-reviewer | consultants |
+|---|---|---|---|---|
+| `issue_create` / `issue_close` | ✓ | | | |
+| `task_create_batch` | ✓ | | | |
+| `task_update_status(closed)` | ✓ | | | |
+| `task_update_status(completed/failed)` | ✓ | ✓ | | |
+| `validation_record` | | | ✓ | |
+| `file_registry_update_summaries` | ✓ | | | |
+| `identity_set` / `identity_reset` | ✓ | | | |
+| `discussion_append` | ✓ (any kind) | ✓ (note/concern) | ✓ (any) | ✓ (analysis/concern) |
+| `ledger_log`, `audit_log`, `task_get` | ✓ | ✓ | ✓ | ✓ |
 
 ---
 


### PR DESCRIPTION
Supersedes the closed PR #184 (rebase-conflicted with linter-applied formatting on dev).

## Three improvements

1. **Adds the design philosophy section** at the top — the canonical role split per Daisy:
   - **bro** = persona, full picture, does everything EXCEPT coding (incl. all MCP/DB ops). Most permissioned + most resilient layer.
   - **swe** = coding only — three reasons: token-heavy work, no self-homework, subagent fragility (narrow tools + fresh context + hook denies can abort mid-task; critical writes stay with the resilient layer).
   - **pr-reviewer** = independent 3rd party, git-diff focused, can pair with bro for integration testing. Read-only. Same fragility caveat — owns only its `validation_record` verdict.

2. **Strips issue-ref noise** — no `#181` / `#174` references in the structural reference doc. Issue numbers belong in commit messages and CHANGELOG, not in a "what each agent does" doc.

3. **Resolves unresolved git-stash-pop conflict markers** that had accumulated on the dev version. Clean rewrite, same content as the author intended.

## Test plan

- [x] No conflict markers (`grep '<<<<<<<'` returns 0)
- [x] No issue-ref noise (`grep '#1[0-9][0-9]\b'` returns 0)
- [ ] CI confirms (doc-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)