### PR TITLE
🔧 ci(#303): gate PRs to dev with run-all.sh (L1–L4)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -4,6 +4,8 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches: [dev]
   workflow_dispatch:
     inputs:
       skip_l6:
@@ -87,19 +89,19 @@ jobs:
         run: bash tests/run-all.sh
 
       - name: Install Claude Code CLI (required by L6 chain runner)
-        if: ${{ inputs.skip_l6 != true }}
+        if: ${{ inputs.skip_l6 != true && github.event_name != 'pull_request' }}
         run: |
           npm install -g @anthropic-ai/claude-code
           claude --version
 
       - name: Run L6 13-step chain
-        if: ${{ inputs.skip_l6 != true }}
+        if: ${{ inputs.skip_l6 != true && github.event_name != 'pull_request' }}
         env:
           L6_FROM_STEP: ${{ inputs.l6_from_step || '1' }}
         run: bash tests/dogfood/run-l6-chain.sh --from "$L6_FROM_STEP" --fresh
 
       - name: Upload L6 chain artifacts (on success or failure)
-        if: ${{ always() && inputs.skip_l6 != true }}
+        if: ${{ always() && inputs.skip_l6 != true && github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v4
         with:
           name: l6-chain-runs-${{ github.run_id }}
@@ -109,6 +111,8 @@ jobs:
 
   install-smoke:
     name: L0 docker install-smoke
+    # L0 docker smoke stays release-only; PR gate is L1–L4 (run-all.sh).
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Closes #303.

Per-PR CI on `dev` was **CodeQL-only**; the real suite (`tests/run-all.sh` — L1 lint + L2 unit + L3 integration + L4 workflow-sim) ran only in the **manual** release-gate. That's how three regressions rode into dev clean during the #295–#301 batch (broken semantic search, pr-reviewer line-budget, shellcheck).

**Change:** add `pull_request: [dev]` to `release-gate.yml`, reusing its existing setup (node/bun/HF-model-cache/build) to run the L1–L4 sweep on every PR to dev. The expensive bits stay release-only:
- L6 Claude chain (install + run + artifact) → gated `&& github.event_name != 'pull_request'`
- L0 docker install-smoke job → `if: github.event_name != 'pull_request'`

The `run-all.sh` step itself runs on all triggers.

**Self-validating:** this PR targets `dev`, so the new trigger fires on it — if the `release-gate / L1+L2+L3+L4` check goes green here, the gate works. Merge once it's green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
