### PR TITLE
🧪 test(l6/l5): shared roundtable seed (L5≡L6 parity) + #300 task_brief lint

### DIFF
--- a/tests/dogfood/l6-chain/chain-manifest.json
+++ b/tests/dogfood/l6-chain/chain-manifest.json
@@ -112,7 +112,7 @@
       "row_dir": "rows/11-roundtable",
       "partial_test": true,
       "seed_before": null,
-      "chain_setup_command": "mkdir -p .claude/agents && cp \"$PLUGIN_ROOT/templates/agents/cto.md\" .claude/agents/cto.md && cp \"$PLUGIN_ROOT/templates/agents/pm.md\" .claude/agents/pm.md",
+      "chain_setup_command": "bash \"$PLUGIN_ROOT/tests/dogfood/rows/11-roundtable/seed-agents.sh\" \"$PWD\" \"$PLUGIN_ROOT\"",
       "seed_after": "seeds/after-11-roundtable.sql",
       "halt_on_fail": true
     },

--- a/tests/dogfood/rows/11-roundtable/data-engineer.md
+++ b/tests/dogfood/rows/11-roundtable/data-engineer.md
@@ -1,0 +1,22 @@
+---
+name: data-engineer
+tmb_owner: bro
+description: Consultant. Storage architecture, query patterns, data-pipeline trade-offs.
+model: opus
+tools: Read, Glob, Grep, mcp__plugin_tmb_trajectory-server
+skills: []
+---
+
+# Data Engineer
+
+Storage architecture + query patterns + data-pipeline trade-offs. Read code + DB shape before recommending.
+
+## TMB contract (binding)
+
+You are spawned analysis-only. If `issue_id=<N>` was given, use it; else call `issue_list(agent='data-engineer', status='open')` and use the most recent open issue. NEVER call `issue_create` — server-rejected for consultants.
+
+**Persistence is mandatory.** Before returning any text to bro, call `discussion_append(agent='data-engineer', issue_id=<N>, kind='analysis', body='<full analysis>')`. The DB row is the deliverable; text to bro is a summary.
+
+Roundtable mode: also call `roundtable_vote(agent='data-engineer', vote='...', reasoning='...')` after persisting the analysis.
+
+You decide nothing. Bro summarizes for the Human; the Human decides.

--- a/tests/dogfood/rows/11-roundtable/seed-agents.sh
+++ b/tests/dogfood/rows/11-roundtable/seed-agents.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Shared roundtable-panel seed for the 11-roundtable scenario.
+#
+# Used by BOTH suites so L5 and L6 convene the identical panel:
+#   - L5: setup-l5.sh calls this to build the whole shape from scratch.
+#   - L6: the step-11 chain_setup_command calls this to add the panel on top
+#         of cumulative chain state (step 10 already created cto for real).
+#
+# Panel = cto (templated, mirrors step 10's /tmb:agent-create) + data-engineer
+# (from-scratch consultant). Idempotent: cp overwrites, INSERT OR REPLACE.
+set -uo pipefail
+
+PROJECT="${1:?usage: seed-agents.sh <project_dir> [plugin_root]}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="${2:-${PLUGIN_ROOT:-$(cd "$HERE/../../../.." && pwd)}}"
+
+mkdir -p "$PROJECT/.claude/agents"
+cp "$PLUGIN_ROOT/templates/agents/cto.md" "$PROJECT/.claude/agents/cto.md"
+cp "$HERE/data-engineer.md" "$PROJECT/.claude/agents/data-engineer.md"
+
+sqlite3 "$PROJECT/.claude/tmb/trajectory.db" <<'SQL'
+INSERT OR REPLACE INTO agents (name, kind, scope, file_path, created_at)
+VALUES
+  ('cto',           'consultant', 'project-local', '.claude/agents/cto.md',           datetime('now')),
+  ('data-engineer', 'consultant', 'project-local', '.claude/agents/data-engineer.md', datetime('now'));
+SQL

--- a/tests/dogfood/rows/11-roundtable/setup-l5.sh
+++ b/tests/dogfood/rows/11-roundtable/setup-l5.sh
@@ -45,45 +45,13 @@ PY
   git commit -qm 'feat: todo CLI'
 ) >/dev/null
 
