### PR TITLE
🔧 fix(lint): clear 3 pre-L6 L1 failures (stale-framing + SC2034 + token-burn label) (#54)

### DIFF
--- a/commands/agent-create.md
+++ b/commands/agent-create.md
@@ -1,6 +1,6 @@
 ---
 name: agent-create
-description: Create or copy an agent into the project's .claude/agents/ directory and (optionally) spawn it on a consultant question. Self-contained — replaces the retired tmb_agent-creator skill; routing/enforcement comes from this command body + the consultant-spawn-required hook.
+description: Create or copy an agent into the project's .claude/agents/ directory and (optionally) spawn it on a consultant question. Self-contained — routing/enforcement comes from this command body + the consultant-spawn-required hook.
 argument-hint: <kebab-case agent name> [optional consultant question]
 ---
 

--- a/docs/contributing/LABELS.md
+++ b/docs/contributing/LABELS.md
@@ -10,7 +10,7 @@ If you need a new label and it's not below, ask in the PR. Adding a label is a d
 
 ---
 
-## Canonical list — 18 labels on GH, 14 on Linear (Linear has native priority field)
+## Canonical list — 19 labels on GH, 14 on Linear (Linear has native priority field)
 
 ### Type / kind (4)
 
@@ -49,12 +49,13 @@ New area labels are added when a genuinely new surface emerges. Adding one is a 
 
 GH has no priority field, so we keep them as labels. Linear has a native priority field — no labels needed there.
 
-### TMB-specific (2)
+### TMB-specific (3)
 
 | Label | Means |
 |---|---|
 | **Doctrine** | Design rule / contract change (CLAUDE.md, planning skills, agent prompts) |
 | **Discussion** | Open design question, no decided action yet |
+| **token-burn** | Issue or PR that caused or risks abnormally high token spend |
 
 Adding any other TMB-specific label requires an entry in this table with a "why" justification.
 

--- a/tests/dogfood/lib/l6-chain-helpers.sh
+++ b/tests/dogfood/lib/l6-chain-helpers.sh
@@ -71,8 +71,6 @@ l6c_run_step() {
     terminal_pattern=""
   fi
 
-  local session_id
-  session_id=$(l6c_uuid)
   : > "$out_jsonl"
 
   local turn=1


### PR DESCRIPTION
## Summary

PR-E of pre-L6 cleanup sweep (#54). 3 mechanical L1 lint fixes blocking the `bash tests/run-all.sh` green gate.

### Fixes

- `commands/agent-create.md:3` — removed stale "replaces the retired tmb_agent-creator skill" from description (positive phrasing preserved).
- `tests/dogfood/lib/l6-chain-helpers.sh` — deleted dead `session_id` local (SC2034); per-turn UUID is already captured in `per_turn_session_id`.
- `docs/contributing/LABELS.md` — added `token-burn` row + bumped count to 19 / TMB-specific (3).

### Verification

- `stale-framing-prose.sh` PASS
- `shellcheck-hooks.sh` PASS
- `labels-stable.sh` PASS

pr-reviewer validation_attempts row id=40 (PASS).

Companion PR: PR-F (`fix/pre-l6-test-and-hook-cleanup`) — coming next, covers L2 agents.test idempotency + L3 cleanup-worktree-on-task-close hook.