### PR TITLE
🧪 test(infra): symlink fix, gitignore dup, l6_from_step, runner dedupe, stale-content sweep

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -97,7 +97,12 @@ jobs:
         if: ${{ inputs.skip_l6 != true && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')) }}
         env:
           L6_FROM_STEP: ${{ inputs.l6_from_step || '1' }}
-        run: bash tests/l5-l6/run-l6-chain.sh --from "$L6_FROM_STEP" --fresh
+        run: |
+          if [ "$L6_FROM_STEP" = "1" ]; then
+            bash tests/l5-l6/run-l6-chain.sh --fresh
+          else
+            bash tests/l5-l6/run-l6-chain.sh --from "$L6_FROM_STEP"
+          fi
 
       - name: Upload L6 chain artifacts (on success or failure)
         if: ${{ always() && inputs.skip_l6 != true && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')) }}

--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,3 @@ dist/
 .vscode/
 .env
 
-# TMB plugin runtime state — never commit
-.claude/

--- a/skills/tmb_skill-creator/scripts/prompt-author-lint.sh
+++ b/skills/tmb_skill-creator/scripts/prompt-author-lint.sh
@@ -1,1 +1,1 @@
-../../tmb_agent-creator/scripts/prompt-author-lint.sh
+../../../scripts/prompt-author-lint.sh

--- a/tests/EVALUATION.md
+++ b/tests/EVALUATION.md
@@ -251,7 +251,7 @@ bash tests/l5-l6/run-l5.sh <SUBSTRING>
 ```
 
 Runs only rows whose directory name contains `<SUBSTRING>`. Examples:
-- `bash tests/l5-l6/run-l5.sh 14` → runs `14-skill-invocation-recorded`
+- `bash tests/l5-l6/run-l5.sh 07` → runs `07-push-gate`
 - `bash tests/l5-l6/run-l5.sh consultant` → runs `consultant-ad-hoc`
 - `bash tests/l5-l6/run-l5.sh misc` → runs all three `misc-*` rows
 
@@ -327,7 +327,7 @@ Every L6 run produces a per-step log so failures are debuggable without replayin
 ├── step-02-reonboard-implicit-from-local/
 │   └── …
 …
-└── step-14-skill-invocation-recorded/
+└── step-13-search-grounding/
     └── …
 ```
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,11 +37,13 @@ Applies to:
 The escalation chain:
 
 ```
-PR opened → L0 + L1–L4 in CI (free, < 2 min)
+Local run before push → bash tests/run-all.sh (L1–L4, free, < 2 min)
    ↓ green
 PR labeled `L5` (optional) → L5 per-flow runner (~$0.20/flow, ~3 min/flow)
    ↓ green
 PR labeled `L6` (optional) → L6 multi-turn integration (~$0.30–1/scenario)
+   ↓ green
+workflow_dispatch on feature branch → full release-gate (L0 + L1–L4 + L6)
    ↓ green
 RC tag pushed → Release canary in CI (~$1–3, ~10 min)
    ↓ green

--- a/tests/l1-lint/symlink-targets.sh
+++ b/tests/l1-lint/symlink-targets.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Lint: every symlink in the repo must point at an existing target.
+#
+# Catches: broken symlinks left behind after file moves/deletes
+# (e.g. skills/*/scripts/ pointing at deleted skill dirs).
+#
+# Skips: node_modules, .git, dist/.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+BROKEN=0
+TOTAL=0
+
+while IFS= read -r link; do
+  TOTAL=$((TOTAL + 1))
+  if ! [ -e "$link" ]; then
+    target=$(readlink "$link")
+    printf "BROKEN symlink: %s -> %s\n" "$link" "$target" >&2
+    BROKEN=$((BROKEN + 1))
+  fi
+done < <(find . -type l \
+  -not -path './node_modules/*' \
+  -not -path './*/node_modules/*' \
+  -not -path './.git/*' \
+  -not -path './*/dist/*' \
+  | sort)
+
+if [ "$BROKEN" -gt 0 ]; then
+  printf "\n%d broken symlink(s) found (checked %d total).\n" "$BROKEN" "$TOTAL" >&2
+  exit 1
+fi
+
+printf "symlink-targets: %d symlink(s) checked, all resolve.\n" "$TOTAL"

--- a/tests/l3-integration/mcp/run.sh
+++ b/tests/l3-integration/mcp/run.sh
@@ -17,12 +17,11 @@ if [ ! -f "mcp/trajectory-server/dist/index.js" ]; then
   (cd mcp/trajectory-server && bun run build)
 fi
 
-WORKFLOW_SIM="$PLUGIN_ROOT/tests/l4-workflow-sim"
-
-# Run both L3 integration tests and L4 workflow-simulation flows in one Node
-# process. Both share the same harness + spawn the real MCP server.
+# Run L3 integration tests. L4 workflow-simulation flows are run separately by
+# run-all.sh via bun test (canonical). Both share the same harness + spawn the
+# real MCP server.
 # --experimental-sqlite needed on Node 22 (no-op on 24+); the harness imports
 # the MCP server, which uses node:sqlite via its own --experimental-sqlite flag
 # on the spawned subprocess. The flag here is for any direct node:sqlite use
 # the test files might add later.
-exec node --experimental-sqlite --test --test-reporter spec "$HERE"/*.test.mjs "$WORKFLOW_SIM"/*.test.mjs
+exec node --experimental-sqlite --test --test-reporter spec "$HERE"/*.test.mjs

--- a/tests/l4-workflow-sim/README.md
+++ b/tests/l4-workflow-sim/README.md
@@ -40,10 +40,11 @@ If a flow's contract changes (new step, new role enforcement, new audit event), 
 
 ## Running
 
-These tests are run by the integration runner alongside `tests/l3-integration/mcp/`:
+The canonical runner is `bun test` per file (or the full suite via `run-all.sh`):
 
 ```
-bash tests/l3-integration/mcp/run.sh
+bun test tests/l4-workflow-sim/flow-02-simple-task.test.mjs
+bun test tests/l4-workflow-sim/*.test.mjs
 ```
 
 Or via the full suite:
@@ -52,4 +53,4 @@ Or via the full suite:
 bash tests/run-all.sh
 ```
 
-CI runs them on every PR.
+Run locally before every push; the release-gate workflow (workflow_dispatch + RC tags) also runs them in CI.

--- a/tests/l5-l6/l6-chain/README.md
+++ b/tests/l5-l6/l6-chain/README.md
@@ -48,7 +48,7 @@ Per-step logs land under `~/.claude/tmb/l6-chain-runs/<run-id>/`:
 
 L5 runs each row alone against its fixture. L6 walks all 13 against ONE cumulative trajectory DB — each row fires a fresh `claude -p`, and bro picks up state from the DB via `tmb_recovery` / `issue_get_phase` / `task_first_actionable` on every cold start. Row N's DB writes are row N+1's pre-state — that's what the chain tests.
 
-**Between-row seeds** bridge the AUQ gaps for partial-test rows (1, 2, 3, 8, 11, 13):
+**Between-row seeds** bridge the AUQ gaps for partial-test rows (1, 2, 3, 11):
 
 | After step | Seed applied | What it does |
 |---|---|---|
@@ -57,7 +57,7 @@ L5 runs each row alone against its fixture. L6 walks all 13 against ONE cumulati
 | 8 architectural-change | `after-08-architectural-change.sql` | records the chosen architectural conclusion as a `kind='decision'` discussion + ADR data |
 | 11 roundtable | `after-11-roundtable.sql` | injects the human's ratify vote |
 
-Rows 4, 5, 6, 7, 9, 10, 12 are not partial-test — they progress purely on the DB writes bro made in earlier rows + their per-row `setup.sh` for any extra repo state.
+Rows 4, 5, 6, 7, 9, 10, 12 are not partial-test — they progress purely on the DB writes bro made in earlier rows + their per-row `chain_setup_command` for any extra repo state.
 
 ## Adding a new row to the chain
 

--- a/tests/l5-l6/l6-chain/chain-manifest.json
+++ b/tests/l5-l6/l6-chain/chain-manifest.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "./schema.json",
-  "description": "Single chained L6 integration test. 14 sequential rows fired via fresh `claude -p` each, against a cumulative trajectory DB. State carries across rows via the trajectory DB. See tests/EVALUATION.md for the journey spec.",
+  "description": "Single chained L6 integration test. 13 sequential rows fired via fresh `claude -p` each, against a cumulative trajectory DB. State carries across rows via the trajectory DB. See tests/EVALUATION.md for the journey spec.",
   "initial_fixture": "empty",
   "initial_setup": null,
   "steps": [

--- a/tests/l5-l6/lib/timeout-shim.sh
+++ b/tests/l5-l6/lib/timeout-shim.sh
@@ -13,13 +13,17 @@ _l5_timeout() {
   else
     perl -e '
       use strict; use warnings;
+      use POSIX ":sys_wait_h";
       my $secs = shift @ARGV;
-      eval {
-        local $SIG{ALRM} = sub { kill 9, $$; exit 124 };
-        alarm $secs;
-        exec @ARGV;
-      };
-      exit 124;
+      my $pid = fork();
+      if (!defined $pid) { exit 1; }
+      if ($pid == 0) { exec @ARGV; exit 1; }
+      local $SIG{ALRM} = sub { kill 9, $pid; waitpid($pid, 0); exit 124 };
+      alarm $secs;
+      waitpid($pid, 0);
+      alarm 0;
+      my $status = $?;
+      exit(($status >> 8) & 0xff);
     ' "$secs" "$@"
   fi
 }

--- a/tests/l5-l6/rows/03-reonboard-remote/README.md
+++ b/tests/l5-l6/rows/03-reonboard-remote/README.md
@@ -2,11 +2,11 @@
 
 **Scenario under test:** the user types `/onboard` on an already-onboarded project to switch from local (GitHub-flow, no remote) to remote (gitflow, GitHub). Bro must call `onboard_state_get` (sees `first_run=false`), call `onboard_get_questions(shape='remote')`, and would render AUQ rounds for the new branching model + remote provider.
 
-**🟡 Partial-test:** AUQ rendering is suppressed in test mode. The L5 unit asserts the **re-initiation** signal (the two MCP calls). The post-AUQ state — flipping `branching_model` to `'gitflow'`, `pr_target` to `'dev'`, and adding a GitHub remote entry — is seeded by `setup.sh` so downstream rows see the new config.
+**🟡 Partial-test:** AUQ rendering is suppressed in test mode. The L5 unit asserts the **re-initiation** signal (the two MCP calls). The post-AUQ state — flipping `branching_model` to `'gitflow'`, `pr_target` to `'dev'`, and adding a GitHub remote entry — is seeded by `setup-l5.sh` so downstream rows see the new config.
 
 ## Pre-state
 
-`onboarding-named` fixture (local-shape state, identity row exists). `setup.sh` does NOT pre-apply the remote-shape values — that happens after the AUQ-intent signal so the test can observe `onboard_state_get` returning `first_run=false`.
+`onboarding-named` fixture (local-shape state, identity row exists). `setup-l5.sh` does NOT pre-apply the remote-shape values — that happens after the AUQ-intent signal so the test can observe `onboard_state_get` returning `first_run=false`.
 
 ## Turns
 

--- a/tests/l5-l6/rows/04-first-task-hits-gate/README.md
+++ b/tests/l5-l6/rows/04-first-task-hits-gate/README.md
@@ -10,7 +10,7 @@ The prompt is a natural full-feature ask, so bro typically also dispatches SWE +
 
 ## Pre-state
 
-`onboarding-named` fixture, but `setup.sh` deletes the seeded `deep_scan_completed` audit row to simulate "user onboarded but never ran /scan". Scaffolds `src/__init__.py` + `tests/__init__.py` so `/scan` discovers source structure.
+`onboarding-named` fixture, but `setup-l5.sh` deletes the seeded `deep_scan_completed` audit row to simulate "user onboarded but never ran /scan". Scaffolds `src/__init__.py` + `tests/__init__.py` so `/scan` discovers source structure.
 
 ## Turns
 

--- a/tests/l5-l6/rows/07-push-gate/README.md
+++ b/tests/l5-l6/rows/07-push-gate/README.md
@@ -15,7 +15,7 @@ The bug class this catches: pr-reviewer paraphrasing the MCP-availability prefix
 
 ## Pre-state
 
-`onboarding-named` fixture + a pre-seeded `needs_validation` task on `feat/seed-todo` with a real commit (set up by `setup.sh`).
+`onboarding-named` fixture + a pre-seeded `needs_validation` task on `feat/seed-todo` with a real commit (set up by `setup-l5.sh`).
 
 ## Turns
 

--- a/tests/l5-l6/run-l5.sh
+++ b/tests/l5-l6/run-l5.sh
@@ -7,7 +7,7 @@
 #
 # Usage:
 #   bash tests/l5-l6/run-l5.sh             # all rows
-#   bash tests/l5-l6/run-l5.sh 14          # filter by substring match on row name
+#   bash tests/l5-l6/run-l5.sh 07          # filter by substring match on row name
 #
 # Requirements:
 #   - CLAUDE_CODE_OAUTH_TOKEN env var (or active CC session in macOS keychain)
@@ -53,6 +53,7 @@ printf "\n"
 PASS=0
 FAIL=0
 FAILED_ROWS=()
+RUN_BASE="$(date +%s)-$$"
 
 for row_dir in "$HERE/rows"/*/; do
   [ -d "$row_dir" ] || continue
@@ -67,7 +68,7 @@ for row_dir in "$HERE/rows"/*/; do
   printf "\n=== L5 row: %s ===\n" "$row_name"
 
   FLOW_NAME="$row_name"
-  RUN_ID="${RUN_ID:-$(date +%s)-$$}-${row_name}"
+  RUN_ID="${RUN_BASE}-${row_name}"
   export FLOW_NAME RUN_ID
 
   PROJECT=$(l5_setup_scratch_project)

--- a/tests/l5-l6/run-l6-chain.sh
+++ b/tests/l5-l6/run-l6-chain.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# L6 chain runner — drives ALL 14 journey rows sequentially through ONE
+# L6 chain runner — drives ALL 13 journey rows sequentially through ONE
 # cumulative trajectory DB. Rows live in tests/l5-l6/rows/ (canonical tree).
 # State carries across rows via DB; see tests/EVALUATION.md for the journey spec
 # and tests/l5-l6/l6-chain/chain-manifest.json for the step manifest.
@@ -109,13 +109,13 @@ trap 'if [ -f "$HOME/.claude/tmb-active-workspace.l6-bak-$$" ]; then mv "$HOME/.
 PROJECT="$RUN_DIR/project"
 
 # Most recent prior run dir (excluding $RUN_DIR), sorted by mtime desc.
-# BSD-stat compatible.
+# Dual-platform stat: GNU stat -c on Linux, BSD stat -f on macOS.
 l6c_find_recent_prior_runs() {
   while IFS= read -r d; do
     [ "$d" = "$RUN_DIR" ] && continue
     [ -d "$d" ] && echo "$d"
   done < <(find "$RUNS_ROOT" -mindepth 1 -maxdepth 1 -type d -print0 \
-            | xargs -0 stat -f '%m %N' 2>/dev/null \
+            | xargs -0 sh -c 'stat -c "%Y %n" "$@" 2>/dev/null || stat -f "%m %N" "$@" 2>/dev/null' -- \
             | sort -rn \
             | awk '{$1=""; sub(/^ /,""); print}')
 }
@@ -286,16 +286,6 @@ for idx in $(seq 0 $((STEP_COUNT - 1))); do
     printf "  chain_setup_command: %s\n" "$chain_setup_cmd"
     ( cd "$PROJECT" && eval "$chain_setup_cmd" ) >> "$STEP_DIR/chain-setup.log" 2>&1 \
       || printf "  ⚠ chain_setup_command exited non-zero (continuing)\n" >&2
-  fi
-
-  # Per-row setup.sh (mirrors L5 — extra pre-state on top of seeds).
-  if [ -f "$ROW_DIR/setup.sh" ]; then
-    bash "$ROW_DIR/setup.sh" "$PROJECT" "$ROW_DIR" || {
-      printf "  ✗ step %d: setup.sh failed\n" "$step_id" >&2
-      CHAIN_FAIL=$((CHAIN_FAIL + 1))
-      [ "$HALT_ON_FAIL" = "1" ] && [ "$halt_step" = "true" ] && break
-      continue
-    }
   fi
 
   l6c_snapshot_db "$PROJECT" "$STEP_DIR/pre-state.sql"

--- a/tests/l7-benchmark/run-l7-chain.sh
+++ b/tests/l7-benchmark/run-l7-chain.sh
@@ -4,17 +4,17 @@
 # Today's bench (run-l7.sh) resets the scratch project between tasks:
 # fresh clone, fresh .claude/tmb/, fresh git. That measures single-shot
 # completion but invisibility-erases TMB's actual value prop — cumulative
-# state across tasks (file_registry warming, atomic-close history, decision
-# audit). Tier 2 confirmed: on small single-shot tasks, the TMB doctrine
-# ceremony doesn't even engage because bro correctly judges the task isn't
-# big enough.
+# world-model state across tasks (trajectory DB warming, atomic-close history,
+# decision audit). Tier 2 confirmed: on small single-shot tasks, the TMB
+# doctrine ceremony doesn't even engage because bro correctly judges the task
+# isn't big enough.
 #
 # This script preserves state across a sequence of tasks on the same repo.
 # Measures whether TMB's per-task token / duration / hallucination metrics
 # improve as the chain progresses (vs the cold-start baseline).
 #
-# Status: NOT IMPLEMENTED YET. See docs/BENCHMARK.md → "Multi-task chained
-# bench" for the design. This file is the agreed entry point.
+# Status: NOT IMPLEMENTED YET. See docs/contributing/BENCHMARK.md →
+# "Multi-task chained bench" for the design. This file is the agreed entry point.
 #
 # Intended usage (when implemented):
 #
@@ -31,8 +31,8 @@ cat >&2 <<'EOF'
   run-l7-chain.sh is a STUB. Not implemented yet.
 ================================================================
 
-Design captured in docs/BENCHMARK.md → "Multi-task chained bench
-— the real product measurement".
+Design captured in docs/contributing/BENCHMARK.md → "Multi-task chained
+bench — the real product measurement".
 
 To implement, the harness needs:
 
@@ -49,7 +49,7 @@ To implement, the harness needs:
 
 3. Cross-task analysis:
    - Per-task metrics over chain position
-   - Hypothesis: tokens DROP as chain progresses (registry warms)
+   - Hypothesis: tokens DROP as chain progresses (world model warms)
    - Hypothesis: hallucination rate stays 0 (atomic-close seeded)
 
 4. Three arms for fair comparison:

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -64,6 +64,9 @@ run_step "L1 lint: no stale framing prose"            bash "$HERE/l1-lint/stale-
 run_step "L1 lint: no hardcoded plugin name"          bash "$HERE/l1-lint/no-hardcoded-plugin-name.sh"
 run_step "L1 lint: CI workflow file refs exist"       bash "$HERE/l1-lint/ci-workflow-refs-exist.sh"
 run_step "L1 lint: no bare role compare in hooks"     bash "$HERE/l1-lint/no-bare-role-compare.sh"
+run_step "L1 lint: symlink targets all resolve"       bash "$HERE/l1-lint/symlink-targets.sh"
+run_step "L1 lint: no directories-table refs"         bash "$HERE/l1-lint/no-directories-table-refs.sh"
+run_step "L1 lint: RAG schema invariants"             bash "$HERE/l1-lint/rag-schema-invariants.sh"
 
 # ----- L2 — Unit + L3 — Integration -------------------------------------
 


### PR DESCRIPTION
Fixes #352, #380, #382, #383, #384, #385, #386, #390; verifies #331 complete (audit-batch B8).

- tmb_skill-creator lint symlink re-pointed + new symlink-targets l1 lint
- .gitignore duplicate .claude/ block removed (rules/ negation works again)
- tests READMEs now describe the real dispatch-based CI policy
- release-gate.yml: --fresh conditional so l6_from_step works ⚠️ workflow_dispatch on this branch was NOT run (L6 burns API tokens) — Human may dispatch to confirm before/after merge
- no-directories-table-refs + rag-schema-invariants wired into run-all.sh
- run-l5 RUN_ID accumulation fixed; L4 double-execution removed; 6-item stale sweep incl. timeout-shim exit-124 contract

Verification: L1 32/32 · L3 hooks PASS · L4 5/5 · L2/L3-mcp failures confirmed pre-existing on base (env). pr-reviewer verdict: PASS (task 12, attempt 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)