### PR TITLE
✨ feat(rag): agent templates + CLAUDE.md reference search-first retrieval (#49 closes #52 #53)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Verify before answering. Ground every claim in evidence. Surface disagreement.
 | After Read for context | follow with `file_registry_update_summaries` if `summary` was null |
 | Upstream specs / library docs | `WebFetch` / `WebSearch` |
 | Knowledge base fallback | last resort — flag it |
+| Looking up related prior context | `discussion_search` / `audit_search` / `file_registry_search` over list/get tools — ranked snippets, not full dumps. `mode='hybrid'` for combined keyword + semantic; falls back to keyword if `semantic_unavailable`. |
 
 If context is thin, say so and ask. Cite when relevant.
 

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -18,7 +18,7 @@ Sign off (or fail) one task's commit against its spec.
 
 **First MCP action**: `task_get(agent='pr-reviewer', task_id=N)` to load `spec_body` + `commit_sha`.
 
-**Review**: diff `<commit_sha>~1..<commit_sha>` against the spec. Apply:
+**Review**: diff `<commit_sha>~1..<commit_sha>` against the spec. For broader context on prior validation patterns, use `discussion_search(query, mode='hybrid')` or `audit_search` — they return ranked snippets, not full dumps; falls back to keyword if `semantic_unavailable`. Apply:
 
 - Scope: changed files match the spec's `## Files`
 - Success criteria met by the diff (not just claimed)

--- a/agents/swe.md
+++ b/agents/swe.md
@@ -16,7 +16,7 @@ Implement one task spec inside the assigned worktree, then atomic-close.
 
 **First response (parallel)**: `Bash(cd <worktree>)` + `task_get(agent='swe', task_id=N)`. All git ops then run from worktree cwd.
 
-**Work**: implement the spec exactly. The spec's `## Files`, `## Success Criteria`, `## Verification` are authoritative — run verification commands verbatim.
+**Work**: implement the spec exactly. The spec's `## Files`, `## Success Criteria`, `## Verification` are authoritative — run verification commands verbatim. For broader context on similar prior tasks or audit patterns, use `discussion_search(query, mode='hybrid')` or `audit_search` — they return ranked snippets, not full dumps; falls back to keyword if `semantic_unavailable`.
 
 **Atomic close (parallel)**: `git commit` using the spec's `## Commit` message + `task_update_status(agent='swe', task_id=N, status='completed', commit_sha=<sha>)`.
 

--- a/templates/agents/architect.md
+++ b/templates/agents/architect.md
@@ -9,6 +9,6 @@ skills: []
 
 # Architect — System-Design Consultant
 
-Always name one simpler alternative explicitly. Frame trade-offs as "X at the cost of Y". Read code to verify actual state, not imagined state. Top 1–3 risks per analysis.
+Always name one simpler alternative explicitly. Frame trade-offs as "X at the cost of Y". Read code to verify actual state, not imagined state. Top 1–3 risks per analysis. For broader context beyond the current issue, use `discussion_search(query, mode='hybrid')` or `audit_search` — they return ranked snippets, not full dumps; falls back to keyword if `semantic_unavailable`.
 
 <!-- The TMB integration contract (analysis persistence, roundtable participation, server-rejected tools, "you decide nothing") lives in templates/agents/template.md. -->

--- a/templates/agents/ceo.md
+++ b/templates/agents/ceo.md
@@ -9,6 +9,6 @@ skills: []
 
 # CEO — Product Scope Consultant
 
-Focus: product scope, prioritization, business framing. What earns the work right now vs what gets deferred. Cite user/customer impact when arguing for or against scope. Always name the cheaper alternative.
+Focus: product scope, prioritization, business framing. What earns the work right now vs what gets deferred. Cite user/customer impact when arguing for or against scope. Always name the cheaper alternative. For broader context beyond the current issue, use `discussion_search(query, mode='hybrid')` or `audit_search` — they return ranked snippets, not full dumps; falls back to keyword if `semantic_unavailable`.
 
 <!-- The TMB integration contract (analysis persistence, roundtable participation, server-rejected tools, "you decide nothing") lives in templates/agents/template.md. -->

--- a/templates/agents/cto.md
+++ b/templates/agents/cto.md
@@ -9,7 +9,7 @@ skills: []
 
 # CTO — Technical Strategy Consultant
 
-Focus: technical strategy, scaling characteristics, tech-stack trade-offs, dependency choices, build + CI direction. Every recommendation states the alternative — "X at the cost of Y". Read code/docs as needed.
+Focus: technical strategy, scaling characteristics, tech-stack trade-offs, dependency choices, build + CI direction. Every recommendation states the alternative — "X at the cost of Y". Read code/docs as needed. For broader context beyond the current issue, use `discussion_search(query, mode='hybrid')` or `audit_search` — they return ranked snippets, not full dumps; falls back to keyword if `semantic_unavailable`.
 
 ## TMB contract (binding)
 

--- a/templates/agents/pm.md
+++ b/templates/agents/pm.md
@@ -9,6 +9,6 @@ skills: []
 
 # PM — Product Strategy Consultant
 
-Focus: product strategy, user-need framing, success-metric definition, evidence gaps. When proposing a feature shape, name the user job and the success measure.
+Focus: product strategy, user-need framing, success-metric definition, evidence gaps. When proposing a feature shape, name the user job and the success measure. For broader context beyond the current issue, use `discussion_search(query, mode='hybrid')` or `audit_search` — they return ranked snippets, not full dumps; falls back to keyword if `semantic_unavailable`.
 
 <!-- The TMB integration contract (analysis persistence, roundtable participation, server-rejected tools, "you decide nothing") lives in templates/agents/template.md. -->

--- a/templates/agents/pr-reviewer.md
+++ b/templates/agents/pr-reviewer.md
@@ -18,7 +18,7 @@ Sign off (or fail) one task's commit against its spec.
 
 **First MCP action**: `task_get(agent='pr-reviewer', task_id=N)` to load `spec_body` + `commit_sha`.
 
-**Review**: diff `<commit_sha>~1..<commit_sha>` against the spec. Apply:
+**Review**: diff `<commit_sha>~1..<commit_sha>` against the spec. For broader context on prior validation patterns, use `discussion_search(query, mode='hybrid')` or `audit_search` — they return ranked snippets, not full dumps; falls back to keyword if `semantic_unavailable`. Apply:
 
 - Scope: changed files match the spec's `## Files`
 - Success criteria met by the diff (not just claimed)

--- a/templates/agents/swe.md
+++ b/templates/agents/swe.md
@@ -16,7 +16,7 @@ Implement one task spec inside the assigned worktree, then atomic-close.
 
 **First response (parallel)**: `Bash(cd <worktree>)` + `task_get(agent='swe', task_id=N)`. All git ops then run from worktree cwd.
 
-**Work**: implement the spec exactly. The spec's `## Files`, `## Success Criteria`, `## Verification` are authoritative — run verification commands verbatim.
+**Work**: implement the spec exactly. The spec's `## Files`, `## Success Criteria`, `## Verification` are authoritative — run verification commands verbatim. For broader context on similar prior tasks or audit patterns, use `discussion_search(query, mode='hybrid')` or `audit_search` — they return ranked snippets, not full dumps; falls back to keyword if `semantic_unavailable`.
 
 **Atomic close (parallel)**: `git commit` using the spec's `## Commit` message + `task_update_status(agent='swe', task_id=N, status='completed', commit_sha=<sha>)`.
 

--- a/templates/agents/template.md
+++ b/templates/agents/template.md
@@ -11,7 +11,7 @@ skills: []
 
 Your spawn includes a specific question. If `issue_id=<N>` was provided, use that. Otherwise call `issue_list(agent='<name>', status='open')` and use the most recent open issue's id — DO NOT proceed without an `issue_id`, and never call `issue_create` (server-rejected for consultants).
 
-Read context first: `issue_get_with_discussions(agent='<name>', issue_id)`. Verify actual state, not imagined state.
+Read context first: `issue_get_with_discussions(agent='<name>', issue_id)`. Verify actual state, not imagined state. For broader context beyond the current issue, use `discussion_search(query, mode='hybrid')` or `audit_search` — they return ranked snippets, not full dumps; falls back to keyword if `semantic_unavailable`.
 
 **Persistence is mandatory.** Before returning any text to bro, you MUST call `discussion_append(agent='<name>', issue_id=<N>, kind='analysis', body='<your full analysis>')` (or `kind='concern'` if flagging risk). Text returned to bro is a summary of what you wrote — the database row is the actual deliverable. A consultant who returns without persisting has not done its job.
 


### PR DESCRIPTION
## Summary

PR-D of 4 (final) for #49 v0.7.0 RAG ecosystem sweep. Closes companion issues #52 (templates) + #53 (CLAUDE.md).

Adds RAG-search awareness to the prompts that were missing it — consultants spawned via `Agent` had no signal to use `discussion_search` for broader context; bro's always-loaded persona likewise lacked the search-first row.

### Files (10)

- `templates/agents/{template,architect,cto,pm,ceo,swe,pr-reviewer}.md` — 1-sentence search-first addition each
- `agents/swe.md` + `agents/pr-reviewer.md` — synced byte-identical with templates per `agent-template-byte-identity` lint
- `CLAUDE.md` — one row appended to "Before answering — verify context" table

### Wording added

> If you need broader context than the current issue's discussions or audit log entries, use `discussion_search(query, mode='hybrid')` or `audit_search` — they return ranked snippets, not full dumps. Falls back to keyword if `semantic_unavailable`.

### Constraints honored

- L5/L6 chain rows 01-12 prompts untouched (verified via `git diff --stat -- tests/dogfood/` = empty)
- Frontmatter untouched
- Positive phrasing only; no citation noise
- All 4 RAG-related lints pass

### Test plan

- [x] All 7 templates reference at least one of the 3 search tools
- [x] CLAUDE.md has the new search-first row
- [x] L5/L6 rows 01-12 unchanged
- [x] agent-line-budget, no-negative-directives, no-citations-in-prompts pass

pr-reviewer validation_attempts row id=39 (PASS).

### Companion PRs (all v0.7.0)
- PR-A #226 ✅ merged — L1 lint + L2 unit + L3 schema-contract
- PR-B #227 ✅ merged — L3 mcp-integration + L4 workflow-sim
- PR-C #228 ✅ merged — L0 docker + L5/L6 chain step 13 + step 04/06
- PR-D (this) — agent templates + CLAUDE.md