### PR TITLE
🐛 fix(ci): release-gate workdir + cut v0.7.0-rc.4 (#60)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.7.0-rc.3",
+  "version": "0.7.0-rc.4",
   "description": "TMB plugin — bro orchestrates SWE + pr-reviewer in two gates (task gate, push gate) backed by a SQLite trajectory MCP server.",
   "author": {
     "name": "trustmybot",

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -24,9 +24,6 @@ jobs:
     name: L1+L2+L3+L4 (+ L6 chain)
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    defaults:
-      run:
-        working-directory: plugin
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     steps:
@@ -64,9 +61,6 @@ jobs:
     name: L0 docker install-smoke
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    defaults:
-      run:
-        working-directory: plugin
     steps:
       - uses: actions/checkout@v4
       - name: Run install-smoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.7.0-rc.4 — 2026-05-22
+
+### Fixed
+
+- `release-gate.yml` workflow no longer assumes the local monorepo layout (`TMB/plugin/`); runs at GH repo root since `trustmybot/plugin` IS the plugin code.
+
 ## v0.7.0-rc.3 — 2026-05-22
 
 ### Added

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.7.0-rc.3",
+  "version": "0.7.0-rc.4",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.7.0-rc.3",
+  "version": "0.7.0-rc.4",
   "description": "TMB multi-agent Claude Code plugin — workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Summary

Fixes the release-gate workflow that failed at the rc.3 tag (workdir assumed local TMB/plugin/ monorepo path; GH's trustmybot/plugin repo IS the plugin code at root). Bundles the rc.4 bump.

### Fix
Removed `defaults.run.working-directory: plugin` blocks from both jobs.

### Verification
- Both lints + run-all.sh green
- pr-reviewer validation_attempts id=49 (PASS)
- Will dogfood via rc.4 tag

Closes #60.