### PR TITLE
✨ test(rag): L0 docker + L5/L6 chain step 13 + step 04/06 embedding assertions (#49)

### DIFF
--- a/tests/EVALUATION.md
+++ b/tests/EVALUATION.md
@@ -68,8 +68,9 @@ flowchart TD
     S10[step 10: 10-consultant<br/>'JSON or SQLite for cli.py storage?'<br/>→ hook injects routing → /tmb:agent-create cto]
     S11[step 11: 11-roundtable<br/>/roundtable storage choice → cto + data-engineer]
     S12[step 12: 12-issue-resume<br/>'keep going on the in-progress task']
+    S13[step 13: 13-search-grounding<br/>'why did we choose to extract storage into a backend interface?'<br/>→ discussion_search grounds answer in step 08 ADR]
 
-    Done([all 12 green = release-ready])
+    Done([all 13 green = release-ready])
 
     Start --> S1
     S1 -- "identity row<br/>plugin_config: local shape" --> S2
@@ -83,7 +84,11 @@ flowchart TD
     S9 -- "kind='note' concern discussion;<br/>no Agent spawn this turn" --> S10
     S10 -- "cto registered project-local +<br/>kind='analysis' discussion" --> S11
     S11 -- "roundtable + analyses + votes<br/>from cto + data-engineer" --> S12
-    S12 -- "existing pending task dispatched<br/>(no duplicate planning)" --> Done
+    S12 -- "existing pending task dispatched<br/>(no duplicate planning)" --> S13
+    S13 -- "discussion_search grounded<br/>kind='decision' cited" --> Done
+
+    %% Cross-step direct dependency: S13 reads step 08's ADR decision
+    S8 -. "kind='decision' discussion<br/>(ADR content for search grounding)" .-> S13
 
     %% Cross-step direct dependencies (dotted = specific artifact consumed)
     S3 -. "GitHub remote URL<br/>(push target)" .-> S7
@@ -108,6 +113,8 @@ Reading the dotted edges:
 
 **Note on retired step 14:** the `skill_invocations` hook-attribution assertion that step 14 used to own is now folded into step 04's outcome.sql — `skill_invocations` rows accumulate naturally on any chain step that invokes tmb skills, and step 04 is the first such step. The standalone row was redundant.
 
+**Reading the S13 dotted edge:** S8 → S13: step 08 records the `kind='decision'` discussion that step 13 searches for. In L6, the organic DB carry means the row is already present when step 13 fires. In L5 isolation, `setup-l5.sh` seeds the same decision body so the same prompt + assertion work unchanged.
+
 ---
 
 ## Per-step I/O table
@@ -130,6 +137,7 @@ The "Carried from" column is the chain provenance: which prior step's Output pro
 | **10** | `10-consultant` | `src/cli.py` from step 4/5 + an open "Evaluate TODO CLI storage scale-out" issue. `cto` is template-scope in the registry but NOT instantiated locally. | step 4 (cli) + earlier-step issue | `@bro should we keep src/cli.py's storage in JSON or move to SQLite as the CLI scales?` → `consultant-spawn-required.sh` hook injects "invoke /tmb:agent-create cto" routing → bro invokes the command → Branch B template-copy → `agent_register` + `audit_log(event_type='tmb_agent_created')` → spawn cto via `Agent`. | `audit WHERE event_type='tmb_agent_created'` ≥1. `agents WHERE name='cto' AND scope='project-local'` ≥1. |
 | **11** | `11-roundtable` | `src/cli.py` + `cto` + `data-engineer` both registered project-local. L5: setup-l5 seeds both consultants. L6: `cto` from step 10; `data-engineer` from a prior chain step's from-scratch creation. | step 10 (cto) + earlier from-scratch | `/roundtable should the todo CLI's storage be JSON, SQLite, or a small backend service?` → bro calls `roundtable_create(participants=['cto','data-engineer'])` → spawns each via `Agent` → each writes `discussion_append(kind='analysis')` + `roundtable_vote`. | `roundtables` ≥1. `discussions WHERE kind='analysis'` ≥2. `roundtable_votes` from BOTH `cto` AND `data-engineer`. |
 | **12** | `12-issue-resume` | An in-progress issue with a `planning_complete` audit and a task in `pending`. L5: pre-seeded by setup-l5. L6: organic from earlier in-progress work. | step 4 + step 5 (existing planned task) | `@bro let's keep going on the CLI entry-point work.` → bro picks up the existing task (no `issue_create`, no `task_create_batch`), dispatches SWE via `Agent`. | The pre-existing issue still exists exactly once (no duplicate). `Agent` was spawned. `issue_create` + `task_create_batch` were NOT called this turn. |
+| **13** | `13-search-grounding` | A `kind='decision'` discussion from step 08 (the storage-backend ADR) + a `discussions_embeddings` row (stub vector). L5: seeded by setup-l5.sh. L6: inherits step 08's organic decision row + server backfill. | step 8 (kind='decision' discussion) | `@bro why did we choose to extract storage into a backend interface in src/cli.py?` → bro calls `discussion_search` to ground the answer in the recorded decision; cites the ADR body. No code work. | `discussions_embeddings` ≥ 1 row; `discussions WHERE kind='decision'` ≥ 1. `discussion_search` called. `task_create_batch` NOT called. |
 
 ### Seed bridges (between-row `seed_after` SQL files)
 

--- a/tests/docker/install-smoke.Dockerfile
+++ b/tests/docker/install-smoke.Dockerfile
@@ -78,6 +78,23 @@ RUN ( \
       cat /tmp/smoke-out.log; exit 1)
 RUN echo "✓ A3b: SQLite open + onboard_state_get round-tripped"
 
+# A3c: semantic search round-trip — discussion_search with mode='semantic'.
+# Acceptable outcomes: real results array OR warning='semantic_unavailable'
+# (no ONNX model in the Docker layer). Either is a valid MCP 200 response;
+# what we reject is an MCP-level error (id:2 with "error" key).
+RUN ( \
+    echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}'; \
+    echo '{"jsonrpc":"2.0","method":"notifications/initialized"}'; \
+    echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"discussion_search","arguments":{"agent":"bro","query":"storage backend interface","mode":"semantic","k":3}}}'; \
+    sleep 1; \
+  ) \
+  | TRAJECTORY_DB_PATH=/tmp/smoke-semantic.db timeout 8 node --experimental-sqlite mcp/trajectory-server/dist/index.js > /tmp/smoke-semantic.log 2>&1; \
+  grep '"id":2' /tmp/smoke-semantic.log | grep -qvE '"error"' \
+   && (grep -qE '"results"' /tmp/smoke-semantic.log || grep -qE 'semantic_unavailable' /tmp/smoke-semantic.log) \
+  || (echo "❌ FAIL: discussion_search(mode=semantic) returned MCP error or unexpected payload"; \
+      cat /tmp/smoke-semantic.log; exit 1)
+RUN echo "✓ A3c: discussion_search(mode=semantic) returns results or semantic_unavailable (no MCP error)"
+
 # A4: every shipped agent template parses (frontmatter + body, ≤30 lines)
 RUN bash tests/lint/agent-line-budget.sh \
  || (echo "❌ FAIL: agent-line-budget lint failed in clean install" && exit 1)

