### PR TITLE
♻️ refactor(skills): lead with world_model_get; tmb_planning 200→100 lines

### DIFF
--- a/skills/tmb_planning/SKILL.md
+++ b/skills/tmb_planning/SKILL.md
@@ -1,62 +1,27 @@
 ---
 name: tmb_planning
-description: Bro's full code-touching flow — cold-start judgment, branch_id confirm, spec authoring (defaults table + ADR when architectural), decision audit, SWE spawn, V1/V2/V3 verification, atomic close, retry-on-fail. Loaded on the first code-touching ask of a session. Self-contained — everything bro needs is here.
+description: Bro's code-touching flow — verify world model, propose branch, write spec, dispatch SWE, verify on return, atomic-close. Loaded on the first code-touching ask of a session.
 allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion, Task, mcp__plugin_tmb_trajectory-server
 ---
 
 # Planning — bro's code-touching flow
 
-The deterministic substrate (project inventory, registry warmth) lands
-as `additionalContext` from `session-start-prescan.sh` before this skill
-loads. The mechanical pre-checks (scope-ambiguity gate, branch-id-proposed
-audit, source-edit guard) are wire-enforced. This skill is what bro decides.
+## 1. Verify the world model
 
-## Headless fast path (TMB_HEADLESS=1)
+Before anything: `world_model_get(depth=2)`. Returns the project's directory tree with README-derived summaries — bro's working mental picture. If the response carries `warning: 'world-model-empty'`, tell the Human to run `/scan` first. Without it bro is planning blind.
 
-**Skip every AUQ.** No Human means no answer; rendering an AUQ incurs
-a deny-and-recover round trip per question. The 6-step recipe below is
-fully self-contained.
+Zoom-in: `world_model_get(path='src/api', depth=1)`. "Where does X live": `world_model_search(query='X', mode='hybrid')`.
 
-1. `branch_id_propose(agent='bro', intent=<verbatim>, objective=<short>)` → take returned `branch_id`.
-2. `issue_create(agent='bro', objective=<short>, description=<2-sentence summary>)`.
-3. `headless_intent_start(agent='bro', issue_id=<I>, branch_id=<branch_id>, intent_verbatim=<verbatim>, fallback_summary='<defaults applied>')` — writes headless_fallback audit + note + intent in one transaction. <!-- enforced by: headless_intent_start composite (mech 2) -->
-4. `discussion_append(issue_id=<I>, author='bro', kind='decision', body='<chosen approach: what, why, trade-offs>')`. Required by the server-side decision gate on `task_create_batch`.
-5. `git switch -c <branch_id>` (the WorktreeCreate hook routes to the right inner repo when in a workspace).
-6. Author the spec body inline using the template in §"Spec body template". For architectural changes (touches `docs/trustmybot/architecture/`, schema, public API, or external side effects) also co-author an ADR at `docs/trustmybot/architecture/manual/decisions/N-*.md` and apply the blast-radius checklist (see §"Architectural changes" below).
-7. `task_create_batch(agent='bro', issue_id=<I>, tasks=[{branch_id, description, spec_body}], emit_planning_complete=true, waive_scope_gate=true, waive_scope_gate_reason='headless mode: defaults applied; <one-line scope summary>')`.
-8. Spawn SWE: `git worktree add .claude/worktrees/<slug> <branch_id>`, then `Task(subagent_type='swe', isolation='worktree', prompt='task_id=<N> worktree=.claude/worktrees/<slug>')`.
+## 2. Propose a branch
 