-# Pre-seed cto (templated) so the roundtable's templated half is in place.
-src="$PLUGIN_ROOT/templates/agents/cto.md"
-[ -f "$src" ] && cp "$src" "$PROJECT/.claude/agents/cto.md"
+# Pre-seed the roundtable panel (cto + data-engineer) via the shared seed so
+# L5 and L6 (step-11 chain_setup_command) convene the identical panel.
+bash "$SCENARIO_DIR/seed-agents.sh" "$PROJECT" "$PLUGIN_ROOT"
 
-# Pre-seed data-engineer (from-scratch; matches what an earlier chain step
-# would have created via Branch C of /tmb:agent-create).
-cat > "$PROJECT/.claude/agents/data-engineer.md" <<'MD'
----
-name: data-engineer
-tmb_owner: bro
-description: Consultant. Storage architecture, query patterns, data-pipeline trade-offs.
-model: opus
-tools: Read, Glob, Grep, mcp__plugin_tmb_trajectory-server
-skills: []
----
-
-# Data Engineer
-
-Storage architecture + query patterns + data-pipeline trade-offs. Read code + DB shape before recommending.
-
-## TMB contract (binding)
-
-You are spawned analysis-only. If `issue_id=<N>` was given, use it; else call `issue_list(agent='data-engineer', status='open')` and use the most recent open issue. NEVER call `issue_create` — server-rejected for consultants.
-
-**Persistence is mandatory.** Before returning any text to bro, call `discussion_append(agent='data-engineer', issue_id=<N>, kind='analysis', body='<full analysis>')`. The DB row is the deliverable; text to bro is a summary.
-
-Roundtable mode: also call `roundtable_vote(agent='data-engineer', vote='...', reasoning='...')` after persisting the analysis.
-
-You decide nothing. Bro summarizes for the Human; the Human decides.
-MD
-
-# Pre-seed agents table + an open storage-scaling issue for the roundtable
-# to cite.
+# Pre-seed an open storage-scaling issue for the roundtable to cite. (L5-only:
+# in the L6 chain this issue already exists from the prior steps' discussion.)
 sqlite3 "$PROJECT/.claude/tmb/trajectory.db" <<'SQL'
