### PR TITLE
📐 docs(reorg): architecture docs lead with kuzu graph DB (slice 5)

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -4,7 +4,8 @@ Lookups bro hits occasionally — keep here so they don't bloat CLAUDE.md.
 
 ## Where state lives
 
-- **Trajectory DB** — SQLite at `<project>/.claude/<plugin-name>/trajectory.db`. The `<plugin-name>` segment resolves from `CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json`'s `name` field; today that's `tmb` for both stable and RC channels, so both write to `.claude/tmb/`. True channel isolation (`tmb/` vs `tmb-rc/`) is tracked in issue #1. Project-local, gitignored, per-developer.
+- **Trajectory DB** — SQLite at `<project>/.claude/<plugin-name>/trajectory.db`. Holds the workflow ledger: issues, tasks, discussions, audit, validation, plugin metadata. The `<plugin-name>` segment resolves from `CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json`'s `name` field; today that's `tmb` for both stable and RC channels, so both write to `.claude/tmb/`. Project-local, gitignored, per-developer.
+- **World model graph DB** — kuzu at `<project>/.claude/<plugin-name>/world-model.kuzu/`. Holds bro's project mental picture: Directory nodes + CONTAINS edges (more node/edge types in follow-up slices). Sibling file to the trajectory DB. See ADR 0002 + `docs/architecture/WORLD_MODEL.md`.
 - **Task specs** — `tasks.spec_body` column, fetched via `task_get(task_id)`. NOT on disk.
 - **ADRs** — `docs/trustmybot/architecture/manual/decisions/N-*.md`, hand-curated.
 - **Auto-rendered architecture docs** — `docs/trustmybot/architecture/auto/`, refreshed by the scan-side renderer pass.

--- a/docs/architecture/ERD.md
+++ b/docs/architecture/ERD.md
@@ -9,7 +9,9 @@ SQLite schema (`mcp/trajectory-server/src/schema.sql`, `schema_version = 2` base
 | Group | Tables | Keyed by |
 |---|---|---|
 | **Workflow** (per-issue) | `issues`, `tasks`, `audit`, `validation_attempts`, `discussions`, `roundtables`, `roundtable_votes` | `issue_id` (directly or transitively) |
-| **Registries** (standalone) | `skills`, `rules`, `commands`, `agents`, `repos`, `directories` (world model — ADR 0001), `plugin_config`, `plugin_meta`, `agent_runs`, `pr_review_runs`, `debug_trajectory`, `eval_results` | own primary keys; not tied to any issue |
+| **Registries** (standalone) | `skills`, `rules`, `commands`, `agents`, `repos`, `plugin_config`, `plugin_meta`, `agent_runs`, `pr_review_runs`, `debug_trajectory`, `eval_results` | own primary keys; not tied to any issue |
+
+The **world model** lives in a sibling kuzu graph database (`world-model.kuzu`), not in this SQLite file. See ADR 0002 + `docs/architecture/WORLD_MODEL.md`.
 | **Junctions** (catalog ↔ run) | `skill_invocations`, `rule_invocations` | FK to both `skills`/`rules` and `agent_runs` — bridges the catalog to per-run analytics |
 
 The onboarded marker lives at `plugin_config('onboarded': true)`. Scan-side drift state rides in `audit(event_type='deep_scan_completed').content_json`; `scan_run` is the single scan-side surface.
@@ -36,16 +38,7 @@ erDiagram
         TEXT  last_scanned_at
     }
 
