### PR TITLE
🪝 feat(hooks): salvage search-grounding + pr-reviewer-after-close hooks from #244

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -85,6 +85,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/adr-required-hint.sh",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/search-grounding-hint.sh",
+            "timeout": 3
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -147,6 +147,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pr-reviewer-spawn-prompt-shape.sh",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pr-reviewer-after-atomic-close.sh",
+            "timeout": 3
           }
         ]
       },

--- a/scripts/hooks/pr-reviewer-after-atomic-close.sh
+++ b/scripts/hooks/pr-reviewer-after-atomic-close.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# PreToolUse hook on Agent. Enforces the doctrine that pr-reviewer spawn
+# happens AFTER bro_atomic_close: the task referenced by task_id=N in the
+# spawn prompt must have status='closed' in the trajectory DB.
+#
+# Doctrine source: feedback_pr_reviewer_required_pre_push memory + planning
+# skill Step 5.5 — "After bro_atomic_close succeeds, BEFORE pushing the
+# branch, spawn pr-reviewer". The order is non-negotiable: bro_atomic_close
+# is the in-DB closure that produces the artifact pr-reviewer evaluates.
+#
+# Non-deterministic bro flakiness has shipped CI runs where bro inferred
+# "SWE completed and closed the task" from SWE's status return and skipped
+# straight to pr-reviewer — leaving the task open + no verification audit.
+# Structural enforcement here removes the failure mode without touching
+# any prompt (prompt-freeze doctrine during auto-solve).
+#
+# Bypass: TMB_SKIP_PR_REVIEWER_CLOSE_GATE=1 (for tests that intentionally
+# spawn pr-reviewer outside the close flow).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/normalize-role.sh
+. "$SCRIPT_DIR/lib/normalize-role.sh"
+# shellcheck source=lib/query-task.sh
+. "$SCRIPT_DIR/lib/query-task.sh"
+
+INPUT=$(cat 2>/dev/null) || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+command -v sqlite3 >/dev/null 2>&1 || exit 0
+
+if [ "${TMB_SKIP_PR_REVIEWER_CLOSE_GATE:-0}" = "1" ]; then
+  exit 0
+fi
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
+[ "$TOOL_NAME" = "Agent" ] || exit 0
+
+SUBAGENT=$(tmb_normalize_role "$(echo "$INPUT" | jq -r '.tool_input.subagent_type // ""' 2>/dev/null)")
+[ "$SUBAGENT" = "pr-reviewer" ] || exit 0
+
+PROMPT=$(echo "$INPUT" | jq -r '.tool_input.prompt // ""' 2>/dev/null)
+TASK_ID=$(printf '%s' "$PROMPT" | grep -Eo 'task_id[[:space:]]*=[[:space:]]*[0-9]+' | head -1 | grep -Eo '[0-9]+' | head -1)
+
+# No task_id in prompt? prompt-shape hook will catch it; not our concern.
+[ -n "$TASK_ID" ] || exit 0
+
+DB=$(tmb_db_path 2>/dev/null || true)
+[ -n "$DB" ] && [ -f "$DB" ] || exit 0
+
+STATUS=$(sqlite3 "$DB" "SELECT status FROM tasks WHERE id = $TASK_ID;" 2>/dev/null || true)
+
+# Task not found? Don't block — let pr-reviewer surface the error itself.
+[ -n "$STATUS" ] || exit 0
+
+if [ "$STATUS" = "closed" ]; then
+  exit 0
+fi
+
+REASON=$(jq -Rn --arg id "$TASK_ID" --arg st "$STATUS" '
+  "BLOCKED: pr-reviewer spawn requires task " + $id + " status=closed but actual status=" + $st + ".\n\nPer planning skill Step 5.5 + feedback_pr_reviewer_required_pre_push doctrine, the order is:\n  1. SWE returns status=completed (lifecycle answer, NOT a DB closure).\n  2. bro runs V1 (task_get + git diff), V2 (3 checks), V3 (bro_atomic_close).\n  3. ONLY THEN: spawn pr-reviewer for the push gate.\n\nSWE returning completed does not close the trajectory task — that is bro_atomic_close.\n\nFix: call bro_atomic_close(agent='\''bro'\'', task_id=" + $id + ", commit_sha=<sha>, file_summaries=[...], verification_summary='\''...'\'') first, then retry this spawn."
+')
+printf '{"decision":"block","reason":%s}\n' "$REASON"
+exit 0

--- a/scripts/hooks/search-grounding-hint.sh
+++ b/scripts/hooks/search-grounding-hint.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook. When the user asks bro a "why did we X" / "what
+# was the rationale" / "what did we decide" question — i.e. a retrieval
+# question over past decisions — inject a hint nudging bro toward the
+# *_search MCP tools (discussion_search, audit_search, file_registry_search)
+# instead of the linear-scan *_list / *_get_with_discussions tools.
+#
+# Motivation: CLAUDE.md already documents the search-first preference, but
+# bro's tool selection is non-deterministic — on a marginal turn it may
+# default to discussion_list(issue_id=N). The hook makes the preference
+# *salient at prompt-submit time*, which empirically holds the line.
+#
+# Bypass: TMB_DISABLE_SEARCH_HINT=1.
+# Always silent on failure; never blocks.
+
+set -uo pipefail
+
+INPUT=$(cat 2>/dev/null) || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+if [ "${TMB_DISABLE_SEARCH_HINT:-0}" = "1" ]; then
+  exit 0
+fi
+
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // ""' 2>/dev/null | tr '[:upper:]' '[:lower:]')
+[ -n "$PROMPT" ] || exit 0
+
+matched=""
+for pat in \
+  'why did we' 'why we chose' 'why we picked' 'why we decided' \
+  'why was' 'why is' 'why are we' \
+  'what was the rationale' 'what is the rationale' \
+  'what did we decide' 'what was decided' 'what was our decision' \
+  'how did we decide' 'when did we decide' \
+  'rationale for' 'reasoning behind' \
+  'past decision' 'prior decision' 'previous decision' \
+  'find the discussion' 'search the discussion' 'search discussions' \
+  'recall why' 'remind me why'; do
+  case "$PROMPT" in
+    *"$pat"*)
+      matched="$pat"
+      break
+      ;;
+  esac
+done
+
+[ -n "$matched" ] || exit 0
+
+REASON="🔎 search-grounding hint: the user's prompt contains '${matched}' — a retrieval question over past decisions.
+
+Prefer the *_search MCP tools over linear scans:
+- \`discussion_search(query='<key terms>', mode='hybrid')\` returns ranked snippets across ALL issues (keyword + semantic). Use this first.
+- \`audit_search(query='<key terms>')\` for event-history grounding.
+- \`file_registry_search(query='<key terms>')\` for code-context grounding.
+
+Only fall back to \`discussion_list(issue_id=N)\` / \`issue_get_with_discussions\` once \`discussion_search\` has narrowed the candidate set — those tools enumerate, they don't rank. Hybrid mode auto-falls-back to keyword if the embedding model is offline (\`warning: 'semantic_unavailable'\`)."
+
+jq -nc --arg reason "$REASON" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: $reason
+  }
+}'
+
+exit 0


### PR DESCRIPTION
Cherry-picks the 2 commits from PR #244 that survive the v0.7 world-model refactor. The other 3 commits in #244 patched file_registry behavior that no longer exists; closing #244 separately.

- `search-grounding-hint.sh` (UserPromptSubmit) — nudges bro toward `*_search` tools on retrieval-shaped prompts.
- `pr-reviewer-after-atomic-close.sh` (PreToolUse Agent) — blocks pr-reviewer spawn until the named task is `status=closed`.

Both are orthogonal to the world-model substrate; clean cherry-picks, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)