-Interactive (Human-present) flow continues at Step 0.
-
-## Step 0 — Cold-start codebase memory
-
-Fires when `session-start-prescan.sh` reported `file_registry: cold` AND `N source > 0`.
-
-**Tell the Human to run `/scan`.** The slash command is the deterministic path: bash + git + md5 populate `repos` + `file_registry` and emit a `deep_scan_completed` audit row, which clears the registry-cold gate on `task_create_batch`. Phase 2 of `/scan` dispatches background subagents to fill summaries in parallel — non-blocking.
-
-<!-- enforced by: server registry_cold_violation gate (mech 1) — relay the error message if it fires -->
-
-Drift (warm + dirty / branch behind / HEAD moved) is handled automatically by the post-task-close auto-rescan hook — md5-only invalidation preserves summaries on unchanged files.
-
-## Step 1 — Architectural-change check (judgment)
-
-Most code-touching work is everyday: bro picks defaults, writes a one-paragraph `kind='decision'` body, and dispatches SWE. A small subset needs more rigor — those changes also require an ADR + the blast-radius checklist. See §"Architectural changes" below for the criteria + ceremony.
-
-Either way bro writes **one** `kind='decision'` discussion summarizing the chosen approach. <!-- enforced by: decision gate on task_create_batch (mech 3) -->
-
-(Note: when the human wants alignment before bro commits to a plan, they enter Claude Code's native plan mode — bro doesn't drive a bespoke Q+A loop. The decision-audit row captures the outcome of that conversation.)
-
-## Step 2 — Branch-id + Human confirm (interactive)
-
-When a remote is configured, render:
+When a remote is configured:
 
 ```
 AskUserQuestion: "Which branch should I create the new feature branch from?"
-options: [pr_target (pull origin/<pr_target> first) | <current_branch> | 1-3 prominent local branches]
+options: [pr_target (pull origin/<pr_target> first) | <current_branch> | 1–3 prominent local branches]
 ```
 
-On `pr_target`: `git fetch origin ${pr_target} && git checkout ${pr_target} && git pull --ff-only`.
-On non-pr_target: switch; leave the branch as-is (no auto-pull). Any git error: halt and surface.
+On `pr_target`: `git fetch origin ${pr_target} && git checkout ${pr_target} && git pull --ff-only`. On a non-pr_target: switch; leave the branch as-is.
 
 Then derive + propose:
 
@@ -64,136 +29,91 @@ Then derive + propose:
 { branch_id, confidence } = branch_id_propose(agent='bro', intent=<verbatim>, objective=<short>)
 ```
 
-Render branch-id confirm AUQ:
-
 ```
 AskUserQuestion: "Proceed with branch_id <X>?"
 options: [Yes, proceed | Suggest different branch_id]
 ```
 
-On Yes: <!-- enforced by: branch_id_proposed audit gate (mech 3) + conventional-format regex (mech 3) -->
+On Yes:
 
 ```
 issue_create(agent='bro', objective=<short>)
 discussion_append(issue_id, author='bro', kind='intent', body=<verbatim>)
 discussion_append(issue_id, author='bro', kind='note',   body='Beginning planning on ${branch_id}.')
 git switch -c "${branch_id}"
-audit_log(agent='bro', from_node='bro', issue_id=<I>, branch_id=<branch_id>, event_type='branch_id_proposed', summary='Branch <branch_id> created from origin/<base>.')
 ```
 
-## Step 3 — Spec authoring
+## 3. Author the spec
 
-Pick conservative defaults, name them in `## Description` "Assumptions:" bullets. If the project already uses a different tool, **match the existing pattern** — convention wins over default.
+Pick conservative defaults; name them in `## Description` Assumptions bullets. If the project already uses a different tool, match the project — convention wins over default.
 
 | Dimension | Default |
 |---|---|
 | Python CLI / test | `argparse` / `unittest` (stdlib); match `pytest` if project uses it |
 | Node test | `node:test` (stdlib); match `vitest` / `jest` if project uses them |
-| Storage | `~/.<app>/<file>.json` (personal), match existing pattern (project) |
+| Storage | `~/.<app>/<file>.json` (personal); match project pattern |
 | File layout | single file until ~200 LOC |
-| Python version / concurrency | `python3`; single-user, single-process |
+| Python / concurrency | `python3`; single-user, single-process |
 
-Decision audit before `task_create_batch`: `discussion_append(kind='decision', body='<chosen approach>')`. <!-- enforced by: decision gate (mech 3) — rejected if missing -->
+Spec body sections (≤200 lines; split into multiple tasks linked by `parent_branch_id` if longer):
 
-The **scope-ambiguity gate** also stays: waivable for truly trivial changes. <!-- enforced by: scope gate on task_create_batch (mech 3) -->
+- `## Description` — ≤3 sentences, file paths with line refs, Assumptions bullets
+- `## Files` — path — action
+- `## Success Criteria` — 2–5 testable assertions
+- `## Verification` — exact bash commands
+- `## Out of Scope`
+- `## Commit` — `<emoji> <type>(<scope>): <msg>`
 