-    directories {
-        INT   id PK
-        TEXT  repo
-        TEXT  path
-        TEXT  parent_path
-        TEXT  summary
-        TEXT  summary_source
-        TEXT  summary_updated_at
-        INT   file_count
-    }
+    %% World model — see ADR 0002 — lives in sibling kuzu graph DB, not here
 
     skills {
         INT  id PK
@@ -206,7 +199,7 @@ erDiagram
 |---|---|
 | `skills` | Registry of curated + agent-created skills with effectiveness stats (`uses`, `successes`, `effectiveness`). Looked up by name. |
 | `repos` | One row per discovered git repo under the session dir. Written by `scan_run` (the `/scan` slash command's MCP backend). Workspace-pattern projects (multiple inner repos under a non-git workspace dir) are first-class — `tasks.repo` references `repos.name` by convention (no FK). |
-| `directories` | One row per directory in each scanned repo — bro's world model (ADR 0001). `scan_run` populates `path` + `parent_path` + `file_count` + `summary`. `summary` preferentially comes from `<dir>/README.md` (author-curated, `summary_source='readme'`); otherwise `NULL` for lazy LLM fill. Companion `directories_fts` (keyword search) and `directories_embeddings` (semantic search via bge-small) back the `world_model_search` tool. Closed-task hook (`post-task-close-rescan.sh`) re-runs `scan_run` automatically; README-derived summaries refresh from disk on each scan. |
+| _(world model)_ | Lives in the sibling kuzu graph DB at `<project>/.claude/tmb/world-model.kuzu/`, not in this SQLite file. Directory nodes + CONTAINS edges, populated by `scan_run` via `src/graph-db.ts`. See ADR 0002 + `docs/architecture/WORLD_MODEL.md`. |
 | `plugin_config` | KV for plugin settings (branching model, protected branches, PR target, issue_sync, remotes). See `mcp/trajectory-server/docs/CONFIG_KEYS.md` for the canonical key list. |
 | `plugin_meta` | Schema + plugin version. Current `schema_version=2`. `plugin_version` is seeded as `'0.0.0'` and synced dynamically from `CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json` on every `TrajectoryDB` construction — so the row always reflects the running plugin version without a migration. |
 | `agent_runs` | Per-spawn resource tracking (tokens, tool_uses, duration). Written by `swe-atomic-close.sh` SubagentStop hook. |
@@ -228,7 +221,7 @@ erDiagram
 
 ## How agents use this
 
-- **bro** (planner + task gate, CLAUDE.md persona on main Claude) — full write access for the workflow side: `onboard_state_get`/`onboard_apply` (which write `plugin_config('onboarded')`), `config_get`/`set`/`list`, `issue_create`/`get`/`resume`/`close`, `discussion_append` (kind='intent'/'note'/'question'/'answer'/'decision'), `task_create_batch`, `task_update_status` (closes tasks after verifying SWE's return), `audit_log`, `scan_run` (writes `repos`, `directories`, `deep_scan_completed` audit). Reads the world model via `world_model_get` / `world_model_search` as the cold-start navigation surface. Also reads `validation_history` to drive the retry loop (flow 8).
+- **bro** (planner + task gate, CLAUDE.md persona on main Claude) — full write access for the workflow side: `onboard_state_get`/`onboard_apply` (which write `plugin_config('onboarded')`), `config_get`/`set`/`list`, `issue_create`/`get`/`resume`/`close`, `discussion_append` (kind='intent'/'note'/'question'/'answer'/'decision'), `task_create_batch`, `task_update_status` (closes tasks after verifying SWE's return), `audit_log`, `scan_run` (writes `repos` SQLite + Directory nodes / CONTAINS edges in kuzu, `deep_scan_completed` audit). Reads the world model via `world_model_get` / `world_model_search` (kuzu queries) as the cold-start navigation surface. Also reads `validation_history` to drive the retry loop (flow 8).
 - **swe** (executor, project-local subagent in worktree) — `task_get(id)` for spec → `audit_log` during work → `task_update_status('completed', commit_sha)` on success. Cannot write to `issues`, `validation_attempts`, or close tasks. Reads the world model when scoping unfamiliar parts of the codebase.
 - **pr-reviewer** (push gate, project-local subagent) — `task_get(task_id)` for spec + commit → `validation_record(task_id, attempt_n, verdict, feedback, subagent_session_id)` to sign off. Only role permitted to write `validation_attempts`. Never writes to `tasks`; the close flip stays bro's call.
 - **consultants** (architect, cto, ceo, pm, project-local domain agents) — read-only on workflow tables (`issue_get_with_discussions`, `task_get`, `validation_history`); may write `discussion_append(kind='analysis'|'concern')` to record their position. Server-rejected on `task_create_batch`, `task_update_status`, `validation_record`, `issue_create` via `requireRoles`.

--- a/docs/architecture/FILES.md
+++ b/docs/architecture/FILES.md
@@ -114,7 +114,8 @@ mcp/trajectory-server/
 | `config.ts` | `config_get`, `config_set`, `config_list` |
 | `discussions.ts` | `discussion_append` (verified_human gate), `discussion_list`, `issue_get_with_discussions` |
 | `world-model.ts` | `world_model_get` (annotated dir tree), `world_model_search` (FTS5 / semantic / hybrid — ADR 0001) |
-| `scan.ts` | `scan_run` (forks `scripts/scan.sh`, persists to `repos` + `directories`, pulls each `<dir>/README.md` into `directories.summary`, emits `deep_scan_completed` audit with `source` + `structural_change` content_json), `repos_list` |
+| `scan.ts` | `scan_run` (forks `scripts/scan.sh`, persists to `repos` in SQLite + Directory nodes / CONTAINS edges in the kuzu graph via `graph-db.ts`, pulls each `<dir>/README.md` into the Directory's `summary`, emits `deep_scan_completed` audit), `repos_list` |
+| `graph-db.ts` | `WorldModelGraph` class — kuzu wrapper. Directory nodes + CONTAINS edges today; File / Symbol / IMPORTS / CALLS post-v0.7. Backs `world_model_get` / `world_model_search` (ADR 0002). |
 | `issues.ts` | `issue_create/get/resume/close/update_description/sync_retry` |
 | `onboard.ts` | `onboard_state_get`, `onboard_get_questions`, `onboard_apply` (writes `plugin_config('onboarded')`) |
 | `pr_comments.ts` | `pr_comments_get` (gh + glab backends, bot-filtered) |

--- a/docs/architecture/FLOWS.md
+++ b/docs/architecture/FLOWS.md
@@ -16,11 +16,11 @@ All consultants (architect, cto, ceo, pm, project-local) advise but never write 
 | 4 | Agent-creator | Routing hits role not in `.claude/agents/` | bro | — (file-based outcome) | — |
 | 5 | Skill creation | Recurring pattern needs encoding | bro | `skills` (registered via `skill_register`) | — |
 | 6 | Push gate / PR review | `git push` to protected branch | bro → pr-reviewer (one per unsigned task, parallel) | `validation_attempts` | `git-push-guard` |
-| 7 | Scan + world-model refresh | First code-touching ask of session, `/scan`, OR `post-task-close-rescan.sh` hook fires after `bro_atomic_close` | bro (or hook in background) | `repos`, `directories` (summary preferentially from `<dir>/README.md`), `audit(event_type='deep_scan_completed')` — `content_json` carries `source`, `structural_change`, `repos_seen`, `top_dirs` | `post-task-close-rescan` |
+| 7 | Scan + world-model refresh | First code-touching ask of session, `/scan`, OR `post-task-close-rescan.sh` hook fires after `bro_atomic_close` | bro (or hook in background) | `repos` (SQLite) + Directory nodes / CONTAINS edges (kuzu graph, ADR 0002; summary preferentially from `<dir>/README.md`), `audit(event_type='deep_scan_completed')` | `post-task-close-rescan` |
 | 8 | SWE retry / escalation | Bro verification or pr-reviewer verdict='fail' | bro ↔ swe (↔ pr-reviewer at push) | `validation_attempts` (multiple), `discussions` | `task_retry_batch` composite |
 | 9 | Roundtable | Multi-consultant deliberation with AUQ ratification | bro orchestrates 2–4 consultants | `roundtables`, `roundtable_votes`, `discussions`, `audit` | `roundtable-auq-shape`, `roundtable-cleanup-postcheck` |
 | 13 | Bulk cleanup | Human pre-authorizes a bulk delete | bro (direct Bash, no SWE spawn) | — | — |
-| 33 | Multi-repo path discipline | `tmb_default_repo` set; bro indexes inner repo | bro | `directories` (repo-relative paths; `repo` column resolves to the right inner git repo) | — |
+| 33 | Multi-repo path discipline | `tmb_default_repo` set; bro indexes inner repo | bro | kuzu Directory nodes (repo-relative paths; `repo` property scopes to the right inner git repo) | — |
 | **C** | Consultant invocation | Human asks for second opinion | bro → consultant | `discussions(kind='analysis'/'concern')` | — |
 | **M** | Monitor PR comments | `/monitor <PR_number>` (invokes `tmb_review` §C) | bro → pr-reviewer per actionable comment batch | `pr_review_runs`, `issues`, `tasks`, `audit` | — |
 
@@ -235,9 +235,9 @@ When the Human's prompt names what to delete (branches, temp files, etc.), bro e
 
 ## 33. Multi-repo path discipline
 
-When a workspace has multiple inner git repos (siblings or submodules), `tmb_default_repo` config or per-task `tasks.repo` names the active inner repo. `directories` paths are stored repo-relative — `scan_run` does NOT prepend the inner repo directory when writing rows.
+When a workspace has multiple inner git repos (siblings or submodules), `tmb_default_repo` config or per-task `tasks.repo` names the active inner repo. Directory node `path` properties are stored repo-relative — `scan_run` does NOT prepend the inner repo directory when writing nodes.
 
-The L5 row `tests/dogfood/rows/33-multirepo-commit/` catches regressions at the storage layer: `directories.path LIKE 'api/%' OR LIKE 'app/%'` returns ≥1 row only on a workspace-rooted path leak.
+The L5 row `tests/dogfood/rows/33-multirepo-commit/` catches regressions at the storage layer: a Cypher `MATCH (d:Directory) WHERE d.path STARTS WITH 'api/' OR d.path STARTS WITH 'app/'` returns ≥1 node only on a workspace-rooted path leak.
 
 ---
 

--- a/docs/architecture/WORLD_MODEL.md
+++ b/docs/architecture/WORLD_MODEL.md
@@ -1,72 +1,61 @@
 # World Model
 
-Bro is the architect of every project it works on. The world model is the stable, queryable mental picture bro reasons from — built once by `scan_run`, refreshed lazily, queried on every cold start.
+Bro is the architect of every project it works on. The world model is the stable, queryable mental picture bro reasons from — built by `scan_run`, refreshed lazily, queried on every cold start.
 
-## Shape
+## Substrate: kuzu graph database
 
-The substrate is the `directories` table in the trajectory DB. One row per directory in each scanned repo.
+The world model lives in a dedicated **kuzu** graph database at `<project>/.claude/tmb/world-model.kuzu/`, separate from the trajectory DB. This is by design:
+
+| | Graph DB (kuzu) | Trajectory DB (SQLite) |
+|---|---|---|
+| Content | Project mental model: dirs as nodes, parent/import/call relations as edges | Workflow ledger: issues, tasks, discussions, audit, validation, plugin metadata |
+| Engine | kuzu (embedded, single file, MIT, Cypher) | SQLite via node:sqlite |
+| Bro's use | "What does this project look like?" / "Where does X live?" / "What depends on what?" | "What did we decide?" / "What's open?" / "What did SWE commit?" |
+
+See ADR 0002 for the substrate decision (supersedes 0001).
+
+## Schema
+
+Initial schema (v0.7 ship):
 
 ```
-directories
-├─ id                    -- INTEGER PRIMARY KEY
-├─ repo                  -- which repo this dir lives in
-├─ path                  -- repo-relative path; '' for repo root
-├─ parent_path           -- repo-relative path of the enclosing dir; NULL for repo root
-├─ summary               -- README.md content (truncated to ~1 KB) OR LLM-derived OR NULL
-├─ summary_source        -- 'readme' | 'llm' | 'manual'
-├─ summary_updated_at    -- last summary write
-├─ file_count            -- cached count of files directly in this dir
+NODE Directory   { key (PK), repo, path, parent_path, summary, summary_source, summary_updated_at, file_count }
+EDGE CONTAINS    (Directory) → (Directory)    // parent → child
 ```
 
-Companion tables: `directories_fts` (keyword search over summary + path), `directories_embeddings` (semantic search via bge-small).
+`key` is the composite string `<repo>:<path>` — kuzu requires single-column primary keys.
+
+Follow-up slices (post-v0.7) add `File`, `Symbol`, `IMPORTS`, `CALLS`, `DEFINES` nodes + edges for code-structure reasoning.
 
 ## Population
 
-`scan_run` populates the table. For each unique directory in the discovered file set:
+`scan_run` walks the session dir for git repos, derives the unique directory set from each repo's tracked file list, then writes Directory nodes + CONTAINS edges to kuzu via `src/graph-db.ts`. For each directory it also checks disk for `<dir>/README.md` (or `readme.md` / `README.rst`); if present, content (truncated to ~1 KB) becomes the dir's `summary` with `summary_source='readme'`. Otherwise `summary=NULL`.
 
-1. Insert the row with `path` + `parent_path` + `file_count`.
-2. Check disk for `<repo_path>/<dir>/README.md` (or `readme.md`, `README.rst`).
-3. If present: read content, truncate to ~1 KB, store with `summary_source='readme'`. README-derived summaries are author-curated and high-trust by construction.
-4. If absent: leave `summary=NULL`. Lazy fill is the agent's responsibility on first ask.
-
-Re-running `scan_run` is idempotent: existing rows keep their `summary` unless the README file content changed.
+Re-running `scan_run` is summary-preserving via MERGE — existing nodes update structural fields and refresh README-derived summaries.
 
 ## Querying
 
-`world_model_get(repo, path, depth)` returns a tree:
+`world_model_get(repo, path, depth)` returns a directory tree. Implementation reads all Directory nodes for the repo from kuzu, then builds the tree in TypeScript by linking each node to its `parent_path`. Default `depth=2` (root + immediate children); `depth=null` returns the full subtree.
 
-```json
-{
-  "repo": "plugin",
-  "root": {
-    "path": "",
-    "summary": "TMB plugin for Claude Code — agentic workflow harness.",
-    "file_count": 3,
-    "children": [
-      {
-        "path": "agents",
-        "summary": "Backbone agent prompts (swe, pr-reviewer).",
-        "file_count": 2,
-        "children": []
-      }
-    ]
-  }
-}
-```
+`world_model_search(query, mode='hybrid')` queries kuzu for directories whose `summary` or `path` matches the query.
 
-`depth` defaults to 2 (root + immediate children). `depth=0` returns just the named directory; `depth=null` returns the full subtree.
-
-`world_model_search(query, mode='hybrid')` searches dir summaries — same shape as `discussion_search`. Returns ranked dir paths with their summaries.
+| Mode | Behavior today | Follow-up |
+|---|---|---|
+| `keyword` | Substring CONTAINS over summary + path; constant score | Real FTS via kuzu's FTS extension |
+| `semantic` | Returns `warning: 'semantic_unavailable'` | bge-small embeddings via kuzu's vector extension |
+| `hybrid` (default) | Keyword hits + `semantic_unavailable` warning | RRF over FTS + vector |
 
 ## When bro reaches for it
 
 | Situation | Bro's move |
 |---|---|
-| Cold session, code-touching ask | `world_model_get(depth=2)` — full project map |
-| Looking for "where in this codebase does X live" | `world_model_search(query='X')` |
+| Cold session, code-touching ask | `world_model_get(depth=2)` |
+| "Where in this codebase does X live" | `world_model_search(query='X', mode='hybrid')` |
 | Zoom into one part | `world_model_get(path='src/api', depth=1)` |
-| Need file-level detail (rare) | direct Read with explicit paths |
+| File-level detail (rare) | direct Read with explicit paths |
 
 ## What was replaced
 
-`file_registry` was retired in schema v7 (PR #253). Per-file md5 + summary state was the wrong granularity — too churn-prone, too narrow, and rarely consulted by agents on cold starts. The world model is the navigation surface now; explicit file reads handle leaf-zoom on demand.
+ADR 0001 placed the dir-level world model in a SQLite `directories` table — a stepping stone to validate the navigation pattern. ADR 0002 moves it to kuzu, the right substrate for graph-shaped data. Schema v8 drops the SQLite `directories` / `directories_fts` / `directories_embeddings` tables; the world model rebuilds from `/scan` on first boot under v8.
+
+`file_registry` (v6) was retired in v7. Per-file md5 + summary state is gone for good — leaf-zoom happens via direct Read on demand.


### PR DESCRIPTION
Slice 5 of v0.7 graph-DB shipping. WORLD_MODEL.md rewritten end-to-end; ERD/FILES/FLOWS/REFERENCE updated. 🤖