### PR TITLE
🔒 ci: main branch guards — CODEOWNERS + source-branch enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS — main branch protection routes review to the @trustmybot/admin team.
+# Any team member`s approval satisfies the "Require review from Code Owners" gate.
+* @trustmybot/admin

--- a/.github/workflows/main-source-guard.yml
+++ b/.github/workflows/main-source-guard.yml
@@ -1,0 +1,25 @@
+# main-source-guard — only PRs from `dev` may target `main`.
+#
+# Enforces the gitflow doctrine: feature branches go through dev; only the
+# dev branch promotes to main. Any other source branch fails this check,
+# blocking the merge.
+name: main source guard
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR source is dev
+        run: |
+          if [ "${{ github.head_ref }}" != "dev" ]; then
+            echo "::error::PR to main must come from dev. This PR is from '${{ github.head_ref }}' — open it against dev first, then promote dev → main."
+            exit 1
+          fi
+          echo "✓ PR source is dev"


### PR DESCRIPTION
## Summary

Two guards for the `main` branch to enforce the gitflow doctrine + restrict approvals:

1. **`.github/CODEOWNERS`** — `* @trustmybot/admin`. Combined with "Require review from Code Owners" in main branch protection, only admin team members can approve PRs to main.
2. **`.github/workflows/main-source-guard.yml`** — `pull_request` workflow that fails if `github.head_ref != 'dev'` when the PR targets main. Enforces "only dev can promote to main"; any feature branch trying to PR directly to main hits a hard fail.

## After merge — manual steps

These need admin perms; not in this PR:

- [ ] Grant `@trustmybot/admin` team `push` access to `trustmybot/plugin` (currently 0 repos). `PUT /orgs/trustmybot/teams/admin/repos/trustmybot/plugin -f permission=push`. CODEOWNERS routing needs the team to have at least read access on the repo.
- [ ] Add `main source guard` as required status check on main branch protection.
- [ ] Enable "Require review from Code Owners" + "Require approvals: 1" on main branch protection.

## Net effect after the manual steps land

- Any PR to main from a branch other than dev → workflow fails → can't merge.
- Any PR to main needs admin-team approval to satisfy CODEOWNERS.
- Combined: only `dev → main` PRs reviewed by an admin team member can merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)