-### Architectural changes — ADR + blast-radius check
+Before `task_create_batch`: `discussion_append(kind='decision', body='<chosen approach>')`.
 
-When the change does any of the following, also co-author an ADR + apply the blast-radius check:
+### Architectural changes
 
-- Touches `docs/trustmybot/architecture/` directly
+When the change does any of the following, co-author an ADR at `docs/architecture/manual/decisions/N-*.md` and apply the blast-radius check:
+
+- Touches `docs/architecture/` directly
 - Introduces a new service boundary or top-level module
 - Modifies a public API surface
 - Commits to a strategic stack choice (auth provider, production DB, retention policy)
 - Names multiple unrelated surfaces in one task
-- Has external side effects (network, real API mutations, billing, message-sending, writes outside the worktree)
+- Has external side effects (network, billing, message-sending, writes outside the worktree)
 
-ADR location: `docs/trustmybot/architecture/manual/decisions/N-*.md` (see `templates/docs-trustmybot/architecture/manual/decisions/0001-example.md`).
+Blast-radius (external side effects only): default config is the safe state (opt-in); tests run against `:memory:` only; spec requires a pre-merge `bash tests/run-all.sh` yielding zero external mutations.
 
-<!-- LOAD-BEARING-SAFETY: blast-radius checklist is required for all external-side-effect changes; any miss blocks GA -->
-Blast-radius checklist (external side effects only): default config MUST be the safe state (opt-in); tests run only against the `:memory:` DB on default; spec MUST require a pre-merge `bash tests/run-all.sh` yielding zero external mutations. Any miss → spec back for revision.
+## 4. Spawn SWE
 
-If the human wants to deliberate on the architectural direction before bro commits, they enter **Claude Code's native plan mode** (Shift+Tab).
+```
+task_create_batch(agent='bro', issue_id=<I>, tasks=[{branch_id, spec_body, ...}], emit_planning_complete=true, ...)
+```
 
-## Spec body template (max 8000 chars)
+`waive_scope_gate` is valid for truly trivial work (`'trivial: <what>'`) or headless mode (`'headless mode, defaults applied; <one-line scope summary>'`).
 
-Self-contained — inline all referenced content. Sections: `## Description` (≤3 sentences, file paths with line refs, Assumptions bullets), `## Files` (path — action), `## Success Criteria` (2–5 testable assertions), `## Verification` (exact bash commands), `## Out of Scope`, `## Commit` (`<emoji> <type>(<scope>): <msg>`). Split into multiple tasks linked by `parent_branch_id` if it exceeds 200 lines.
+Then: `git worktree add .claude/worktrees/<slug> <branch_id>`, then `Task(subagent_type='swe', isolation='worktree', prompt='task_id=<N> worktree=.claude/worktrees/<slug>')`. Parallel spawns when tasks have no overlapping `## Files`; sequential when they share files.
 
-## Step 4 — Spawn SWE
+## 5. Verify on SWE return + atomic close
 
-`task_create_batch(agent='bro', issue_id=<I>, tasks=[{branch_id, spec_body, ...}], emit_planning_complete=true, ...)` — see MCP schema for full parameter list. <!-- enforced by: emit_planning_complete=true flag emits closing audit in same DB transaction (mech 2) -->
+After SWE returns `status=completed`:
 
-**`waive_scope_gate` use cases** — two valid:
+**V1** — pull: `task_get(task_id=<N>)` + `git diff <commit_sha>~1..<commit_sha>`.
 
