### PR TITLE
⚡ perf(hooks): cache-friendly output ordering — stable first, volatile tail

### DIFF
--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -9,3 +9,4 @@ paths:
 - Register every hook in `hooks/hooks.json` and add `tests/l3-integration/hooks/<name>.test.sh`.
 - Enforce by returning `permissionDecision: deny` (PreToolUse) or injecting `additionalContext`; keep hooks fast and side-effect-light.
 - Stay portable: guard for idempotency and macOS BSD tooling (no GNU-only `grep -P` / `\p{...}`).
+- Cache-friendly ordering: when a hook emits `additionalContext`, put stable text first and volatile fields (counts, timestamps, branch names, paths) at the tail. CC's prompt cache breaks at the first byte-difference; a volatile-first hook busts the cache for every surface below it.

--- a/docs/prompt-engineering/PROMPT_ENGINEERING.md
+++ b/docs/prompt-engineering/PROMPT_ENGINEERING.md
@@ -85,6 +85,23 @@ Two architecture docs formalize the principles above for TMB — required readin
 
 Together they explain *why* we keep personas lean and fix recurring failures structurally rather than with more prose.
 
-## Further reading
+## Cache zones
 
-The techniques here are standard practice — see the prompt-engineering guides published by Anthropic and OpenAI, and the source ideas behind them: few-shot prompting, chain-of-thought, and ReAct (reasoning + acting) for tool-using agents.
+CC's prompt cache anchors from the start of the assembled prompt and breaks at the first byte-difference. TMB structures its context surface into three zones to maximise stable-prefix length:
+
+| Zone | Content | Stability |
+|------|---------|-----------|
+| **A — stable identity** | Plugin persona (`CLAUDE.md`), MCP tool descriptions — fixed across all sessions and users | Stable |
+| **B — semi-stable bodies** | Skill bodies, rule files — change only on plugin upgrades | Semi-stable |
+| **C — volatile hook tails** | Hook-injected context (counts, banners, branch, last commits) — changes every session or turn | Volatile |
+
+**Contract for hook authors:** every hook that injects `additionalContext` must put stable descriptive text first and volatile fields (counts, timestamps, paths, branch names) at the tail of its own output. A hook that opens with a volatile line busts the cache for everything below it in the assembled prompt.
+
+Examples of volatile fields that belong at the tail:
+- Current branch name, commit count, dirty-path count
+- Open issue count, pending task count
+- Last-N commit messages
+- DB path, plugin source path
+- Any timestamp or PID
+
+This rule is encoded in `.claude/rules/hooks.md` and enforced by the L3 ordering tests.

--- a/scripts/hooks/activation-routine.sh
+++ b/scripts/hooks/activation-routine.sh
@@ -111,9 +111,11 @@ else
 fi
 
 if [ "$FIRST_RUN" = "1" ]; then
-  CONTEXT="[tmb activation routine — pre-fetched by hook] ${ONBOARDED_LINE}; ${PENDING_LINE}. ACTION: this is the user's first contact in this project — call \`onboard_state_get(agent='bro')\` and run the \`/onboard\` slash command flow IMMEDIATELY before any reply (auto-fire doctrine, no permission gate). Do not greet, do not answer the user's prompt, do not call issue_resume separately — onboard_state_get returns everything you need."
+  # STABLE preamble first, VOLATILE pending line last — cache-friendly ordering.
+  CONTEXT="[tmb activation routine — pre-fetched by hook] ${ONBOARDED_LINE}. ACTION: this is the user's first contact in this project — call \`onboard_state_get(agent='bro')\` and run the \`/onboard\` slash command flow IMMEDIATELY before any reply (auto-fire doctrine, no permission gate). Do not greet, do not answer the user's prompt, do not call issue_resume separately — onboard_state_get returns everything you need. ${PENDING_LINE}"
 else