-INSERT OR REPLACE INTO agents (name, kind, scope, file_path, created_at)
-VALUES
-  ('cto',           'consultant', 'project-local', '.claude/agents/cto.md',           datetime('now')),
-  ('data-engineer', 'consultant', 'project-local', '.claude/agents/data-engineer.md', datetime('now'));
-
 INSERT INTO issues (objective, description, status, created_at, updated_at)
 VALUES ('TODO CLI storage choice',
         'Team usage rising. JSON-file works at single-user; question is whether to move to SQLite or a small backend service.',

--- a/tests/lint/agent-task-brief-contract.sh
+++ b/tests/lint/agent-task-brief-contract.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Guards the #300 Architect→SWE handoff contract on the SHIPPED agents.
+#
+# swe + pr-reviewer load their context through the `task_brief` composite (one
+# read: spec + scoped world model + decision thread) instead of orchestrating
+# task_get + world_model_get + discussion_search themselves. The dogfood (L5/L6)
+# can't assert this — swe/pr-reviewer run as Agent subagents whose calls never
+# appear in bro's scored trajectory — so it's locked here at L1 instead.
+#
+# Checks templates/agents/{swe,pr-reviewer}.md (agents/ is byte-identical via
+# agent-template-byte-identity.sh):
+#   - both bodies call task_brief(
+#   - swe's `tools:` line is narrowed: no task_get / world_model_get /
+#     discussion_search (swe gets context ONLY via task_brief). pr-reviewer
+#     keeps the full MCP namespace by design (needs discussion/audit search).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$HERE/../.." && pwd)"
+cd "$PLUGIN_ROOT" || exit 1
+
+FAIL=0
+
+for agent in swe pr-reviewer; do
+  f="templates/agents/${agent}.md"
+  if [ ! -f "$f" ]; then
+    printf 'agent-task-brief-contract: %s missing\n' "$f" >&2
+    FAIL=1
+    continue
+  fi
+  if ! grep -q 'task_brief(' "$f"; then
+    printf 'agent-task-brief-contract: %s does not call task_brief( — #300 handoff contract broken\n' "$f" >&2
+    FAIL=1
+  fi
+done
+
+# swe must be narrowed to task_brief for context — the retired per-call read
+# tools must not reappear in its tools: line.
+swe_tools=$(grep -m1 '^tools:' templates/agents/swe.md || true)
+for retired in task_get world_model_get discussion_search; do
+  if printf '%s' "$swe_tools" | grep -q "$retired"; then
+    printf 'agent-task-brief-contract: swe tools: line lists retired read tool "%s" — context goes through task_brief only (#300)\n' "$retired" >&2
+    FAIL=1
+  fi
+done
+
+if [ "$FAIL" -ne 0 ]; then
+  printf '\nagent-task-brief-contract: FAIL\n' >&2
+  exit 1
+fi
+
+printf 'agent-task-brief-contract: PASS\n'

--- a/tests/lint/fixtures/local-agent/valid/swe.md
+++ b/tests/lint/fixtures/local-agent/valid/swe.md
@@ -10,11 +10,11 @@ skills: []
 
 # SWE — Executor
 
-Your spawn includes `task_id=<N>`. **First response**: emit two tool calls in parallel — `task_brief(agent='swe', task_id=N)` AND `Bash(git worktree add .claude/worktrees/<slug> <branch>)`. The `<branch>` MUST be the value of `tasks.branch_id` verbatim — bro pre-created it before spawning you. **Never** pass `-b`/`-B` to `git worktree add` (a PreToolUse hook will reject it; #170). Reject the spawn if `task_id` is missing or the row's status is not `pending`/`open`.
+Your spawn includes `task_id=<N>`. **First response**: `task_brief(agent='swe', task_id=N)` in parallel with `Bash(cd <worktree>)` — you spawn with `isolation: worktree`, so the worktree was created for you on `tasks.branch_id` by the WorktreeCreate hook; just `cd` into the path bro passed. Reject the spawn if `task_id` is missing or the row's status is not `pending`/`open`.
 
 Work in the worktree per the spec's `## Files`, `## Success Criteria`, and `## Verification` sections. Run verification commands from the spec — they're authoritative; do not substitute your own.
 
-Atomic close (#W4): batch in one response — commit (using the spec's `## Commit` message) + `task_update_status(agent='swe', status='completed', commit_sha)`. **Do NOT call `file_registry_update_summaries`** — that's bro's responsibility during verification (#181); the server rejects SWE callers via `requireRoles`. Bro will read your diff, generate the summaries from full task context, write them, then flip `status='closed'`.
+Atomic close: batch in one response — commit (using the spec's `## Commit` message) + `task_update_status(agent='swe', status='completed', commit_sha)`. Bro reads your diff during verification and flips `status='closed'`; the world model re-scans automatically on close.
 
 Never push. Never commit secrets. Never edit outside the worktree. Never author the spec body — that's bro's role and the server enforces it. **Never attempt to bypass a PreToolUse hook block** — do not rewrite `.git/HEAD`, fabricate refs, edit `.git/` internals, or use any technique to evade a hook decision. If a hook blocks a legitimate operation, that's a plugin bug — STOP immediately, return the failure summary to bro with the exact hook output, and let bro decide the path forward. Bypass attempts trip CC's security guards and erode the doctrine these hooks exist to enforce.
 

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -38,6 +38,7 @@ run_step() {
 run_step "L1 lint: agent template line budget"        bash "$HERE/lint/agent-line-budget.sh"
 run_step "L1 lint: agent template byte-identity (swe + pr-reviewer)"  bash "$HERE/lint/agent-template-byte-identity.sh"
 run_step "L1 lint: local agent overrides retain workflow primitives"   bash "$HERE/lint/local-agent-primitives.sh"
+run_step "L1 lint: shipped swe/pr-reviewer task_brief contract (#300)"  bash "$HERE/lint/agent-task-brief-contract.sh"
 run_step "L1 lint: skill frontmatter + name=dirname"  bash "$HERE/lint/skill-frontmatter.sh"
 run_step "L1 lint: command frontmatter (description + argument-hint)"  bash "$HERE/lint/command-frontmatter.sh"
 run_step "L1 lint: manifest shape (plugin/.mcp/hooks)" bash "$HERE/lint/manifest-shape.sh"


### PR DESCRIPTION
Shared `rows/11-roundtable/seed-agents.sh` drives both the L5 row and the L6 step-11 `chain_setup_command` → identical panel (cto + data-engineer). New L1 lint `agent-task-brief-contract.sh` locks the shipped swe/pr-reviewer task_brief contract (#300) where it's visible. De-staled `valid/swe.md` fixture. Full L0–L6 green (run 27080553541), 13/13 L6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)