### PR TITLE
📝 backport: README corrections to main (cherry-pick of #192)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Details: [`CLAUDE.md`](CLAUDE.md) (bro persona), [`agents/swe.md`](agents/swe.md
 
 ### 2. Trajectory Memory — state survives session kills
 
-Every transition lands in a per-project SQLite DB at `<project>/.claude/<plugin-name>/trajectory.db` (`tmb/` for stable, `tmb-rc/` for the RC channel — fully isolated). Five tables you'll touch directly:
+Every transition lands in a per-project SQLite DB at `<project>/.claude/tmb/trajectory.db`. Five tables you'll touch directly:
 
 - **`issues`** — your goals + objectives, one row per ask
 - **`discussions`** — Human ↔ bro Q+A, ADR (Architecture Decision Record) notes, design decisions
@@ -178,10 +178,12 @@ bash tests/run-all.sh
 
 Architecture reference for new contributors:
 - [`CLAUDE.md`](CLAUDE.md) — bro persona, first-action chain, push gate
+- [`docs/architecture/RESPONSIBILITIES.md`](docs/architecture/RESPONSIBILITIES.md) — design philosophy + per-agent contract (bro / SWE / pr-reviewer / consultants)
+- [`docs/architecture/ENFORCEMENT.md`](docs/architecture/ENFORCEMENT.md) — 6-layer enforcement model + per-agent × per-interaction coverage matrix
 - [`docs/architecture/FLOWS.md`](docs/architecture/FLOWS.md) — workflow flowcharts
 - [`docs/architecture/FILES.md`](docs/architecture/FILES.md) — file-by-file map
 - [`docs/architecture/ERD.md`](docs/architecture/ERD.md) — SQLite schema
-- [`tests/manual/scenarios.md`](tests/manual/scenarios.md) — Layer 3 dogfood test plan
+- [`tests/manual/scenarios.md`](tests/manual/scenarios.md) — manual dogfood test plan
 
 ---
 


### PR DESCRIPTION
## Summary

Cherry-picks the README corrections from #192 (already on dev) onto main. Required because #191's squash-merge broke the linear dev↔main history; a normal dev → main PR sees phantom conflicts on already-shared content.

## What this brings

- Fixes the false "fully isolated" DB-path claim (now: \`.claude/tmb/\` for both channels — accurate)
- Adds links to the new \`RESPONSIBILITIES.md\` and \`ENFORCEMENT.md\` architecture docs

## Why no v0.5.1 tag

\`marketplace.json\` ships with \`ref: "main"\` → CC fetches main HEAD on next \`/plugin update\`, so users get the README correction automatically. README on GitHub's repo page renders from main HEAD → public-facing doc updates immediately on merge. No runtime change → no tag needed.

## Test plan

- [x] #192 (the source) passed CI on dev
- [ ] CI confirms (single-file backport)

🤖 Generated with [Claude Code](https://claude.com/claude-code)