### PR TITLE
🔧 ci: release-gate fires on release tags only (not dev push/PR)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,14 +1,11 @@
 name: release-gate
 on:
+  # Release gate: fires ONLY on release tags (rc.N + stable) + manual dispatch.
+  # Not on dev pushes/PRs — the full gate (incl. L6) is a release-time check.
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+'
-    # Also run L1–L4 on merges to dev — warms the dev-scoped HF model cache
-    # that PR runs restore from (so PRs don't re-download + risk HF 429).
-    branches: [dev]
-  pull_request:
-    branches: [dev]
   workflow_dispatch:
     inputs:
       skip_l6:


### PR DESCRIPTION
The release gate (L1–L4 + L6 + L0 docker) is a **release-time** check — it shouldn't run on every dev merge/PR. The job is named `L1+L2+L3+L4 (+ L6 chain)`, which made a routine dev merge *look* like it kicked off L6 (it didn't — the L6 steps are conditionally skipped on non-tag pushes), but it still spun up a run.

**Change:** drop `push: branches: [dev]` and `pull_request: branches: [dev]`; keep release tags (`vX.Y.Z-rc.N` + `vX.Y.Z`) + `workflow_dispatch`.

**Tradeoff to confirm:** this also removes the L1–L4 PR-gate on dev (#303) and the dev HF-model-cache warm. If you still want a *lightweight* L1–L4 check on dev PRs, that should be a separate small workflow rather than the full release-gate. Say the word and I'll add one.

v0.7.1 (post-v0.7.0).
