### PR TITLE
🔖 chore(release): bump to 0.7.0-rc.1 (rc channel version label)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.7.0-dev",
+  "version": "0.7.0-rc.1",
   "description": "TMB plugin — bro orchestrates SWE + pr-reviewer in two gates (task gate, push gate) backed by a SQLite trajectory MCP server.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.7.0-rc.1 — 2026-06-06
+
+### Test infrastructure
+
+- L5≡L6 parity: a single shared `seed-agents.sh` now feeds both the L5 roundtable row and the L6 step-11 `chain_setup_command`, so both suites convene the identical panel. New L1 lint `agent-task-brief-contract.sh` locks the shipped swe/pr-reviewer `task_brief` contract (#300) at the layer the dogfood can't see (subagent trajectories).
+
 ### Fixed — v0.7.0 ship-blockers
 
 - **World model: every directory now carries a summary (#288).** Dirs without a README get a deterministic *structural* summary (immediate file + subdir names, `summary_source='structural'`) instead of `summary=NULL` — the whole map is now reachable by `world_model_search`, no more two-thirds-blind cold start.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,13 @@ Stable users (`tmb@trustmybot`) auto-update on next `/plugin update`.
 
 When a change could plausibly break users (the v0.2.0/v0.3.0 install-path class, schema migrations, doctrine flips), validate via `tmb-rc` channel before promoting to stable:
 
-1. **Develop on dev as usual.** When ready to test in marketplace, on `dev`:
+1. **Bump the version, then cut the RC tag.** The marketplace UI shows `plugin.json`'s `version` field, *not* the tag name — so bump it to the rc version first, or the install reads `-dev`. On a branch off `dev`:
+   ```bash
+   bash scripts/maintenance/bump-version.sh 0.4.0-rc.1   # 4 manifests + MCP startup version
+   bun run build                                         # refresh dist (index.ts startup version)
+   # add a `## v0.4.0-rc.1` CHANGELOG section, then PR → dev and merge
+   ```
+   Then, on `dev` (origin = GitHub — canonical; GitLab is a backup mirror only):
    ```bash
    # Cut RC tag
    git tag -a v0.4.0-rc.1 -m "v0.4.0 release candidate 1"
@@ -87,6 +93,7 @@ When a change could plausibly break users (the v0.2.0/v0.3.0 install-path class,
    git push --force-with-lease origin rc
    git checkout dev
    ```
+   For a **new** rc number, also bump the `trustmybot/marketplace-rc` catalog's `ref` to the new tag (it pins `vX.Y.Z-rc.N`); re-cutting the same number needs no catalog change.
 2. **Install + test from `tmb-rc` channel:**
    ```
    /plugin update tmb-rc@trustmybot   # CC re-fetches the rc branch HEAD

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.7.0-dev",
+  "version": "0.7.0-rc.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.7.0-dev",
+  "version": "0.7.0-rc.1",
   "description": "TMB multi-agent Claude Code plugin — workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Marketplace shows plugin.json version, not the tag — so the rc must bump plugin.json or it reads `0.7.0-dev`. Bumps 4 version locations + CHANGELOG, patches CONTRIBUTING Path 2 to include the bump (and GH-canonical note). L1–L4 green locally. 🤖 Generated with [Claude Code](https://claude.com/claude-code)