### PR TITLE
📝 docs(README): correct DB-path claim + link new architecture docs (v0.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Details: [`CLAUDE.md`](CLAUDE.md) (bro persona), [`agents/swe.md`](agents/swe.md
 
 ### 2. Trajectory Memory — state survives session kills
 
-Every transition lands in a per-project SQLite DB at `<project>/.claude/<plugin-name>/trajectory.db` (`tmb/` for stable, `tmb-rc/` for the RC channel — fully isolated). Five tables you'll touch directly:
+Every transition lands in a per-project SQLite DB at `<project>/.claude/tmb/trajectory.db`. Five tables you'll touch directly:
 
 - **`issues`** — your goals + objectives, one row per ask
 - **`discussions`** — Human ↔ bro Q+A, ADR (Architecture Decision Record) notes, design decisions
@@ -178,10 +178,12 @@ bash tests/run-all.sh
 
 Architecture reference for new contributors:
 - [`CLAUDE.md`](CLAUDE.md) — bro persona, first-action chain, push gate
+- [`docs/architecture/RESPONSIBILITIES.md`](docs/architecture/RESPONSIBILITIES.md) — design philosophy + per-agent contract (bro / SWE / pr-reviewer / consultants)
+- [`docs/architecture/ENFORCEMENT.md`](docs/architecture/ENFORCEMENT.md) — 6-layer enforcement model + per-agent × per-interaction coverage matrix
 - [`docs/architecture/FLOWS.md`](docs/architecture/FLOWS.md) — workflow flowcharts
 - [`docs/architecture/FILES.md`](docs/architecture/FILES.md) — file-by-file map
 - [`docs/architecture/ERD.md`](docs/architecture/ERD.md) — SQLite schema
-- [`tests/manual/scenarios.md`](tests/manual/scenarios.md) — Layer 3 dogfood test plan
+- [`tests/manual/scenarios.md`](tests/manual/scenarios.md) — manual dogfood test plan
 
 ---
 


### PR DESCRIPTION
## Summary

Two README updates for v0.5.0 ground-truth alignment:

### 1. DB-path claim corrected

Previous text claimed:
> "trajectory.db (\`tmb/\` for stable, \`tmb-rc/\` for the RC channel — **fully isolated**)"

Wrong: both channels actually write to \`.claude/tmb/\` because \`plugin.json\` ships with \`name: "tmb"\` regardless of channel ([documented in setup.md via #189](https://github.com/trustmybot/plugin/blob/dev/tests/manual/setup.md#path-b)). Proper isolation tracked as v0.6.0 work in #190.

Updated to the actual single-path reality.

### 2. New architecture docs linked

\`RESPONSIBILITIES.md\` and \`ENFORCEMENT.md\` shipped in v0.5.0 — added both to the "Architecture reference for new contributors" list at the bottom of README so contributors discover them.

## Test plan

- [x] L1+L2+L3 + 11 hook test files green (link-check is in L1)
- [ ] CI confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)