### PR TITLE
📐 docs(reorg): architecture docs lead with world model

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -28,10 +28,10 @@ Lookups bro hits occasionally — keep here so they don't bloat CLAUDE.md.
 - **roundtable**: `roundtable_create`, `roundtable_vote`, `roundtable_close`, `roundtable_finalize_decisions`, `roundtable_summarize` (state machine: collecting → awaiting_human → closed | skipped)
 - **pr_comments**: `pr_comments_get` (gh + glab backends; bot detection via DEFAULT_BOT_PATTERNS), `pr_review_runs_list`
 - **validation**: `validation_record` (subagent_session_id required when agent='pr-reviewer'), `validation_history`
-- **file_registry**: `file_registry_upsert`, `file_registry_update_summaries` (bro-only; close-gate-enforced), `file_registry_list`, `file_registry_verify`, `file_registry_delete`
+- **world model** (bro's directory-level memory — ADR 0001): `world_model_get` (annotated dir tree), `world_model_search` (FTS5 / semantic / hybrid)
 - **onboard**: `onboard_state_get`, `onboard_get_questions`, `onboard_apply`
 - **config**: `config_get`, `config_list`, `config_set`
-- **scan**: `scan_run`, `repos_list`, `file_registry_bulk_upsert`
+- **scan**: `scan_run`, `repos_list`
 - **reports**: `issue_report_md`, `issue_snapshot_md`, `branch_report_md`
 - **skills**: `skill_register`, `skill_promote`, `skill_record_outcome`, `skill_record_invocation`, `skill_invocations_list`
 - **rules**: `rule_register`, `rule_list`, `rule_record_invocation`, `rule_invocations_list`
@@ -74,7 +74,7 @@ Catalog: `docs/commands/README.md`.
 | `mcp-health-check.sh` | SessionStart + UserPromptSubmit (periodic) | MCP server liveness probe |
 | `deferred-tools-drift-warn.sh` | SessionStart | Warn when MCP tools on disk newer than running server |
 | `write-active-workspace-sentinel.sh` | SessionStart | Sentinel for cross-session workspace resolution |
-| `session-start-prescan.sh` | SessionStart | Inject project inventory (git state, stacks, registry warmth) |
+| `session-start-prescan.sh` | SessionStart | Inject project inventory (git state, stacks, world-model warmth) |
 | `activation-routine.sh` | UserPromptSubmit | Pre-fetch onboarded marker + pending issue for bro banner |
 | `session-log-capture.sh` | UserPromptSubmit | Track current cc.log for diagnostics |
 | `consultant-spawn-required.sh` | UserPromptSubmit | Inject domain-expert prompt → suggest consultant spawn |
@@ -92,7 +92,6 @@ Catalog: `docs/commands/README.md`.
 | `require-task-spec.sh` | PreToolUse Agent | SWE spawn requires task_id + non-empty spec |
 | `require-feature-branch-active.sh` | PreToolUse Agent | Block issue/task ops without a feature branch |
 | `pr-reviewer-no-worktree.sh` | PreToolUse Agent | Prevent pr-reviewer from creating worktrees |
-| `require-summaries-before-task-close.sh` | PreToolUse task_update_status | Block close if file_registry summaries stale |
 | `askuserquestion-length-lint.sh` | PreToolUse AskUserQuestion | Cap label/description lengths |
 | `roundtable-auq-shape.sh` | PreToolUse AskUserQuestion | Validate AUQ shape during roundtable awaiting_human |
 | `auq-headless-deny.sh` | PreToolUse AskUserQuestion | Deny AUQ when TMB_HEADLESS=1 |
@@ -102,11 +101,10 @@ Catalog: `docs/commands/README.md`.
 | `debug-trajectory.sh` | PreToolUse (all, debug-mode) | Persist trajectory rows when TMB_DEBUG_TRAJECTORY=1 |
 | `cleanup-worktree-on-task-close.sh` | PostToolUse task_update_status | Remove worktree on close |
 | `roundtable-cleanup-postcheck.sh` | PostToolUse roundtable_close | Verify capture surface on close |
-| `post-task-close-rescan.sh` | PostToolUse bro_atomic_close | Background scan to refresh file_registry after close |
-| `post-read-summary-hint.sh` | PostToolUse Read | Hint to update file summary when null |
+| `post-task-close-rescan.sh` | PostToolUse bro_atomic_close | Background /scan to refresh the world model after close |
 | `post-task-create-spawn-hint.sh` | PostToolUse task_create_batch | Remind bro to spawn SWE after task batch |
 | `skill-invocation-record.sh` | PostToolUse Skill | Record skill invocation in trajectory DB |
 | `swe-atomic-close.sh` | SubagentStop | Auto-close pending SWE task; capture agent_runs metrics |
 | `worktree-create.sh` | WorktreeCreate | Enforce worktree-creation rules |
 
-## Schema state — see ERD.md for full table list (19 tables)
+## Schema state — see ERD.md for full table list (schema v7)

--- a/docs/architecture/ENFORCEMENT.md
+++ b/docs/architecture/ENFORCEMENT.md
@@ -32,9 +32,8 @@ The "Layer" column names the **strongest currently deployed** for each interacti
 | Bro creates the task branch (SWE may not invent / abbreviate) | 2 | `scripts/hooks/no-worktree-branch-create.sh` (also blocks `--detach`) |
 | Branch up-to-date with `origin/<pr_target>` before SWE attach | 2 | `scripts/hooks/branch-up-to-date-with-remote.sh` |
 | Worktree cleanup on task close | 2 | `scripts/hooks/cleanup-worktree-on-task-close.sh` |
-| Bro updates `file_registry` summaries before closing the task | 1 + 2 | `requireRoles('file_registry_update_summaries', ['bro'])` + `scripts/hooks/require-summaries-before-task-close.sh` |
-| `task_create_batch` blocked until `/scan` has run (registry-cold gate) | 1 | server gate in `tools/tasks.ts` rejects unless `audit` has a `deep_scan_completed` row OR `waive_registry_gate=true` + reason ≥10 chars |
-| `file_registry` auto-refresh after `bro_atomic_close` (md5-driven drift) | 4 | `scripts/hooks/post-task-close-rescan.sh` PostToolUse on `bro_atomic_close` backgrounds `scripts/maintenance/run-scan.mjs` |
+| `task_create_batch` blocked until `/scan` has run (world-model-cold gate) | 1 | server gate in `tools/tasks.ts` rejects unless `audit` has a `deep_scan_completed` row OR `waive_registry_gate=true` + reason ≥10 chars |
+| World model auto-refresh after `bro_atomic_close` | 4 | `scripts/hooks/post-task-close-rescan.sh` PostToolUse on `bro_atomic_close` backgrounds a fresh `scan_run` |
 | MCP calls include `agent: 'bro'` | 1 | `mcp/.../middleware/agent-scope.ts` |
 | `validation_record` requires `subagent_session_id` (#144) | 1 | `mcp/.../tools/validation.ts` |
 | `validation_record.feedback` MCP-availability prefix (#97) | 4 | schema CHECK on `validation_attempts.feedback` |
@@ -55,7 +54,6 @@ The "Layer" column names the **strongest currently deployed** for each interacti
 | Spawned only with valid `task_id` referencing pending/open task with non-empty `spec_body` | 2 | `scripts/hooks/require-task-spec.sh` |
 | Runs in isolated worktree | 2 | worktree Bash hooks |
 | Cannot create branches (must attach to bro-pre-created branch; no `--detach`) | 2 | `scripts/hooks/no-worktree-branch-create.sh` |
-| Cannot write `file_registry` summaries | 1 | `requireRoles('file_registry_update_summaries', ['bro'])` |
 | Worktree branch must descend from `origin/<pr_target>` | 2 | `scripts/hooks/branch-up-to-date-with-remote.sh` |
 | Scope-limited `tools:` keeps SWE off bro-only MCP writes | 1 + 3 | server `requireRoles` + `agents/swe.md` `tools:` list |
 | MCP calls include `agent: 'swe'`, scope-restricted | 1 | server middleware |
@@ -76,7 +74,7 @@ The "Layer" column names the **strongest currently deployed** for each interacti
 
 | Interaction | Layer | Where |
 |---|---|---|
-| Cannot write workflow state (task_*, validation_record, issue_*, file_registry_update_summaries) | 1 | server middleware |
+| Cannot write workflow state (task_*, validation_record, issue_*) | 1 | server middleware |
 | Spawned only by bro, never by Human directly | 6 only | CLAUDE.md routing |
 | Return analyses, never decisions | 6 only | consultant agent prompts |
 
@@ -90,10 +88,10 @@ The "Layer" column names the **strongest currently deployed** for each interacti
 | Naming conventions (file/identifier kebab/snake/Pascal per language) | 2 | `scripts/hooks/naming-lint.sh` |
 | Conventional-commit subject format | 2 | `scripts/hooks/commit-msg-lint.sh` |
 | Mechanical code-quality patterns (bare except, mutable defaults, missing timeout, f-string SQL, etc.) | 2 | `scripts/hooks/code-quality-lint.sh` |
-| Project inventory at session start | 2 | `scripts/hooks/session-start-prescan.sh` (reports `file_registry: cold`/`warm`; bulk population belongs to `/scan`) |
+| Project inventory at session start | 2 | `scripts/hooks/session-start-prescan.sh` (reports world-model `cold`/`warm`; bulk population belongs to `/scan`) |
 | Domain-expert prompt → suggest spawning consultant | 5 (UserPromptSubmit injection) | `scripts/hooks/consultant-spawn-required.sh` |
 | Roundtable capture-surface verification on `roundtable_close` | 2 | `scripts/hooks/roundtable-cleanup-postcheck.sh` |
-| Bro task-close atomic invariants (audit + summaries + status + issue close in one txn) | 1 (composite) | `mcp/.../tools/composites.ts:bro_atomic_close` |
+| Bro task-close atomic invariants (audit + status + issue close in one txn) | 1 (composite) | `mcp/.../tools/composites.ts:bro_atomic_close` |
 | SWE retry composite (rationale + new task + audit in one txn) | 1 (composite) | `mcp/.../tools/composites.ts:task_retry_batch` |
 | `branch_id` derivation from intent | 1 (composite) | `mcp/.../tools/composites.ts:branch_id_propose` |
 

--- a/docs/architecture/ERD.md
+++ b/docs/architecture/ERD.md
@@ -9,7 +9,7 @@ SQLite schema (`mcp/trajectory-server/src/schema.sql`, `schema_version = 2` base
 | Group | Tables | Keyed by |
 |---|---|---|
 | **Workflow** (per-issue) | `issues`, `tasks`, `audit`, `validation_attempts`, `discussions`, `roundtables`, `roundtable_votes` | `issue_id` (directly or transitively) |
-| **Registries** (standalone) | `skills`, `rules`, `commands`, `agents`, `repos`, `file_registry`, `plugin_config`, `plugin_meta`, `agent_runs`, `pr_review_runs`, `debug_trajectory`, `eval_results` | own primary keys; not tied to any issue |
+| **Registries** (standalone) | `skills`, `rules`, `commands`, `agents`, `repos`, `directories` (world model — ADR 0001), `plugin_config`, `plugin_meta`, `agent_runs`, `pr_review_runs`, `debug_trajectory`, `eval_results` | own primary keys; not tied to any issue |
 | **Junctions** (catalog ↔ run) | `skill_invocations`, `rule_invocations` | FK to both `skills`/`rules` and `agent_runs` — bridges the catalog to per-run analytics |
 
 The onboarded marker lives at `plugin_config('onboarded': true)`. Scan-side drift state rides in `audit(event_type='deep_scan_completed').content_json`; `scan_run` is the single scan-side surface.
@@ -36,13 +36,15 @@ erDiagram
         TEXT  last_scanned_at
     }
 
-    file_registry {
-        TEXT  repo PK
-        TEXT  path PK
-        TEXT  type
-        TEXT  content_md5
+    directories {
+        INT   id PK
+        TEXT  repo
+        TEXT  path
+        TEXT  parent_path
         TEXT  summary
+        TEXT  summary_source
         TEXT  summary_updated_at
+        INT   file_count
     }
 
     skills {
@@ -204,7 +206,7 @@ erDiagram
 |---|---|
 | `skills` | Registry of curated + agent-created skills with effectiveness stats (`uses`, `successes`, `effectiveness`). Looked up by name. |
 | `repos` | One row per discovered git repo under the session dir. Written by `scan_run` (the `/scan` slash command's MCP backend). Workspace-pattern projects (multiple inner repos under a non-git workspace dir) are first-class — `tasks.repo` references `repos.name` by convention (no FK). |
-| `file_registry` | One row per `(repo, path)`. Phase 1 of `/scan` populates `path`/`size`/`content_md5`/`last_commit_sha` deterministically (bash + git + md5); Phase 2 fills `summary` via parallel background subagents. Drift detection is md5-only — `last_commit_sha` is metadata, not invalidation signal. Closed-task hook (`post-task-close-rescan.sh`) re-runs scan automatically; rows where md5 matches keep their summary, rows where md5 differs get the summary cleared. |
+| `directories` | One row per directory in each scanned repo — bro's world model (ADR 0001). `scan_run` populates `path` + `parent_path` + `file_count` + `summary`. `summary` preferentially comes from `<dir>/README.md` (author-curated, `summary_source='readme'`); otherwise `NULL` for lazy LLM fill. Companion `directories_fts` (keyword search) and `directories_embeddings` (semantic search via bge-small) back the `world_model_search` tool. Closed-task hook (`post-task-close-rescan.sh`) re-runs `scan_run` automatically; README-derived summaries refresh from disk on each scan. |
 | `plugin_config` | KV for plugin settings (branching model, protected branches, PR target, issue_sync, remotes). See `mcp/trajectory-server/docs/CONFIG_KEYS.md` for the canonical key list. |
 | `plugin_meta` | Schema + plugin version. Current `schema_version=2`. `plugin_version` is seeded as `'0.0.0'` and synced dynamically from `CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json` on every `TrajectoryDB` construction — so the row always reflects the running plugin version without a migration. |
 | `agent_runs` | Per-spawn resource tracking (tokens, tool_uses, duration). Written by `swe-atomic-close.sh` SubagentStop hook. |
@@ -226,8 +228,8 @@ erDiagram
 
 ## How agents use this
 
-- **bro** (planner + task gate, CLAUDE.md persona on main Claude) — full write access for the workflow side: `onboard_state_get`/`onboard_apply` (which write `plugin_config('onboarded')`), `config_get`/`set`/`list`, `issue_create`/`get`/`resume`/`close`, `discussion_append` (kind='intent'/'note'/'question'/'answer'/'decision'), `task_create_batch`, `task_update_status` (closes tasks after verifying SWE's return), `audit_log`, `scan_run` (writes `repos`, `file_registry`, `deep_scan_completed` audit). Also reads `validation_history` to drive the retry loop (flow 8). Calls `file_registry_update_summaries` during V3 close (bro-only, server-enforced).
-- **swe** (executor, project-local subagent in worktree) — `task_get(id)` for spec → `audit_log` during work → `task_update_status('completed', commit_sha)` on success. Cannot write to `issues`, `validation_attempts`, `file_registry` summaries, or close tasks.
+- **bro** (planner + task gate, CLAUDE.md persona on main Claude) — full write access for the workflow side: `onboard_state_get`/`onboard_apply` (which write `plugin_config('onboarded')`), `config_get`/`set`/`list`, `issue_create`/`get`/`resume`/`close`, `discussion_append` (kind='intent'/'note'/'question'/'answer'/'decision'), `task_create_batch`, `task_update_status` (closes tasks after verifying SWE's return), `audit_log`, `scan_run` (writes `repos`, `directories`, `deep_scan_completed` audit). Reads the world model via `world_model_get` / `world_model_search` as the cold-start navigation surface. Also reads `validation_history` to drive the retry loop (flow 8).
+- **swe** (executor, project-local subagent in worktree) — `task_get(id)` for spec → `audit_log` during work → `task_update_status('completed', commit_sha)` on success. Cannot write to `issues`, `validation_attempts`, or close tasks. Reads the world model when scoping unfamiliar parts of the codebase.
 - **pr-reviewer** (push gate, project-local subagent) — `task_get(task_id)` for spec + commit → `validation_record(task_id, attempt_n, verdict, feedback, subagent_session_id)` to sign off. Only role permitted to write `validation_attempts`. Never writes to `tasks`; the close flip stays bro's call.
 - **consultants** (architect, cto, ceo, pm, project-local domain agents) — read-only on workflow tables (`issue_get_with_discussions`, `task_get`, `validation_history`); may write `discussion_append(kind='analysis'|'concern')` to record their position. Server-rejected on `task_create_batch`, `task_update_status`, `validation_record`, `issue_create` via `requireRoles`.
 

--- a/docs/architecture/FILES.md
+++ b/docs/architecture/FILES.md
@@ -113,8 +113,8 @@ mcp/trajectory-server/
 | `composites.ts` | `branch_id_propose`, `task_retry_batch`, `bro_atomic_close` (per-update `repo` resolution post-#2873) |
 | `config.ts` | `config_get`, `config_set`, `config_list` |
 | `discussions.ts` | `discussion_append` (verified_human gate), `discussion_list`, `issue_get_with_discussions` |
-| `file-registry.ts` | `file_registry_upsert/list/verify/delete/update_summaries` (bro-only) |
-| `scan.ts` | `scan_run` (forks `scripts/scan.sh`, persists to `repos` + `file_registry`, emits `deep_scan_completed` audit with `source` + `structural_change` content_json), `repos_list`, `file_registry_bulk_upsert` |
+| `world-model.ts` | `world_model_get` (annotated dir tree), `world_model_search` (FTS5 / semantic / hybrid — ADR 0001) |
+| `scan.ts` | `scan_run` (forks `scripts/scan.sh`, persists to `repos` + `directories`, pulls each `<dir>/README.md` into `directories.summary`, emits `deep_scan_completed` audit with `source` + `structural_change` content_json), `repos_list` |
 | `issues.ts` | `issue_create/get/resume/close/update_description/sync_retry` |
 | `onboard.ts` | `onboard_state_get`, `onboard_get_questions`, `onboard_apply` (writes `plugin_config('onboarded')`) |
 | `pr_comments.ts` | `pr_comments_get` (gh + glab backends, bot-filtered) |

--- a/docs/architecture/FLOWS.md
+++ b/docs/architecture/FLOWS.md
@@ -16,11 +16,11 @@ All consultants (architect, cto, ceo, pm, project-local) advise but never write 
 | 4 | Agent-creator | Routing hits role not in `.claude/agents/` | bro | — (file-based outcome) | — |
 | 5 | Skill creation | Recurring pattern needs encoding | bro | `skills` (registered via `skill_register`) | — |
 | 6 | Push gate / PR review | `git push` to protected branch | bro → pr-reviewer (one per unsigned task, parallel) | `validation_attempts` | `git-push-guard` |
-| 7 | Scan + architecture refresh | First code-touching ask of session, `/scan`, OR `post-task-close-rescan.sh` hook fires after `bro_atomic_close` | bro (or hook in background) | `repos`, `file_registry`, `audit(event_type='deep_scan_completed')` — `content_json` carries `source`, `structural_change`, `repos_seen`, `top_dirs` | `post-task-close-rescan` |
+| 7 | Scan + world-model refresh | First code-touching ask of session, `/scan`, OR `post-task-close-rescan.sh` hook fires after `bro_atomic_close` | bro (or hook in background) | `repos`, `directories` (summary preferentially from `<dir>/README.md`), `audit(event_type='deep_scan_completed')` — `content_json` carries `source`, `structural_change`, `repos_seen`, `top_dirs` | `post-task-close-rescan` |
 | 8 | SWE retry / escalation | Bro verification or pr-reviewer verdict='fail' | bro ↔ swe (↔ pr-reviewer at push) | `validation_attempts` (multiple), `discussions` | `task_retry_batch` composite |
 | 9 | Roundtable | Multi-consultant deliberation with AUQ ratification | bro orchestrates 2–4 consultants | `roundtables`, `roundtable_votes`, `discussions`, `audit` | `roundtable-auq-shape`, `roundtable-cleanup-postcheck` |
 | 13 | Bulk cleanup | Human pre-authorizes a bulk delete | bro (direct Bash, no SWE spawn) | — | — |
-| 33 | Multi-repo path discipline | `tmb_default_repo` set; bro indexes inner repo | bro | `file_registry` (repo-relative paths via per-update `repo` arg) | — |
+| 33 | Multi-repo path discipline | `tmb_default_repo` set; bro indexes inner repo | bro | `directories` (repo-relative paths; `repo` column resolves to the right inner git repo) | — |
 | **C** | Consultant invocation | Human asks for second opinion | bro → consultant | `discussions(kind='analysis'/'concern')` | — |
 | **M** | Monitor PR comments | `/monitor <PR_number>` (invokes `tmb_review` §C) | bro → pr-reviewer per actionable comment batch | `pr_review_runs`, `issues`, `tasks`, `audit` | — |
 
@@ -235,9 +235,9 @@ When the Human's prompt names what to delete (branches, temp files, etc.), bro e
 
 ## 33. Multi-repo path discipline
 
-When a workspace has multiple inner git repos (siblings or submodules), `tmb_default_repo` config or per-task `tasks.repo` names the active inner repo. `file_registry` paths are stored repo-relative — bro does NOT prepend the inner repo directory when writing rows.
+When a workspace has multiple inner git repos (siblings or submodules), `tmb_default_repo` config or per-task `tasks.repo` names the active inner repo. `directories` paths are stored repo-relative — `scan_run` does NOT prepend the inner repo directory when writing rows.
 
-The L5 row `tests/dogfood/rows/33-multirepo-commit/` catches regressions at the storage layer: `file_registry.path LIKE 'api/%' OR LIKE 'app/%'` returns ≥1 row only on a workspace-rooted path leak.
+The L5 row `tests/dogfood/rows/33-multirepo-commit/` catches regressions at the storage layer: `directories.path LIKE 'api/%' OR LIKE 'app/%'` returns ≥1 row only on a workspace-rooted path leak.
 
 ---
 

--- a/docs/architecture/GIT.md
+++ b/docs/architecture/GIT.md
@@ -98,11 +98,9 @@ plugin/
 ├── agents/swe.md                                      # atomic close: task_update_status(needs_validation)
 ├── scripts/hooks/
 │   ├── swe-atomic-close.sh                           # SubagentStop safety net if SWE skips close
-│   ├── require-summaries-before-task-close.sh        # blocks close if file summaries missing
 │   └── cleanup-worktree-on-task-close.sh             # removes worktree after bro closes task
 └── mcp/trajectory-server/src/tools/
-    ├── tasks.ts                                      # task_update_status(completed, commit_sha)
-    └── file-registry.ts                              # file_registry_update_summaries
+    └── tasks.ts                                      # task_update_status(completed, commit_sha)
 ```
 
 **Bro merges + pushes (MR opens)**
@@ -113,11 +111,10 @@ plugin/
 ├── scripts/hooks/
 │   ├── git-push-guard.sh                             # blocks push without pass verdicts
 │   ├── branch-up-to-date-with-remote.sh              # verifies local branch is current
-│   └── post-task-close-rescan.sh                     # PostToolUse: backgrounds /scan to refresh file_registry
+│   └── post-task-close-rescan.sh                     # PostToolUse: backgrounds /scan to refresh the world model
 └── mcp/trajectory-server/src/tools/
-    ├── composites.ts                                 # bro_atomic_close (audit + summaries + status + close)
+    ├── composites.ts                                 # bro_atomic_close (audit + status + close in one txn)
     ├── audit.ts                                      # audit_log(bro_verification_pass)
-    ├── file-registry.ts                              # file_registry_update_summaries (md5-driven drift)
     └── issues.ts                                     # issue_close
 ```
 
@@ -142,5 +139,5 @@ plugin/
 ├── scripts/maintenance/cleanup-stale-worktrees.sh    # periodic stale worktree GC
 └── mcp/trajectory-server/src/tools/
     ├── audit.ts                                      # audit_log(post-merge state)
-    └── scan.ts                                       # scan_run rerun via post-task-close-rescan hook updates file_registry + emits deep_scan_completed audit
+    └── scan.ts                                       # scan_run rerun via post-task-close-rescan hook refreshes the world model + emits deep_scan_completed audit
 ```

--- a/docs/architecture/RESPONSIBILITIES.md
+++ b/docs/architecture/RESPONSIBILITIES.md
@@ -40,7 +40,7 @@ Source: `CLAUDE.md` (no `agents/bro.md` — bro is a persona on main Claude).
    - V1 — files match the spec's `## Files`
    - V2 — re-run the spec's `## Verification` commands inside the worktree
    - V3 — each `## Success Criteria` bullet visibly met by the diff
-8. `bro_atomic_close` MCP composite — single transaction: `bro_verification_pass` audit + `last_verified_sha` advance + `file_registry` summaries + status `closed` + optional issue close.
+8. `bro_atomic_close` MCP composite — single transaction: `bro_verification_pass` audit + `last_verified_sha` advance + status `closed` + optional issue close. The post-close hook (`post-task-close-rescan.sh`) backgrounds a fresh `scan_run` so the world model refreshes automatically.
 
 ### Server-enforced privileges (Layer 1)
 
@@ -48,7 +48,6 @@ Bro is the only agent allowed to call:
 - `task_create_batch`
 - `task_update_status` (shared with SWE; bro writes `closed`, SWE writes `completed`/`failed`)
 - `issue_create`, `issue_close`, `issue_resume`
-- `file_registry_update_summaries`
 - `discussion_append` for `kind='intent'`
 - `roundtable_create`, `roundtable_vote`, `roundtable_close`, `roundtable_finalize_decisions`, `roundtable_summarize`
 - `pr_comments_get` (shared with pr-reviewer)
@@ -61,13 +60,13 @@ Bro is the only agent allowed to call:
 | Hook | When | Effect |
 |---|---|---|
 | `activation-routine.sh` | UserPromptSubmit | Inject onboarded marker + pending issue as context |
-| `session-start-prescan.sh` | SessionStart | Inject project inventory (git state, stacks, registry warmth) |
+| `session-start-prescan.sh` | SessionStart | Inject project inventory (git state, stacks, world-model warmth) |
 | `ensure-gitignore.sh` | SessionStart | Ensure `.claude/` is gitignored |
 | `no-source-edit-from-main.sh` | PreToolUse Edit/Write | Deny bro source edits outside SWE worktree |
 | `no-worktree-branch-create.sh` | PreToolUse Bash | Deny `git worktree add -b/-B/--detach` (branch authority is bro's pre-creation; attached worktrees only) |
 | `branch-up-to-date-with-remote.sh` | PreToolUse Bash | Deny worktree-add to a branch behind `origin/<pr_target>` |
-| `require-summaries-before-task-close.sh` | PreToolUse `task_update_status` | Deny `closed` when summaries are missing/stale |
 | `cleanup-worktree-on-task-close.sh` | PostToolUse `task_update_status` | Remove worktree after bro closes task |
+| `post-task-close-rescan.sh` | PostToolUse `bro_atomic_close` | Background `scan_run` refreshes the world model |
 
 ### Universal rules
 
@@ -96,8 +95,6 @@ Frontmatter: `model: sonnet`, `maxTurns: 150`, `tools: Read, Glob, Grep, Bash, W
 Batch in one response:
 1. Commit (using the spec's `## Commit` message)
 2. `task_update_status(agent='swe', status='completed', commit_sha)`
-
-SWE does **not** call `file_registry_update_summaries` — bro owns summaries (server-enforced).
 
 ### Server-enforced privileges (Layer 1)
 
@@ -169,7 +166,7 @@ Templates in `templates/agents/<name>.md`, instantiated per-project on demand vi
 
 ### Server-enforced constraints (Layer 1)
 
-Consultants **cannot write workflow state**: `task_create_batch`, `task_update_status`, `issue_create`, `issue_close`, `validation_record`, `file_registry_update_summaries` all return `forbidden`.
+Consultants **cannot write workflow state**: `task_create_batch`, `task_update_status`, `issue_create`, `issue_close`, `validation_record` all return `forbidden`.
 
 They **can write analyses**: `discussion_append(kind='analysis'|'concern')`, `audit_log`. Architect specifically also gets `issue_snapshot_md`.
 
@@ -190,7 +187,7 @@ Source of truth: `mcp/trajectory-server/src/middleware/agent-scope.ts` `requireR
 | `task_update_status(closed)` | ✓ | | | |
 | `task_update_status(completed/failed)` | ✓ | ✓ | | |
 | `validation_record` | | | ✓ | |
-| `file_registry_update_summaries` | ✓ | | | |
+| `world_model_get` / `world_model_search` | ✓ | ✓ | ✓ | |
 | `onboard_*` (state_get/get_questions/apply) | ✓ | | | |
 | `discussion_append` | any kind | note/concern | any | analysis/concern |
 | `audit_log`, `task_get` | ✓ | ✓ | ✓ | ✓ |

--- a/docs/architecture/WORLD_MODEL.md
+++ b/docs/architecture/WORLD_MODEL.md
@@ -65,10 +65,8 @@ Re-running `scan_run` is idempotent: existing rows keep their `summary` unless t
 | Cold session, code-touching ask | `world_model_get(depth=2)` — full project map |
 | Looking for "where in this codebase does X live" | `world_model_search(query='X')` |
 | Zoom into one part | `world_model_get(path='src/api', depth=1)` |
-| Need file-level detail (rare) | `file_registry_search` or direct Read |
+| Need file-level detail (rare) | direct Read with explicit paths |
 
-## Relation to `file_registry`
+## What was replaced
 
-`file_registry` continues to exist as the file-level index during the migration window. Its role is leaf-zoom — when dir-level isn't fine enough. The primary navigation surface is `world_model_get`. `file_registry.summary` becomes lazy (filled only when an agent reads inside a specific file).
-
-`file_registry` infrastructure removal is tracked separately and lands once every consumer (hooks, skills, agents, CLAUDE.md) has migrated to world-model surfaces.
+`file_registry` was retired in schema v7 (PR #253). Per-file md5 + summary state was the wrong granularity — too churn-prone, too narrow, and rarely consulted by agents on cold starts. The world model is the navigation surface now; explicit file reads handle leaf-zoom on demand.


### PR DESCRIPTION
Doc-only sweep. REFERENCE / ENFORCEMENT / ERD / FILES / FLOWS / GIT / RESPONSIBILITIES / WORLD_MODEL all updated to reflect schema v7 and the world-model-as-primary substrate. WORLD_MODEL.md retains a single historical mention of file_registry in the 'What was replaced' section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)