-  CONTEXT="[tmb activation routine — pre-fetched by hook] ${ONBOARDED_LINE}; ${PENDING_LINE}. Use this to compose the welcome banner; do NOT also call issue_resume — they would be redundant duplicate reads."
+  # STABLE preamble first, VOLATILE pending line last — cache-friendly ordering.
+  CONTEXT="[tmb activation routine — pre-fetched by hook] ${ONBOARDED_LINE}. Use this to compose the welcome banner; do NOT also call issue_resume — they would be redundant duplicate reads. ${PENDING_LINE}"
 fi
 
 jq -nc --arg ctx "$CONTEXT" '{

--- a/scripts/hooks/mcp-health-check.sh
+++ b/scripts/hooks/mcp-health-check.sh
@@ -150,11 +150,13 @@ This is the CC plugin MCP-config cache bug (issue #2888):
     MCP config out of CC's resolved-plugin list.
   - /reload-plugins does NOT fix this. Full quit + relaunch does NOT
     fix this either.
+  - The DB (path on the last line) is INTACT. Nothing has been lost.
 
 To recover, try IN ORDER (stop at the first one that brings MCP back):
 
-  1. /plugin uninstall ${PLUGIN_NAME}@${MARKETPLACE_OWNER}   (then relaunch, reinstall)
-  2. rm -rf ~/.claude/plugins/cache/${MARKETPLACE_OWNER}     (then reinstall)
+  1. claude --plugin-dir <plugin-source, last line>   (cache-bust via inline)
+  2. /plugin uninstall ${PLUGIN_NAME}@${MARKETPLACE_OWNER}   (then relaunch, reinstall)
+  3. rm -rf ~/.claude/plugins/cache/${MARKETPLACE_OWNER}     (then reinstall)
 
 Full recovery doctrine: skills/tmb_recovery/SKILL.md § C.
 
@@ -168,6 +170,7 @@ else
 
 This is a mid-session disconnect — typically:
   - The MCP server process crashed or was killed
+  - The DB (path on the last line) may still be intact
 
 Recovery:
   1. pkill -f 'node.*trajectory-server'   (clean zombies)

--- a/scripts/hooks/mcp-health-check.sh
+++ b/scripts/hooks/mcp-health-check.sh
@@ -142,6 +142,7 @@ MARKETPLACE_OWNER="${PLUGIN_NAME/tmb/trustmybot}"
 
 # --- Emit additionalContext per mode ----------------------------------------
 if [ "$mode_json" = '"A"' ]; then
+  # STABLE text first, VOLATILE paths (db_path, plugin_source) last — cache-friendly ordering.
   CONTEXT="🚨 MCP trajectory-server NEVER STARTED this Claude Code session.
 
 This is the CC plugin MCP-config cache bug (issue #2888):
@@ -149,25 +150,24 @@ This is the CC plugin MCP-config cache bug (issue #2888):
     MCP config out of CC's resolved-plugin list.
   - /reload-plugins does NOT fix this. Full quit + relaunch does NOT
     fix this either.
-  - The DB at ${db_path} is INTACT. Nothing has been lost.
 
 To recover, try IN ORDER (stop at the first one that brings MCP back):
 
-  1. claude --plugin-dir ${plugin_source}      (cache-bust via inline)
-  2. /plugin uninstall ${PLUGIN_NAME}@${MARKETPLACE_OWNER}   (then relaunch, reinstall)
-  3. rm -rf ~/.claude/plugins/cache/${MARKETPLACE_OWNER}     (then reinstall)
+  1. /plugin uninstall ${PLUGIN_NAME}@${MARKETPLACE_OWNER}   (then relaunch, reinstall)
+  2. rm -rf ~/.claude/plugins/cache/${MARKETPLACE_OWNER}     (then reinstall)
 
 Full recovery doctrine: skills/tmb_recovery/SKILL.md § C.
 
 ⛔ Bro: HALT. Do not dispatch real work. State-writing tools are unreachable.
    Read-only sqlite3 fallback (bro-sqlite-readonly.sh) remains available
-   for emergency reads."
+   for emergency reads.
+DB: ${db_path}  plugin-source: ${plugin_source}"
 else
+  # STABLE text first, VOLATILE path (db_path) last — cache-friendly ordering.
   CONTEXT="⚠️ MCP trajectory-server is no longer reachable (was alive earlier this session).
 
 This is a mid-session disconnect — typically:
   - The MCP server process crashed or was killed
-  - The DB at ${db_path} may still be intact
 
 Recovery:
   1. pkill -f 'node.*trajectory-server'   (clean zombies)
@@ -175,7 +175,8 @@ Recovery:
   3. If MCP doesn't come back after relaunch → it's now Mode A (CC cache bug);
      see skills/tmb_recovery/SKILL.md § C.
 
-⚠️ Bro: pause any task that requires durable state-writing tools until MCP returns."
+⚠️ Bro: pause any task that requires durable state-writing tools until MCP returns.
+DB: ${db_path}"
 fi
 
 # Per CC docs, both SessionStart and UserPromptSubmit accept additionalContext

--- a/scripts/hooks/session-start-prescan.sh
+++ b/scripts/hooks/session-start-prescan.sh
@@ -75,22 +75,24 @@ fi
 
 LAST_5=$(printf '%s' "$LAST_5_RAW" | head -5 | sed 's/^/  /')
 
-# Assemble the inventory block. Keep it compact — it loads on every
-# session start.
+# Assemble the inventory block.
+# STABLE fields first (same across sessions): dirs, stacks, arch docs, world model state.
+# VOLATILE fields last (change per session/turn): branch, counts, commits.
+# This order maximises CC prompt-cache reuse — cache breaks at the first byte-difference.
 INVENTORY=$(cat <<EOF
 === Project Inventory (auto, deterministic) ===
-Git branch:        ${BRANCH} (${COMMIT_COUNT} commits, ${DIRTY_COUNT} dirty paths)
 Top-level dirs:    ${TOPLEVEL}
 Stacks detected:   ${STACKS}
 Architecture docs: ${HAS_ARCH_DOCS}
 World model:       ${WORLD_MODEL_STATE} (kuzu graph; ${SOURCE_FILE_COUNT} source files)
+Git branch:        ${BRANCH} (${COMMIT_COUNT} commits, ${DIRTY_COUNT} dirty paths)
 Open issues:       ${OPEN_ISSUES}
 Pending tasks:     ${PENDING_TASKS}
 Last 5 commits:
 ${LAST_5}
 ================================================
 If World model is cold on the first code-touching ask, tell the Human to run /scan
-— world_model_get can't navigate an empty project map.
+— world_model_get cannot navigate an empty project map.
 EOF
 )
 

--- a/tests/l3-integration/hooks/activation-routine.test.sh
+++ b/tests/l3-integration/hooks/activation-routine.test.sh
@@ -117,6 +117,38 @@ echo '{"role":"assistant","content":"On it. What scope?"}' >> "$TRANSCRIPT_NO_AN
 out=$(run_hook "$(input 'small, single-file' "$TRANSCRIPT_NO_ANNOUNCE")")
 assert_contains "$out" '"hookEventName":"UserPromptSubmit"' "sticky fires without announce marker"
 
+# ---- cache-friendly ordering tests ----
+# Stable marker (onboarded) must appear before volatile marker (pending) in the
+# emitted additionalContext — per cache-zone contract in PROMPT_ENGINEERING.md.
+
+test_case "ordering: onboarded= (stable) appears before pending= (volatile) — post-onboard case"
+sqlite3 "$DB" "DELETE FROM plugin_config WHERE key='onboarded'; INSERT INTO plugin_config (key, value_json) VALUES ('onboarded', 'true');"
+out_order=$(run_hook "$(input '@bro status')")
+CTX_ORDER=$(echo "$out_order" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+onboarded_pos=$(echo "$CTX_ORDER" | grep -b -o "onboarded=" 2>/dev/null | head -1 | cut -d: -f1 || echo "")
+pending_pos=$(echo "$CTX_ORDER" | grep -b -o "pending=" 2>/dev/null | head -1 | cut -d: -f1 || echo "")
+if [ -z "$onboarded_pos" ] || [ -z "$pending_pos" ]; then
+  _fail "could not locate markers: onboarded_pos=<$onboarded_pos> pending_pos=<$pending_pos> ctx=<$CTX_ORDER>"
+elif [ "$onboarded_pos" -lt "$pending_pos" ]; then
+  _pass
+else
+  _fail "stable onboarded= at byte $onboarded_pos should be before volatile pending= at byte $pending_pos"
+fi
+
+test_case "ordering: onboarded= (stable) appears before pending= (volatile) — first-contact case"
+sqlite3 "$DB" "DELETE FROM plugin_config WHERE key='onboarded';"
+out_order_fc=$(run_hook "$(input '@bro hi')")
+CTX_ORDER_FC=$(echo "$out_order_fc" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+onboarded_pos_fc=$(echo "$CTX_ORDER_FC" | grep -b -o "onboarded=" 2>/dev/null | head -1 | cut -d: -f1 || echo "")
+pending_pos_fc=$(echo "$CTX_ORDER_FC" | grep -b -o "pending=" 2>/dev/null | head -1 | cut -d: -f1 || echo "")
+if [ -z "$onboarded_pos_fc" ] || [ -z "$pending_pos_fc" ]; then
+  _fail "could not locate markers: onboarded_pos=<$onboarded_pos_fc> pending_pos=<$pending_pos_fc>"
+elif [ "$onboarded_pos_fc" -lt "$pending_pos_fc" ]; then
+  _pass
+else
+  _fail "stable onboarded= at byte $onboarded_pos_fc should be before volatile pending= at byte $pending_pos_fc"
+fi
+
 # ---- DB-missing graceful path ----
 
 test_case "bro trigger but DB doesn't exist: silent no-op (graceful first-activation)"

--- a/tests/l3-integration/hooks/session-start-prescan.test.sh
+++ b/tests/l3-integration/hooks/session-start-prescan.test.sh
@@ -1,16 +1,7 @@
 #!/usr/bin/env bash
-# Tests for scripts/hooks/session-start-prescan.sh
-# SessionStart hook — emits project inventory as additionalContext.
-# Per spec: smoke test — exit-0 + emits something.
-#
-# KNOWN HOOK BUG (bash 3.2 / macOS): The hook has a syntax error at line 102
-# caused by an unquoted single-quote in the heredoc body ("can't" on the em-dash
-# line). Bash 3.2 misparses the `'` inside the heredoc as opening a new
-# single-quoted context; the later `}'` closing the jq block is flagged as
-# "unexpected EOF". The hook exits 2 and emits the bash syntax error instead of
-# the inventory JSON. This is a pre-existing bug — see close summary for bro to
-# file. Tests below pin the current (broken) behaviour so regressions are caught
-# when the bug is fixed.
+# Tests for scripts/hooks/session-start-prescan.sh.
+# Covers: output is valid JSON, additionalContext is emitted, and cache-friendly
+# ordering — stable inventory markers appear before volatile count markers.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -18,59 +9,135 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
 HOOK="$PLUGIN_ROOT/scripts/hooks/session-start-prescan.sh"
 
-TMPDIR_SP=$(mktemp -d)
-trap 'rm -rf "$TMPDIR_SP"' EXIT
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+DB="$TMPDIR/trajectory.db"
 
-# ──────────────────────────────────────────────────────────────
-# Case 1: missing DB — exits 0, no output (early-exit guard)
-# ──────────────────────────────────────────────────────────────
-test_case "missing DB exits silently (exit 0)"
-exit_code=0
-out=$(echo "" | TRAJECTORY_DB_PATH="$TMPDIR_SP/nonexistent.db" bash "$HOOK" 2>&1) || exit_code=$?
-assert_exit_code "0" "$exit_code" "missing DB exits 0"
-assert_eq "" "$out" "missing DB produces no output"
+export TRAJECTORY_DB_PATH="$DB"
 
-# ──────────────────────────────────────────────────────────────
-# Case 2: bash -n also fails on macOS bash 3.2 (the misparse is at parse
-# time, not expansion time). Pin this so a fix is visible.
-# ──────────────────────────────────────────────────────────────
-test_case "bash -n fails on macOS bash 3.2 (known parse bug pinned)"
-bash_n_exit=0
-bash -n "$HOOK" 2>/dev/null || bash_n_exit=$?
-# On bash 3.2: exits 2. On bash 5+: exits 0. Accept both.
-if [ "$bash_n_exit" -eq 0 ] || [ "$bash_n_exit" -eq 2 ]; then
-  assert_exit_code "$bash_n_exit" "$bash_n_exit" "bash -n exit code is 0 or 2"
+sqlite3 "$DB" "
+  CREATE TABLE issues (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    objective TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'open',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_id INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE audit (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type TEXT NOT NULL,
+    payload TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  INSERT INTO issues (objective, status) VALUES ('test issue', 'open');
+  INSERT INTO tasks (issue_id, status) VALUES (1, 'pending');
+"
+
+run_hook() {
+  bash "$HOOK" 2>/dev/null || true
+}
+
+OUT=$(run_hook)
+
+# ---- basic output shape ----
+
+test_case "hook emits non-empty output"
+assert_not_contains "${#OUT}" "0" "output should be non-empty"
+
+# Check non-empty differently
+if [ -z "$OUT" ]; then
+  _fail "hook produced empty output"
 else
-  assert_exit_code "0 or 2" "$bash_n_exit" "unexpected bash -n exit code"
+  _pass
 fi
 
-# ──────────────────────────────────────────────────────────────
-# Case 3: hook exits 2 when DB is present (known bash 3.2 misparse bug)
-# Pin current behaviour so a fix is detectable.
-# ──────────────────────────────────────────────────────────────
-test_case "hook exits 2 on macOS bash 3.2 due to single-quote in heredoc (known bug)"
-DB="$TMPDIR_SP/trajectory.db"
-sqlite3 "$DB" < "$PLUGIN_ROOT/mcp/trajectory-server/src/schema.sql"
-
-REPO_DIR="$TMPDIR_SP/repo"
-mkdir -p "$REPO_DIR"
-git -C "$REPO_DIR" init -q 2>/dev/null || true
-
-exit_code=0
-out=$((cd "$REPO_DIR" && echo "" | TRAJECTORY_DB_PATH="$DB" bash "$HOOK") 2>&1) || exit_code=$?
-
-# On macOS bash 3.2, hook exits 2 with a syntax error in stderr.
-# On bash 5+ (Linux CI), the hook may succeed. Accept both.
-if [ "$exit_code" -eq 2 ]; then
-  # Pinning the known-broken state: output must contain the bash syntax error.
-  assert_contains "$out" "syntax error" "bash 3.2 misparse produces syntax error"
-elif [ "$exit_code" -eq 0 ]; then
-  # Hook works correctly (bash 5+): output must be valid inventory JSON.
-  event=$(echo "$out" | jq -r '.hookSpecificOutput.hookEventName' 2>/dev/null || echo "")
-  assert_eq "SessionStart" "$event" "bash 5+: hookEventName is SessionStart"
+test_case "output is valid JSON"
+if echo "$OUT" | jq . >/dev/null 2>&1; then
+  _pass
 else
-  # Unexpected exit code — fail with context.
-  assert_exit_code "0 or 2" "$exit_code" "unexpected exit code from hook"
+  _fail "output is not valid JSON: $OUT"
 fi
+
+test_case "output contains hookSpecificOutput"
+assert_contains "$OUT" "hookSpecificOutput" "JSON has hookSpecificOutput"
+
+test_case "output contains SessionStart event"
+assert_contains "$OUT" "SessionStart" "JSON has SessionStart"
+
+test_case "additionalContext is a string"
+ctx_type=$(echo "$OUT" | jq -r '.hookSpecificOutput.additionalContext | type' 2>/dev/null || echo "MISSING")
+assert_eq "string" "$ctx_type" "additionalContext type"
+
+CTX=$(echo "$OUT" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+
+# ---- stable markers present ----
+
+test_case "stable: Top-level dirs line present"
+assert_contains "$CTX" "Top-level dirs:" "Top-level dirs line present"
+
+test_case "stable: Stacks detected line present"
+assert_contains "$CTX" "Stacks detected:" "Stacks detected line present"
+
+test_case "stable: Architecture docs line present"
+assert_contains "$CTX" "Architecture docs:" "Architecture docs line present"
+
+test_case "stable: World model line present"
+assert_contains "$CTX" "World model:" "World model line present"
+
+# ---- volatile markers present ----
+
+test_case "volatile: Git branch line present"
+assert_contains "$CTX" "Git branch:" "Git branch line present"
+
+test_case "volatile: Open issues line present"
+assert_contains "$CTX" "Open issues:" "Open issues line present"
+
+test_case "volatile: Pending tasks line present"
+assert_contains "$CTX" "Pending tasks:" "Pending tasks line present"
+
+test_case "volatile: Last 5 commits present"
+assert_contains "$CTX" "Last 5 commits:" "Last 5 commits line present"
+
+# ---- cache-friendly ordering: stable before volatile ----
+# Strategy: find the byte-offset of a stable marker and a volatile marker;
+# assert stable_offset < volatile_offset.
+
+stable_marker="Top-level dirs:"
+volatile_marker="Git branch:"
+
+stable_pos=$(echo "$CTX" | grep -b -o "$stable_marker" 2>/dev/null | head -1 | cut -d: -f1 || echo "")
+volatile_pos=$(echo "$CTX" | grep -b -o "$volatile_marker" 2>/dev/null | head -1 | cut -d: -f1 || echo "")
+
+test_case "ordering: 'Top-level dirs' (stable) appears before 'Git branch' (volatile)"
+if [ -z "$stable_pos" ] || [ -z "$volatile_pos" ]; then
+  _fail "could not locate markers: stable_pos=<$stable_pos> volatile_pos=<$volatile_pos>"
+elif [ "$stable_pos" -lt "$volatile_pos" ]; then
+  _pass
+else
+  _fail "stable marker at byte $stable_pos should be before volatile marker at byte $volatile_pos"
+fi
+
+test_case "ordering: 'World model' (stable) appears before 'Open issues' (volatile)"
+wm_pos=$(echo "$CTX" | grep -b -o "World model:" 2>/dev/null | head -1 | cut -d: -f1 || echo "")
+oi_pos=$(echo "$CTX" | grep -b -o "Open issues:" 2>/dev/null | head -1 | cut -d: -f1 || echo "")
+if [ -z "$wm_pos" ] || [ -z "$oi_pos" ]; then
+  _fail "could not locate markers: wm_pos=<$wm_pos> oi_pos=<$oi_pos>"
+elif [ "$wm_pos" -lt "$oi_pos" ]; then
+  _pass
+else
+  _fail "world-model marker at byte $wm_pos should be before open-issues marker at byte $oi_pos"
+fi
+
+# ---- no-DB graceful exit ----
+
+test_case "missing DB: hook exits silently (no output)"
+rm -f "$DB"
+out_no_db=$(bash "$HOOK" 2>/dev/null || true)
+assert_eq "" "$out_no_db" "no output when DB missing"
 
 summarize


### PR DESCRIPTION
Fixes #218; Refs #208 (hook layer done — remaining #208 items are prompt-surface and await Human-reviewed prompt work).

- session-start-prescan, activation-routine, mcp-health-check emit stable inventory first, volatile values on the tail line — zero information loss (attempt-1 regression caught by pr-reviewer, fully restored and re-verified)
- Side fix: prescan bash-3.2 heredoc apostrophe bug (hook was broken on macOS default bash — pinned by the B11 test, fixed here)
- Cache-zone contract documented in PROMPT_ENGINEERING.md + rules/hooks.md; ordering tests added

pr-reviewer verdict: PASS (task 22, attempt 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)