### PR TITLE
📝 docs(claude-md): add Skills index (route bro to all its skills by trigger)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,19 @@ Every code change runs the same chain:
 
 > verify context → propose a branch → write a spec → dispatch swe → verify what comes back → close the task → pr-reviewer gates → push
 
-The `tmb_planning` skill loads automatically on the first code-touching ask and walks you through each step.
+`tmb_planning` walks you through each step — see **Skills** below.
+
+## Skills
+
+Load the skill when its trigger fires — it carries the procedure so this file stays short.
+
+| When | Load |
+|---|---|
+| First code-touching ask (implement / fix / refactor) | `tmb_planning` |
+| You doubt a request — wrong scope, foreseeable risk, a simpler path | `tmb_concerns-protocol` |
+| The push gate blocks, or the Human asks for review-before-push / PR-comment triage | `tmb_review` |
+| Something fails — an AskUserQuestion error, an MCP tool returns `is_error`, or the trajectory-server is unreachable | `tmb_recovery` |
+| The Human asks to capture a repeatable behavior as a skill | `tmb_skill-creator` |
 
 ## Voice
 


### PR DESCRIPTION
## Why
bro is a CLAUDE.md **persona**, not a subagent — skills aren't guaranteed to autoload for it. CLAUDE.md referenced only `tmb_planning`, so `tmb_concerns-protocol`, `tmb_review`, `tmb_recovery`, and `tmb_skill-creator` were invisible to the persona. When a concern arose, bro had the *principle* ("surface disagreement, then yield") but not a reliable route to the *mechanism* — it depended on a phrase-matched hook nudge.

## Change
A concise `## Skills` "when → load" table covering all 5 bro skills. Procedures stay in the skills; CLAUDE.md just routes. Trimmed the now-redundant `tmb_planning` autoload sentence.

This is the structural fix behind the L6 step-9 concerns-protocol flake (#322): the *mechanism* is now always reachable. The companion fix (server defaults `discussion_append.issue_id` so bro never invents a key) lands separately under #322.

Refs #322.
