### PR TITLE
🧪 test(l6): seed a 2nd consultant before step-11 roundtable

### DIFF
--- a/tests/dogfood/l6-chain/chain-manifest.json
+++ b/tests/dogfood/l6-chain/chain-manifest.json
@@ -112,6 +112,7 @@
       "row_dir": "rows/11-roundtable",
       "partial_test": true,
       "seed_before": null,
+      "chain_setup_command": "mkdir -p .claude/agents && cp \"$PLUGIN_ROOT/templates/agents/cto.md\" .claude/agents/cto.md && cp \"$PLUGIN_ROOT/templates/agents/pm.md\" .claude/agents/pm.md",
       "seed_after": "seeds/after-11-roundtable.sql",
       "halt_on_fail": true
     },


### PR DESCRIPTION
Step 10 leaves only `architect` in the project; the roundtable needs ≥2 non-SWE agents to spawn via `Agent`. Adds a `chain_setup_command` to step 11 seeding `cto` + `pm` from templates. Full L0–L6 green on this branch (run 27079385840) — **13/13 L6 chain pass**, which also validates the #306 worktree change end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)