--- a/tests/dogfood/l6-chain/chain-manifest.json
+++ b/tests/dogfood/l6-chain/chain-manifest.json
@@ -124,6 +124,16 @@
       "seed_before": "seeds/before-12-issue-resume.sql",
       "seed_after": null,
       "halt_on_fail": true
+    },
+    {
+      "step": 13,
+      "id": 13,
+      "name": "13-search-grounding",
+      "row_dir": "rows/13-search-grounding",
+      "partial_test": false,
+      "seed_before": null,
+      "seed_after": null,
+      "halt_on_fail": true
     }
   ]
 }

--- a/tests/dogfood/rows/04-first-task-hits-gate/outcome.sql
+++ b/tests/dogfood/rows/04-first-task-hits-gate/outcome.sql
@@ -37,3 +37,10 @@ SELECT
   'agent_runs bro row (got ' || COUNT(*) || ', expected >=1) — folded from retired step 14' AS description
 FROM agent_runs
 WHERE agent_type = 'bro';
+
+SELECT
+  CASE WHEN COUNT(*) >= 2 THEN 1 ELSE 0 END AS pass,
+  'file_registry_embeddings populated post-scan for cli.py + test_cli.py (got ' || COUNT(*) || ', expected >=2)' AS description
+FROM file_registry_embeddings fre
+JOIN file_registry fr ON fre.file_registry_id = fr.rowid
+WHERE fr.path IN ('src/cli.py', 'tests/test_cli.py');

--- a/tests/dogfood/rows/06-post-close-cleanup/outcome.sql
+++ b/tests/dogfood/rows/06-post-close-cleanup/outcome.sql
@@ -11,3 +11,26 @@ FROM file_registry
 WHERE path = 'src/cli.py'
   AND summary IS NOT NULL
   AND summary != '';
