### PR TITLE
📝 docs(CLAUDE.md): disambiguate 'update my name' → 'update the human's name'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ The banner is mandatory. A silent activation breaks the user's mental model of "
 | "Review before push" / `git push` blocked | `tmb_push-gate` |
 | "Get architect's / cto's / pm's opinion on X" | Check `.claude/agents/<name>.md`. Absent → `tmb_agent-creator`. Spawn in consultant mode. |
 | Domain role with no shipped template | `tmb_agent-creator` from-scratch + Human approval |
-| Configure / change settings (`switch to gitflow`, `update my name`, `reonboard`) | `tmb_reonboard` |
+| Configure / change settings (`switch to gitflow`, `update the human's name`, `reonboard`) | `tmb_reonboard` |
 | `refresh architecture docs` | `tmb_refresh-architecture` |
 | Disagree with the Human's plan | `tmb_concerns-protocol` |
 | File reads / searches / git status | Direct (Read, Glob, Grep, Bash) — no spawn, no skill |


### PR DESCRIPTION
## Summary

Real bug surfaced by v0.5.0-rc.7 manual test (Daisy ran \`@bro hi\`, bro replied "if you'd like to set a name for me, say the word and I'll run the reonboard flow"). Bro read the routing-table entry as referring to itself.

## Fix

One-line positive disambiguation in CLAUDE.md routing table:
- before: \`update my name\` → \`tmb_reonboard\`
- after: \`update the human's name\` → \`tmb_reonboard\`

The \`identity\` row in the trajectory DB has always tracked the HUMAN's name (bro greets the human by name). The routing wording was ambiguous in isolation — "my name" could mean either party — and bro picked the wrong one.

## What was deliberately NOT done

Per Daisy's feedback rule (saved to my memory): **no "never accept rename requests" / "bro is bro" anti-instructions added to CLAUDE.md.** Negative-framing prompt rules amplify the topic via the pink-elephant effect; positive disambiguation at the source is the structural fix.

## Test plan

- [x] L1 + L2 + L3 + 11 hook test files green
- [ ] CI confirms (doc-only)
- [ ] After merge: cut v0.5.0-rc.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)