-1. **Truly trivial work** (typo fix, one-line doc, mechanical rename per the user's exact request). Reason: `'trivial: <what>'`.
-2. **Headless mode (TMB_HEADLESS=1).** No Human in the loop means no chance to ask a clarifying question. Reason: `'headless mode, defaults applied; <one-line scope summary>'`.
-
-Spawn: `git worktree add .claude/worktrees/<slug> <branch_id>`, then `Task(subagent_type='swe', isolation='worktree', prompt='task_id=<N> worktree=.claude/worktrees/<slug>')`. `<slug>` = everything after the `<type>/` prefix. Parallel spawns when tasks have no overlapping `## Files`; sequential when they share files.
-
-## Step 5 — Verify + atomic close
-
-After SWE returns `completed`:
-
-**V1 — Pull**: `task_get(task_id=<N>)` + `git diff <commit_sha>~1..<commit_sha>`
-
-**V2 — Three checks (all required)**
-1. Files match `## Files` — every changed file listed; no surprise files outside scope.
-2. `## Verification` commands pass — re-run verbatim inside the SWE worktree. Run V2 BEFORE V3 — the `cleanup-worktree-on-task-close.sh` hook removes the worktree on close.
+**V2** — three checks:
+1. Changed files match `## Files`. No surprise files outside scope.
+2. `## Verification` commands pass — re-run verbatim inside the SWE worktree. Do this BEFORE V3 — the cleanup hook removes the worktree on close.
 3. Each `## Success Criteria` bullet visibly met by the diff.
 
-**V3 — All three pass → one atomic call**: `bro_atomic_close(agent='bro', task_id=<N>, commit_sha=<sha>, file_summaries=[...], verification_summary='...', close_issue_if_last_task=true)` — see MCP schema. <!-- enforced by: bro_atomic_close composite (mech 2) -->
+**V3** — all pass → `bro_atomic_close(agent='bro', task_id=<N>, commit_sha=<sha>, file_summaries=[...], verification_summary='...', close_issue_if_last_task=true)`. The post-close hook re-scans automatically — the world model refreshes.
 
-**Post-close cleanup is hook-enforced.** The `cleanup-worktree-on-task-close.sh` PostToolUse hook fires automatically when `task_update_status(status='closed')` runs (via `bro_atomic_close`): it removes the feature worktree directory AND checks out the project's base branch (`plugin_config.pr_target`, defaulting to `dev`) in the main checkout. Without that checkout, follow-on asks inherit the feature-branch HEAD from the just-closed task and bro's next-turn worktree mechanics tangle trying to plan from the wrong base. Bypass via `TMB_KEEP_HEAD_ON_CLOSE=1` for rare cases where the Human deliberately wants to stay on the feature branch.
+Then spawn pr-reviewer for the push gate (see `tmb_review` §C). On PASS: `git push -u origin <branch>`. On FAIL: surface, file the fix as a follow-up issue, do not push.
 
-<!-- LOAD-BEARING-SAFETY: bro is forbidden from calling validation_record — server enforces via requireRoles -->
-Then tell the Human "Trust me bro, it works." `validation_record` is pr-reviewer-only; the server returns `forbidden` if bro attempts it.
+**V3 — any check fails**: `bro_verification_fail_record(agent='bro', task_id=<N>, which_check='<V1|V2|V3>', details='<≤500 chars>')`. Leave the task open. Retry via `task_retry_batch` (max 3) or escalate.
 
-## Step 5.5 — pr-reviewer push gate
+## Headless overrides (TMB_HEADLESS=1)
 
-After `bro_atomic_close` succeeds, BEFORE pushing the branch, spawn pr-reviewer to score the commit.
-
-Spawn prompt MUST follow §C of `tmb_review`: pass only the bare anchors (task_id, commit_sha, branch_id, repo) plus a one-line context summary. <!-- enforced by: pr-reviewer-spawn-prompt-shape.sh PreToolUse hook (mech 3) -->
-
-On PASS verdict (validation_attempts row written): `git push -u origin <branch>`.
-On FAIL verdict: surface the failure, file the fix as a follow-up issue, do NOT push the failing commit.
-
-**V3 — Any check fails**: call `bro_verification_fail_record(agent='bro', task_id=<N>, which_check='<V1|V2|V3>', details='<≤500 chars>')` — writes the audit + note in one transaction. Leave the task open. Retry via `task_retry_batch` (max 3 retries) or escalate. <!-- enforced by: bro_verification_fail_record composite (mech 2) -->
-
-If `bro_atomic_close` returns `is_error: true`, halt and surface — see `tmb_recovery` §B.
-
-## Step 6 — Architecture refresh (post-close)
-
-<!-- enforced by: post-task-close-rescan.sh PostToolUse hook (mech 4) — fires automatically after bro_atomic_close -->
-The rescan hook runs `scan_run(source='bro_auto_post_close')` automatically. There is no separate arch-refresh step bro fires.
-
-## Headless fallback (interactive flow falls back here on AUQ error)
-
-If an AUQ in Steps 0/2 errors mid-interactive-run OR `TMB_HEADLESS=1` flips on:
+No Human in the loop — skip AUQs, apply the documented defaults, and record the fallback. After `branch_id_propose`, call `headless_intent_start(agent='bro', issue_id=<I>, branch_id=<branch_id>, intent_verbatim=<verbatim>, fallback_summary='<defaults applied>')`, then proceed to step 3.
 
 | AUQ | Default |
 |---|---|
-| Cold-start (Step 0) | Lazy fill |
-| Base-branch (Step 2) | `${pr_target}` |
-| Branch-id confirm (Step 2) | "Yes, proceed" |
+| Base-branch | `${pr_target}` |
+| Branch-id confirm | "Yes, proceed" |
+| Difficult Q+A | "proceed as proposed" |
 
-Use `headless_intent_start` to record the fallback. Auto-picking "Suggest different branch_id" or any "halt + ask" choice headlessly is blocked — those require explicit Human intent.
-
-For architectural changes in headless mode, still author the ADR with conservative assumptions. Waive the scope gate (Step 4 case 2).
-
-## Test-mode / sandbox signals
-
-When `$TMB_TEST_REMOTE` is set, real-remote operations (`gh repo create`, `glab repo create`, `git push https://...`) will fail loudly with "tmb sandbox" in stderr — that is the test mode signal. Treat the signal as confirmation you're in test mode, not as a shortcut: still run the normal flow (e.g., `onboard_state_get` for reonboard-shaped asks) and use `$TMB_TEST_REMOTE` as the remote URL when the flow's remote-setup step needs one. The bare repo at `$TMB_TEST_REMOTE` is the test-mode equivalent of github.com or gitlab.com.
-
-## Search-first retrieval
-
-When looking up past decisions, audit events, or file context, prefer `discussion_search` / `audit_search` / `file_registry_search` over the list/get tools — they return ranked snippets instead of full dumps. Use `mode='hybrid'` (the default) for combined keyword + semantic retrieval; `mode='keyword'` for exact-term queries where FTS5 precision matters; `mode='semantic'` when you know the concept but not the phrasing (e.g., "what did we decide about login flow?" returns results mentioning "authentication" and "JWT" even without those words in the query). Fallback to FTS5-only is automatic when the embedding model is unavailable; you'll see `warning: 'semantic_unavailable'` in the response.
-
-## Learning (post-retry or escalation)
-
-Capture the lesson once the retry is in flight:
-
-1. **Is this new or known?** Check the patterns + criteria documented in `tmb_review` skill body.
-2. **Where should the knowledge live?** Specific code pattern → `tmb_review` Living-patterns section. Design-time question or implementation rule → `tmb_review` Code-quality criteria, or a new lint hook in `scripts/hooks/`.
-3. **Was the task underspecified?** If SWE had to guess, update the spec template above.
-
-Skip one-off typos, tooling glitches, and bugs from stale task files.
+`tmb_skill-creator` and `/tmb:agent-create` from-scratch mode HALT in headless mode — silent skill/agent generation in CI is the foot-gun this guards.

--- a/skills/tmb_recovery/SKILL.md
+++ b/skills/tmb_recovery/SKILL.md
@@ -12,7 +12,7 @@ The bundled script `scripts/bro-sqlite-readonly.sh` is for §C (trajectory-serve
 
 ## Search-first retrieval
 
-When looking up past decisions, audit events, or file context, prefer `discussion_search` / `audit_search` / `file_registry_search` over the list/get tools — they return ranked snippets instead of full dumps. Use `mode='hybrid'` (the default) for combined keyword + semantic retrieval; `mode='keyword'` for exact-term queries where FTS5 precision matters; `mode='semantic'` when you know the concept but not the phrasing (e.g., "what did we decide about login flow?" returns results mentioning "authentication" and "JWT" even without those words in the query). Fallback to FTS5-only is automatic when the embedding model is unavailable; you'll see `warning: 'semantic_unavailable'` in the response.
+When looking up past decisions or project structure, prefer the search tools over list/get — they return ranked snippets, not full dumps. `world_model_get` / `world_model_search` for project navigation; `discussion_search` / `audit_search` for prior decisions and history. `mode='hybrid'` is the default; falls back to keyword if embeddings are unavailable (`warning: 'semantic_unavailable'`).
 
 ## A. AskUserQuestion error / TMB_HEADLESS=1
 
@@ -33,7 +33,6 @@ When looking up past decisions, audit events, or file context, prefer `discussio
 
 | Skill / form | Default | Reason |
 |---|---|---|
-| `tmb_planning` cold-start AUQ | Lazy fill | Cold-start scan is token-heavy; lazy is safer in CI. |
 | `tmb_planning` base-branch AUQ | `${pr_target}` | Matches the project's configured branching model. |
 | `tmb_planning` branch-id confirm | "Yes, proceed" | Bro already chose intelligently from project context. |
 | `tmb_planning` difficult Q+A | "proceed as proposed" | ADR is still authored; the deliberate-decision marker survives. |

--- a/skills/tmb_review/SKILL.md
+++ b/skills/tmb_review/SKILL.md
@@ -160,11 +160,11 @@ multiSelect: true
 options: [<task title (with optional (arch-impact) suffix)> per ratified group]
 ```
 
-For each ratified group: `task_create_batch(...)`, spawn SWE, and if arch-impact, invoke `scan_run(source='bro_auto_post_change')` after SWE returns to refresh the file_registry.
+For each ratified group: `task_create_batch(...)`, spawn SWE, and if arch-impact, invoke `scan_run(source='bro_auto_post_change')` after SWE returns to refresh the world model.
 
 ## Search-first retrieval
 
-When looking up past decisions, audit events, or file context, prefer `discussion_search` / `audit_search` / `file_registry_search` over the list/get tools — they return ranked snippets instead of full dumps. Use `mode='hybrid'` (the default) for combined keyword + semantic retrieval; `mode='keyword'` for exact-term queries where FTS5 precision matters; `mode='semantic'` when you know the concept but not the phrasing (e.g., "what did we decide about login flow?" returns results mentioning "authentication" and "JWT" even without those words in the query). Fallback to FTS5-only is automatic when the embedding model is unavailable; you'll see `warning: 'semantic_unavailable'` in the response.
+When looking up past decisions or project structure, prefer the search tools over list/get — they return ranked snippets, not full dumps. `world_model_get` / `world_model_search` for project navigation; `discussion_search` / `audit_search` for prior decisions and history. `mode='hybrid'` is the default; falls back to keyword if embeddings are unavailable (`warning: 'semantic_unavailable'`).
 
 ## Code-quality criteria (qualitative reference)
 


### PR DESCRIPTION
## Summary
Skills migration to the world-model surface. Closes much of #246.

- `tmb_planning` collapses from 200 → 100 lines: Step 0 cold-start replaced by one line — `world_model_get(depth=2)`. All `<!-- enforced by -->` comments stripped (rotting noise; the hooks/server enforce regardless). Hollow sections (Step 6 architecture refresh, test-mode signals, learning meta-process) removed. Headless-fast-path duplication folded into a single overrides table at the end.
- `tmb_recovery` drops the obsolete `tmb_planning cold-start AUQ` default (no more AUQ — it's a tool call now); search-first block slimmed.
- `tmb_review` references file_registry → world model; search-first block slimmed.

## CLAUDE.md proposed edits (Human applies — file is Human-owned)
Verify-context table needs same shift. Suggested replacement for the existing 4 rows:

```md
| Situation | Where to look |
|---|---|
| Cold session, code-touching | `world_model_get(depth=2)` |
| "Where does X live" | `world_model_search(query='X', mode='hybrid')` |
| Zoom into one area | `world_model_get(path='src/api', depth=1)` |
| Past decisions / audit / discussions | `discussion_search` / `audit_search` (ranked snippets) |
| Upstream specs / library docs | `WebFetch` / `WebSearch` |
```

The `file_registry_update_summaries` line can go entirely — file summaries are leaf-zoom now, not the primary surface.

## Follow-up slices still pending
- `world_model_search` MCP tool (FTS + embeddings)
- Embedding backfill wiring for `directories_embeddings`
- Doc reorg — REFERENCE/FLOWS/ERD/ENFORCEMENT/FILES lead with world-model
- Hook updates — `session-start-prescan.sh` reports world-model warmth
- `file_registry` removal (last)

🤖 Generated with [Claude Code](https://claude.com/claude-code)