+
+-- file_registry_embeddings for src/cli.py must have been bumped after the
+-- stale row seeded by setup-l5.sh (baseline stored in plugin_config by setup).
+-- In L6 chain mode this row is skipped because plugin_config key is absent
+-- (setup-l5.sh not run); the assertion short-circuits to pass via COALESCE.
+SELECT
+  CASE
+    WHEN (SELECT value_json FROM plugin_config WHERE key = 'l5_06_embedding_baseline') IS NULL
+      THEN 1
+    WHEN EXISTS (
+      SELECT 1
+      FROM file_registry_embeddings fre
+      JOIN file_registry fr ON fre.file_registry_id = fr.rowid
+      WHERE fr.path = 'src/cli.py'
+        AND fre.embedded_at > json_extract(
+              (SELECT value_json FROM plugin_config WHERE key = 'l5_06_embedding_baseline'),
+              '$'
+            )
+    )
+      THEN 1
+    ELSE 0
+  END AS pass,
+  'file_registry_embeddings.embedded_at for src/cli.py bumped past stale baseline (L5 only; L6 skips when key absent)' AS description;

--- a/tests/dogfood/rows/06-post-close-cleanup/setup-l5.sh
+++ b/tests/dogfood/rows/06-post-close-cleanup/setup-l5.sh
@@ -109,3 +109,20 @@ VALUES ('$REPO_NAME', '$PROJECT_REAL');
 INSERT OR REPLACE INTO file_registry (repo, path, type, content_md5, summary, summary_updated_at)
 VALUES ('$REPO_NAME', 'src/cli.py', 'source', '$content_md5', NULL, NULL);
 SQL
+
+# Pre-seed a stale file_registry_embeddings row for src/cli.py.
+# The outcome assertion verifies that after bro's file_registry_update_summaries
+# call the embedded_at timestamp is newer than this baseline.
+FR_ROWID=$(sqlite3 "$PROJECT/.claude/tmb/trajectory.db" \
+  "SELECT rowid FROM file_registry WHERE repo = '$REPO_NAME' AND path = 'src/cli.py' LIMIT 1;" 2>/dev/null)
+
+if [ -n "$FR_ROWID" ]; then
+  sqlite3 "$PROJECT/.claude/tmb/trajectory.db" <<SQL2
+INSERT OR REPLACE INTO file_registry_embeddings (file_registry_id, embedding, model_id, embedded_at)
+VALUES ($FR_ROWID, zeroblob(1536), 'sentinel-stale-v0', datetime('now', '-1 hour'));
+
+-- Store the baseline timestamp so outcome.sql can compare without reading a file.
+INSERT OR REPLACE INTO plugin_config (key, value_json)
+VALUES ('l5_06_embedding_baseline', json_quote(datetime('now', '-30 minutes')));
+SQL2
+fi

