### PR TITLE
🔖 chore(release): cut v0.7.0-rc.3 + consolidate CHANGELOG (#59)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.7.0-rc.2",
+  "version": "0.7.0-rc.3",
   "description": "TMB plugin — bro orchestrates SWE + pr-reviewer in two gates (task gate, push gate) backed by a SQLite trajectory MCP server.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.7.0-rc.3 — 2026-05-22
+
+### Added
+
+- ✨ **GH release-gate CI workflow restored** (#235). `release-gate.yml` fires on rc/stable version tags and `workflow_dispatch`. Runs L1–L4 (`run-all.sh`) + L6 13-step chain (skippable via `skip_l6` input) + L0 docker install-smoke as a parallel job. Includes HuggingFace ONNX model cache step to avoid re-downloading the bge-small model on every run.
+
 ## v0.7.0-rc.2 — 2026-05-22
 
 ### Added

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.7.0-rc.2",
+  "version": "0.7.0-rc.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.7.0-rc.2",
+  "version": "0.7.0-rc.3",
   "description": "TMB multi-agent Claude Code plugin — workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Summary

Cuts v0.7.0-rc.3 from dev HEAD. Mechanical version bump.

### Changes
- 3 canonical manifests bumped 0.7.0-rc.2 → 0.7.0-rc.3
- CHANGELOG.md adds section listing PR #235 (CI restore)

### Why rc.3
PR #235 (`ff4e6f4`) restored GH Actions CI. Tagging rc.3 dogfoods the new `release-gate.yml` workflow on its first real trigger.

pr-reviewer validation_attempts row id=48 (PASS). Closes #59.