### PR TITLE
🐛 fix(hooks): drop refs to removed columns/tables — pr_target, world-model status, bench scorer

### DIFF
--- a/scripts/hooks/branch-up-to-date-with-remote.sh
+++ b/scripts/hooks/branch-up-to-date-with-remote.sh
@@ -62,7 +62,7 @@ DB_PATH="${TRAJECTORY_DB_PATH:-$REPO_ROOT/.claude/${PLUGIN_NAME}/trajectory.db}"
 [ -f "$DB_PATH" ] || exit 0
 command -v sqlite3 >/dev/null 2>&1 || exit 0
 
-PR_TARGET=$(sqlite3 "$DB_PATH" "SELECT value FROM plugin_config WHERE key='pr_target' LIMIT 1;" 2>/dev/null)
+PR_TARGET=$(sqlite3 "$DB_PATH" "SELECT json_extract(value_json, '$') FROM plugin_config WHERE key='pr_target' LIMIT 1;" 2>/dev/null)
 [ -n "$PR_TARGET" ] || PR_TARGET="main"
 PR_TARGET=$(echo "$PR_TARGET" | tr -d '"')
 

--- a/scripts/hooks/session-start-prescan.sh
+++ b/scripts/hooks/session-start-prescan.sh
@@ -61,14 +61,15 @@ elif find docs/trustmybot/architecture -maxdepth 2 -type f -name '*.md' 2>/dev/n
   HAS_ARCH_DOCS="yes"
 fi
 
-# World model indexed status (cold vs warm). The world model is the
-# directory-level memory bro reasons from (ADR 0001); cold = no
-# directories row exists for the project, warm = at least one populated.
-WORLD_MODEL_COUNT=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM directories;" 2>/dev/null || echo 0)
+# World model status (cold vs warm). The world model lives in the kuzu graph
+# (ADR 0002), not SQLite — so the warm/cold proxy is the deep_scan_completed
+# audit event (the same signal the registry-cold gate uses): present ⇒ a scan
+# has populated the graph.
+WORLD_MODEL_SCANNED=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM audit WHERE event_type='deep_scan_completed';" 2>/dev/null || echo 0)
 SOURCE_FILE_COUNT=$(git ls-files 2>/dev/null | grep -cvE '^(\.claude/|node_modules/|dist/|build/|\.git/)' || echo 0)
 
 WORLD_MODEL_STATE="warm"
-if [ "$WORLD_MODEL_COUNT" = "0" ] && [ "$SOURCE_FILE_COUNT" != "0" ]; then
+if [ "$WORLD_MODEL_SCANNED" = "0" ] && [ "$SOURCE_FILE_COUNT" != "0" ]; then
   WORLD_MODEL_STATE="cold"
 fi
 
@@ -82,7 +83,7 @@ Git branch:        ${BRANCH} (${COMMIT_COUNT} commits, ${DIRTY_COUNT} dirty path
 Top-level dirs:    ${TOPLEVEL}
 Stacks detected:   ${STACKS}
 Architecture docs: ${HAS_ARCH_DOCS}
-World model:       ${WORLD_MODEL_STATE} (${WORLD_MODEL_COUNT} dirs indexed / ${SOURCE_FILE_COUNT} source files)
+World model:       ${WORLD_MODEL_STATE} (kuzu graph; ${SOURCE_FILE_COUNT} source files)
 Open issues:       ${OPEN_ISSUES}
 Pending tasks:     ${PENDING_TASKS}
 Last 5 commits:

--- a/tests/manual/bench/scorers/quality.sh
+++ b/tests/manual/bench/scorers/quality.sh
@@ -68,33 +68,20 @@ else
   notes+=("no conventional-commits message in last 5 commits")
 fi
 
-# --- Sub-check 3: file_registry summaries fresh (arm A only) ---
+# --- Sub-check 3: world model populated (arm A only) ---
+# Per-file summaries (file_registry) were retired at v7; the world model now
+# lives in the kuzu graph (ADR 0002). Proxy "the agent populated its world
+# model" via the deep_scan_completed audit event in the trajectory DB.
 if [ -n "$DB" ] && [ -f "$DB" ]; then
-  # Get list of files the agent touched (modified in any commit since the
-  # initial "init" commit).
-  TOUCHED=$(git -C "$PROJECT" log --format='%H' HEAD --not --grep='^init$' 2>/dev/null \
-    | xargs -I {} git -C "$PROJECT" diff-tree --no-commit-id --name-only -r {} 2>/dev/null \
-    | sort -u | head -50)
-  if [ -z "$TOUCHED" ]; then
-    notes+=("no touched files; summaries sub-check skipped")
+  SCANNED=$(sqlite3 "$DB" "SELECT COUNT(*) FROM audit WHERE event_type='deep_scan_completed';" 2>/dev/null || echo 0)
+  if [ "${SCANNED:-0}" -gt 0 ]; then
+    SUMMARIES_FRESH=1
+    SCORE=$((SCORE + 1))
   else
-    TOTAL=0
-    FRESH=0
-    while IFS= read -r f; do
-      [ -z "$f" ] && continue
-      TOTAL=$((TOTAL + 1))
-      ROW=$(sqlite3 "$DB" "SELECT 1 FROM file_registry WHERE path = '$f' AND summary IS NOT NULL LIMIT 1;" 2>/dev/null)
-      [ "$ROW" = "1" ] && FRESH=$((FRESH + 1))
-    done <<< "$TOUCHED"
-    if [ "$TOTAL" -gt 0 ] && [ "$FRESH" -eq "$TOTAL" ]; then
-      SUMMARIES_FRESH=1
-      SCORE=$((SCORE + 1))
-    else
-      notes+=("summaries: $FRESH/$TOTAL touched files have fresh summary")
-    fi
+    notes+=("world model not populated (no deep_scan_completed audit)")
   fi
 else
-  notes+=("no trajectory DB; summaries sub-check is 0 by design (raw arm)")
+  notes+=("no trajectory DB; world-model sub-check is 0 by design (raw arm)")
 fi
 
 # --- Sub-check 4: ADR present when arch-impact ---


### PR DESCRIPTION
Three deterministic-layer reads still referenced schema removed in v7/v8.

| # | Where | Bug | Fix |
|---|---|---|---|
| **#275** | `branch-up-to-date-with-remote.sh` | reads `SELECT value` (no such column) → pr_target falls back to `main`, gitflow validates against wrong base | `json_extract(value_json,'$')` |
| **#287** | `session-start-prescan.sh` | counts `FROM directories` (dropped v8) → world model always reported "cold" | `deep_scan_completed` audit proxy (registry-cold gate's own signal); shows "kuzu graph" |
| **#286** | `bench/scorers/quality.sh` | queries `FROM file_registry` (dropped v7) → freshness always 0 | same audit proxy (per-file summaries retired) |

**Verified** against `schema.sql`: old `SELECT value` errors; `json_extract` returns the pr_target; the audit count flips cold→warm. `branch-up-to-date-with-remote` hook test passes. (`session-start-prescan` change is behaviorally identical to HEAD in a bare invocation; the SQL logic is proven above.)

Closes #275, #286, #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