--- a/tests/dogfood/rows/13-search-grounding/README.md
+++ b/tests/dogfood/rows/13-search-grounding/README.md
@@ -1,0 +1,31 @@
+# 13-search-grounding
+
+**Scenario under test:** the Human asks bro why a prior architectural decision was made in `src/cli.py`. Bro must use `discussion_search` to ground the answer in the step 08 ADR decision rather than hallucinating from context. A `kind='decision'` discussion seeded by step 08 (or by `setup-l5.sh` in L5 isolation) is the only source of truth.
+
+The `discussions_embeddings` table is pre-seeded with a deterministic stub vector (zeros) for the decision row so keyword + hybrid search return it without a real ONNX embedding call.
+
+## Pre-state
+
+- `src/cli.py` exists with the storage-backend refactor from step 08.
+- A `kind='decision'` discussion exists (step 08's ADR content) with a corresponding `discussions_embeddings` row (stub vector — deterministic).
+- No real ONNX model needed; the stub vector ensures the DB-level cosine lookup returns the seeded row.
+
+## Turns
+
+| # | Speaker | Message |
+|---|---|---|
+| 1 | user | `@bro why did we choose to extract storage into a backend interface in src/cli.py?` |
+| → | bro | calls `discussion_search` to ground the answer in the recorded decision; cites the ADR body. No code work. |
+
+## Pass criteria
+
+| Scorer | Asserts |
+|---|---|
+| `outcome.sql` | `discussions_embeddings` ≥ 1 row (seeded by setup-l5.sh or step 08 organically) |
+| `outcome-coherence.json` | `discussions_embeddings`: `>=1` |
+| `outcome-git.json` | `base_branch_unchanged: true` |
+| `tools-required.json` | `discussion_search` |
+| `tools-forbidden.json` | `task_create_batch` (no code work) |
+| `cost-budget.json` | Soft 200K / 600s |
+
+**Failure modes captured:** bro answers from LLM memory without calling `discussion_search`; bro calls `task_create_batch` (incorrectly treats a knowledge question as a code task).

--- a/tests/dogfood/rows/13-search-grounding/cost-budget.json
+++ b/tests/dogfood/rows/13-search-grounding/cost-budget.json
@@ -1,0 +1,5 @@
+{
+  "max_tokens_total": 200000,
+  "max_duration_ms": 600000,
+  "fail_above_max": false
+}

--- a/tests/dogfood/rows/13-search-grounding/fixture.txt
+++ b/tests/dogfood/rows/13-search-grounding/fixture.txt
@@ -1,0 +1,1 @@
+onboarding-named

--- a/tests/dogfood/rows/13-search-grounding/outcome-coherence.json
+++ b/tests/dogfood/rows/13-search-grounding/outcome-coherence.json
@@ -1,0 +1,5 @@
+{
+  "expected_writes": {
+    "discussions_embeddings": ">=1"
+  }
+}

--- a/tests/dogfood/rows/13-search-grounding/outcome-git.json
+++ b/tests/dogfood/rows/13-search-grounding/outcome-git.json
@@ -1,0 +1,3 @@
+{
+  "base_branch_unchanged": true
+}

--- a/tests/dogfood/rows/13-search-grounding/outcome.sql
+++ b/tests/dogfood/rows/13-search-grounding/outcome.sql
@@ -1,0 +1,17 @@
+-- 13-search-grounding — bro must search discussions to ground its answer
+-- about the architectural decision made in step 08.
+
+-- (a) The discussions_embeddings table has at least one row — either seeded
+-- by setup-l5.sh (L5 mode) or produced organically by step 08 + server
+-- backfill (L6 chain mode). This verifies the search substrate exists.
+SELECT
+  CASE WHEN COUNT(*) >= 1 THEN 1 ELSE 0 END AS pass,
+  'discussions_embeddings populated for step-08 decision (got ' || COUNT(*) || ', expected >=1)' AS description
+FROM discussions_embeddings;
+
+-- (b) At least one kind='decision' discussion exists — the target of the search.
+SELECT
+  CASE WHEN COUNT(*) >= 1 THEN 1 ELSE 0 END AS pass,
+  'kind=decision discussion exists (got ' || COUNT(*) || ', expected >=1)' AS description
+FROM discussions
+WHERE kind = 'decision';

--- a/tests/dogfood/rows/13-search-grounding/prompt.txt
+++ b/tests/dogfood/rows/13-search-grounding/prompt.txt
@@ -1,0 +1,1 @@
+@bro why did we choose to extract storage into a backend interface in src/cli.py?

--- a/tests/dogfood/rows/13-search-grounding/script.json
+++ b/tests/dogfood/rows/13-search-grounding/script.json
@@ -1,0 +1,5 @@
+{
+  "max_turns": 1,
+  "user_after_bro": [],
+  "terminal_pattern": ""
+}

--- a/tests/dogfood/rows/13-search-grounding/setup-l5.sh
+++ b/tests/dogfood/rows/13-search-grounding/setup-l5.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Pre-seed the state that step 08 (08-architectural-change) would have
+# produced organically in L6 chain mode: a kind='decision' discussion
+# recording why the storage layer was extracted into a backend interface,
+# plus a corresponding discussions_embeddings row with a deterministic
+# stub vector (zero bytes) so keyword + cosine search both return the
+# row without a real ONNX model call.
+#
+# In L6, setup-l5.sh is NOT run — step 08's bro turn produces the
+# decision discussion organically; the after-08-architectural-change.sql
+# seed bridges any post-AUQ gap; the backfill step on server startup
+# would normally populate embeddings. The stub vector here ensures L5
+# isolation gets a hit regardless of whether the embedding model is
+# available in the test environment.
+set -uo pipefail
+
+PROJECT="$1"
+# shellcheck disable=SC2034
+SCENARIO_DIR="$2"
+
+DB="$PROJECT/.claude/tmb/trajectory.db"
+
+# Ensure an issue exists to attach the discussion to.
+ISSUE_ID=$(sqlite3 "$DB" \
+  "SELECT id FROM issues ORDER BY id LIMIT 1;" 2>/dev/null)
+if [ -z "$ISSUE_ID" ]; then
+  sqlite3 "$DB" <<SQL
+INSERT INTO issues (objective, description, status, created_at, updated_at)
+VALUES (
+  'Extract storage layer into backend interface',
+  'Refactor src/cli.py JSON storage into a pluggable backend interface so SQLite can be swapped in later.',
+  'closed',
+  datetime('now', '-2 hours'),
+  datetime('now', '-2 hours')
+);
+SQL
+  ISSUE_ID=$(sqlite3 "$DB" "SELECT last_insert_rowid();")
+fi
+
+# Insert the kind='decision' discussion mirroring step 08's ADR body.
+sqlite3 "$DB" <<SQL
+INSERT INTO discussions (issue_id, author, kind, body, created_at)
+VALUES (
+  $ISSUE_ID,
+  'bro',
+  'decision',
+  'Decision: extract storage into a backend interface (StorageBackend ABC) with a JsonFileBackend default implementation. Factory function selects backend at runtime. Rationale: (1) decouples command handlers from persistence detail; (2) makes SQLite swap-in a targeted change; (3) preserves back-compat for existing ~/.todo-cli/todos.json files via JsonFileBackend. ADR: docs/trustmybot/architecture/manual/decisions/001-storage-backend-interface.md',
+  datetime('now', '-1 hour')
+);
+SQL
+
+DISCUSSION_ID=$(sqlite3 "$DB" "SELECT last_insert_rowid();")
+
+# Seed a stub embedding for the decision row so discussion_search returns it
+# deterministically without a real ONNX call. zeroblob(1536*4) = 6144 zero
+# bytes = 1536-dim float32 zero vector. Cosine of zero vector is undefined
+# (div-by-zero), so the server's topKByCosine will return score=NaN/0 for
+# this row. The FTS5 keyword path and hybrid path will still find it via
+# BM25. The outcome assertion only checks row existence, not search score.
+sqlite3 "$DB" <<SQL
+INSERT OR REPLACE INTO discussions_embeddings (discussion_id, embedding, model_id, embedded_at)
+VALUES ($DISCUSSION_ID, zeroblob(6144), 'stub-zero-v0', datetime('now', '-55 minutes'));
+SQL

--- a/tests/dogfood/rows/13-search-grounding/tools-forbidden.json
+++ b/tests/dogfood/rows/13-search-grounding/tools-forbidden.json
@@ -1,0 +1,3 @@
+[
+  "mcp__plugin_tmb_trajectory-server__task_create_batch"
+]

--- a/tests/dogfood/rows/13-search-grounding/tools-required.json
+++ b/tests/dogfood/rows/13-search-grounding/tools-required.json
@@ -1,0 +1,3 @@
+[
+  "mcp__plugin_tmb_trajectory-server__discussion_search"
+]


### PR DESCRIPTION
## Summary

PR-C of 4 for #49 (v0.7.0 RAG test coverage). L0 docker semantic call + NEW chain step 13 (search-grounding) + assertion-only extensions to step 04/06 outcomes.

### Files (17 changed)

- `tests/docker/install-smoke.Dockerfile` — A3c block: `discussion_search(mode='semantic')` round-trip; accepts real results OR `semantic_unavailable` warning.
- `tests/dogfood/l6-chain/chain-manifest.json` — append step 13 (chain now 13 steps).
- `tests/EVALUATION.md` — append step 13 to per-step I/O table + S13 node in Mermaid + S8→S13 cross-step note.
- `tests/dogfood/rows/04-first-task-hits-gate/outcome.sql` — APPEND: `file_registry_embeddings` ≥2 for src/cli.py + tests/test_cli.py (silent embed-on-write side-effect).
- `tests/dogfood/rows/06-post-close-cleanup/outcome.sql` — APPEND: re-embed assertion (`embedded_at > baseline`). L6 short-circuits to pass when no plugin_config baseline.
- `tests/dogfood/rows/06-post-close-cleanup/setup-l5.sh` — APPEND: seed stale embedding row with sentinel model_id + store baseline timestamp.
- `tests/dogfood/rows/13-search-grounding/` — NEW row dir (11 files): bro must call `discussion_search` to ground answer about step-08 ADR.

### L5/L6 1:1

- L5: setup-l5.sh seeds the decision + embedding stub locally
- L6: inherits step-08's ADR organically; same prompt + outcome assertions
- Same scorers in both modes

### Verification

- Constraint honored: rows 01-12 prompts untouched; only 04/06 outcome.sql + 06 setup-l5.sh appended.
- Schema references validated against `mcp/trajectory-server/src/schema.sql`.

### Test plan

- [x] Step 13 row layout complete (11 standard files)
- [x] chain-manifest extended to step 13
- [x] EVALUATION.md per-step table + Mermaid updated
- [x] Step 04 + 06 outcome additions append-only
- [ ] L6 chain runs 13/13 (deferred to full L6 run post-merge)

pr-reviewer validation_attempts row id=38 written (PASS).

Companion PRs: PR-A (#226 merged), PR-B (#227 merged), PR-D (prompt awareness — coming next).