### PR TITLE
🐛 fix(#273): feature-branch gate checks branch-exists (aligns with GIT.md worktree model)

### DIFF
--- a/scripts/hooks/require-feature-branch-active.sh
+++ b/scripts/hooks/require-feature-branch-active.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Hook: Block SWE agent spawn when the main checkout is not on the task's branch_id.
-# Queries trajectory.db for the task's branch_id and repo, then compares against
-# the current branch of the main checkout.
+# Hook: Block SWE agent spawn when the task's branch_id does not yet exist.
+# Per docs/architecture/GIT.md, bro pre-creates <feature> without checking it
+# out (the main checkout stays on <base>; SWE's worktree owns the branch ref).
+# This gate verifies the branch exists before the worktree attaches to it.
 #
 # Bypass: TMB_ALLOW_BRANCH_MISMATCH=1 (emergency hotfix scenarios).
 set -uo pipefail
@@ -71,11 +72,11 @@ EOF
   fi
 fi
 
-ACTUAL=$(git -C "$REPO_ABS" branch --show-current 2>/dev/null || true)
-
-if [ "$ACTUAL" != "$EXPECTED" ]; then
+# Per GIT.md the prerequisite is that <feature> EXISTS (bro pre-created it),
+# not that the main checkout is on it — the main checkout stays on <base>.
+if ! git -C "$REPO_ABS" show-ref --verify --quiet "refs/heads/$EXPECTED"; then
   cat <<EOF
-{"decision":"block","reason":"BLOCKED: SWE spawn requires main checkout on branch '$EXPECTED' (task $TASK_ID), got '$ACTUAL'. Run 'git -C $REPO_ABS switch $EXPECTED' first. This invariant is documented in docs/architecture/GIT.md and enforced by hooks (#155)."}
+{"decision":"block","reason":"BLOCKED: SWE spawn for task $TASK_ID needs branch '$EXPECTED' to exist first — bro pre-creates it ('git -C $REPO_ABS branch $EXPECTED origin/<base>') and stays on <base>; SWE's worktree owns the branch. See docs/architecture/GIT.md."}
 EOF
   exit 0
 fi

--- a/skills/tmb_planning/SKILL.md
+++ b/skills/tmb_planning/SKILL.md
@@ -40,8 +40,10 @@ On Yes:
 issue_create(agent='bro', objective=<short>)
 discussion_append(issue_id, author='bro', kind='intent', body=<verbatim>)
 discussion_append(issue_id, author='bro', kind='note',   body='Beginning planning on ${branch_id}.')
-git switch -c "${branch_id}"
+git branch "${branch_id}"
 ```
+
+Create the branch but **stay on the base** — don't switch the main checkout to it. SWE's worktree owns `${branch_id}` while the task runs; the main checkout sits on the base branch for the duration.
 
 ## 3. Author the spec
 

--- a/tests/hooks/require-feature-branch-active.test.sh
+++ b/tests/hooks/require-feature-branch-active.test.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Tests for scripts/hooks/require-feature-branch-active.sh
 #
-# Hook contract: block SWE agent spawn when the main checkout is not on the
-# task's branch_id. Passes through silently for non-swe agents, missing task_id,
+# Hook contract: block SWE agent spawn when the task's branch_id does not yet
+# exist (bro pre-creates it; main stays on <base>). Passes through silently for non-swe agents, missing task_id,
 # or missing DB. Bypass: TMB_ALLOW_BRANCH_MISMATCH=1.
 
 set -uo pipefail
@@ -80,24 +80,25 @@ cleanup() {
 
 # ----- tests ------------------------------------------------------------
 
-test_case "happy path: checkout on task branch_id — no block"
-setup_repo "fix/1-foo"
+test_case "happy path: branch exists, main on base — no block"
+setup_repo "dev"
+git -C "$REPO_PATH" branch "fix/1-foo"
 db=$(setup_db "$REPO_PATH")
 insert_task "$db" 1 "fix/1-foo"
 payload=$(make_payload "swe" "task_id=1 You are SWE.")
 out=$(run_hook "$payload" "$db")
-assert_not_contains "$out" '"decision":"block"' "on-branch SWE spawn must not be blocked"
+assert_not_contains "$out" '"decision":"block"' "branch exists (main stays on base) must not be blocked"
 cleanup
 
-test_case "mismatch blocks: checkout on dev, task expects fix/1-foo"
+test_case "branch missing blocks: task expects fix/1-foo but it was never created"
 setup_repo "dev"
 db=$(setup_db "$REPO_PATH")
 insert_task "$db" 1 "fix/1-foo"
 payload=$(make_payload "swe" "task_id=1 You are SWE.")
 out=$(run_hook "$payload" "$db")
-assert_contains "$out" '"decision":"block"' "branch mismatch must produce block decision"
+assert_contains "$out" '"decision":"block"' "missing branch must produce block decision"
 assert_contains "$out" "fix/1-foo" "block message must name the expected branch"
-assert_contains "$out" "switch" "block message must tell user to switch branches"
+assert_contains "$out" "exist" "block message must say the branch must exist"
 cleanup
 
 test_case "non-swe agent passes: architect bypasses the hook"
@@ -137,7 +138,7 @@ out=$(
 assert_not_contains "$out" '"decision":"block"' "bypass env var must suppress block even on mismatch"
 cleanup
 
-test_case "TMB workspace shape: tasks.repo=null + tmb_default_repo='plugin' + on right branch → passes"
+test_case "TMB workspace shape: tasks.repo=null + tmb_default_repo='plugin' + branch exists → passes"
 WORKSPACE=$(mktemp -d -t tmb-workspace-XXXX)
 INNER_REPO="$WORKSPACE/plugin"
 mkdir -p "$INNER_REPO"
@@ -164,7 +165,7 @@ sqlite3 "$WS_DB" "
 REPO_PATH="$INNER_REPO"
 payload=$(make_payload "swe" "task_id=10 You are SWE.")
 out=$(run_hook "$payload" "$WS_DB")
-assert_not_contains "$out" '"decision":"block"' "TMB workspace shape with default_repo set + on right branch must not block"
+assert_not_contains "$out" '"decision":"block"' "TMB workspace shape with default_repo set + branch exists must not block"
 rm -rf "$WORKSPACE"
 REPO_PATH=""
 


### PR DESCRIPTION
Fixes the operational deadlock from #273.

**Bug:** `require-feature-branch-active.sh` blocked SWE spawn unless the **main checkout** was *on* the task's `<feature>` branch. GIT.md says the opposite — the main checkout stays on `<base>` and SWE's worktree owns `<feature>`. It also deadlocked against `worktree-create.sh`, which needs `<feature>` **not** checked out in main to attach it.

**Fix (coupled):**
- **Hook** — verify `refs/heads/<branch_id>` **exists** (bro pre-creates it) instead of requiring main to be on it. Block message + test updated; `require-feature-branch-active.test.sh` 12/12.
- **`tmb_planning` step 2** — create the feature branch without checking it out (was: create-and-switch), with a note that the main checkout stays on base. Matches GIT.md ("creates `<feature>` … without checking it out").

**Out of scope / follow-up:** step 4's worktree-spawn mechanics (manual worktree-add vs `isolation='worktree'` + `worktree-create.sh`) is a separate flow concern worth verifying against a live spawn — not part of this gate fix.

Closes #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
