### PR TITLE
📝 docs(setup): document upstream CC cache + channel-isolation gaps

### DIFF
--- a/tests/manual/setup.md
+++ b/tests/manual/setup.md
@@ -202,6 +202,17 @@ rm -rf ~/.claude/plugins/cache/trustmybot/tmb/<broken-version>
 # then in CC: /plugin install tmb-rc@trustmybot
 ```
 
+**Full cache nuke (when `/plugin uninstall` left orphans):**
+
+CC's `/plugin uninstall` and `/plugin marketplace remove` only update `installed_plugins.json`; the cached payloads at `~/.claude/plugins/cache/<vendor>/<plugin>/<version>/` stay on disk and may be picked up by old sessions or shadow newer installs. Cache *should* auto-clean after 7 days but [often doesn't](https://github.com/anthropics/claude-code/issues/29074) — see also [#15369](https://github.com/anthropics/claude-code/issues/15369), [#35691](https://github.com/anthropics/claude-code/issues/35691), [#37865](https://github.com/anthropics/claude-code/issues/37865). Manual nuke:
+
+```bash
+rm -rf ~/.claude/plugins/cache/trustmybot/
+# then in CC: /plugin install tmb@trustmybot   (or tmb-rc@trustmybot)
+```
+
+**⚠️ Channel isolation caveat (upstream CC limitation):** `tmb` (stable) and `tmb-rc` are distinct marketplace entries but the activated plugin name in both cases is `tmb` (per `plugin.json`'s `name` field) — so installing both simultaneously means **both write to `.claude/tmb/trajectory.db` in your project**, sharing state. CC matches install on plugin name, ignoring the marketplace qualifier ([#20593](https://github.com/anthropics/claude-code/issues/20593)). Until proper isolation lands (TMB-side: would need separate marketplaces or templated plugin name), pick one channel and stick with it.
+
 ---
 
 ## Path C — Docker install-smoke (CI's L0 — also runnable locally)


### PR DESCRIPTION
## Summary

Two upstream CC framework gaps surfaced during v0.5.0-rc.8 manual test, both confirmed via internet research (linked GH issues).

## What's documented

### Cache cleanup gap
\`/plugin uninstall\` and \`/plugin marketplace remove\` only update \`installed_plugins.json\`; cached payloads at \`~/.claude/plugins/cache/<vendor>/<plugin>/<version>/\` stay on disk. Should auto-clean after 7 days but [often doesn't](https://github.com/anthropics/claude-code/issues/29074).

Workaround: \`rm -rf ~/.claude/plugins/cache/trustmybot/\`

Linked upstream issues:
- [#29074 — Plugin cache not cleared on uninstall/reinstall](https://github.com/anthropics/claude-code/issues/29074)
- [#15369 — Plugin uninstall does not clear cached files](https://github.com/anthropics/claude-code/issues/15369)
- [#35691 — \`/plugin uninstall\` removes from installed_plugins.json but leaves cached files](https://github.com/anthropics/claude-code/issues/35691)
- [#37865 — Plugin uninstall/marketplace removal leaves orphaned cache directories](https://github.com/anthropics/claude-code/issues/37865)

### Channel isolation caveat
\`tmb\` (stable) and \`tmb-rc\` are distinct marketplace entries but \`plugin.json\` ships with \`name: "tmb"\` regardless. CC matches install on plugin name only, ignoring the marketplace qualifier ([#20593](https://github.com/anthropics/claude-code/issues/20593)). Both channels write to \`.claude/tmb/trajectory.db\` if installed simultaneously.

Workaround: pick one channel and stick with it. Proper fix is v0.6.0 work (separate marketplaces or templated plugin name).

## Test plan
- [x] Local L1+L2+L3 + 11 hook test files green
- [ ] CI confirms (doc-only, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)