### PR TITLE
🐛 fix(hooks): robustness batch — RO busy-timeout, transcript attribution, portability, log rotation

### DIFF
--- a/scripts/hooks/bro-turn-usage.sh
+++ b/scripts/hooks/bro-turn-usage.sh
@@ -32,10 +32,9 @@ DB_PATH=$(tmb_db_path 2>/dev/null || true)
 
 # Find the open bro agent_run row for the current task.
 RUN_ROW=$(sqlite3 -separator '|' "$DB_PATH" \
-  "SELECT id, task_id FROM agent_runs WHERE agent_type = 'bro' AND completed_at IS NULL ORDER BY id DESC LIMIT 1;" 2>/dev/null)
+  "SELECT id FROM agent_runs WHERE agent_type = 'bro' AND completed_at IS NULL ORDER BY id DESC LIMIT 1;" 2>/dev/null)
 [ -n "$RUN_ROW" ] || exit 0
 RUN_ID="${RUN_ROW%%|*}"
-TASK_ID="${RUN_ROW##*|}"
 [ -n "$RUN_ID" ] || exit 0
 
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null || true)

--- a/scripts/hooks/deferred-tools-drift-warn.sh
+++ b/scripts/hooks/deferred-tools-drift-warn.sh
@@ -40,10 +40,46 @@ TOOL_DIR="${TMB_TOOL_DIR_OVERRIDE:-$PLUGIN_ROOT/mcp/trajectory-server/dist/tools
 if [ -n "${TMB_MCP_START_OVERRIDE:-}" ]; then
   MCP_START="$TMB_MCP_START_OVERRIDE"
 else
-  MCP_START_RAW=$(ps -o lstart= -p "$MCP_PID" 2>/dev/null | xargs || true)
-  [ -n "$MCP_START_RAW" ] || exit 0
-  MCP_START=$(date -j -f '%a %b %d %H:%M:%S %Y' "$MCP_START_RAW" '+%s' 2>/dev/null || echo "")
-  [ -n "$MCP_START" ] || exit 0
+  # Compute MCP_START (epoch seconds) portably (#371):
+  #   Linux: ps -o etimes= gives elapsed seconds directly.
+  #   macOS: etimes unsupported — use ps -o etime= (DD-HH:MM:SS / HH:MM:SS / MM:SS)
+  #   and convert to seconds, then compute start = now - elapsed.
+  NOW_EPOCH=$(date +%s 2>/dev/null || true)
+  [ -n "$NOW_EPOCH" ] || exit 0
+
+  MCP_ETIMES=$(ps -o etimes= -p "$MCP_PID" 2>/dev/null | tr -d ' ' || true)
+  if [ -n "$MCP_ETIMES" ] && echo "$MCP_ETIMES" | grep -qE '^[0-9]+$'; then
+    MCP_START=$(( NOW_EPOCH - MCP_ETIMES ))
+  else
+    # macOS fallback: parse ps -o etime= output (DD-HH:MM:SS, HH:MM:SS, or MM:SS)
+    MCP_ETIME_RAW=$(ps -o etime= -p "$MCP_PID" 2>/dev/null | tr -d ' ' || true)
+    [ -n "$MCP_ETIME_RAW" ] || exit 0
+    # Convert to elapsed seconds
+    MCP_ETIMES_CALC=0
+    case "$MCP_ETIME_RAW" in
+      *-*)
+        # DD-HH:MM:SS
+        _days="${MCP_ETIME_RAW%%-*}"
+        _rest="${MCP_ETIME_RAW#*-}"
+        ;;
+      *)
+        _days=0
+        _rest="$MCP_ETIME_RAW"
+        ;;
+    esac
+    _hms_count=$(echo "$_rest" | tr -cd ':' | wc -c | tr -d ' ')
+    if [ "$_hms_count" -eq 2 ]; then
+      # HH:MM:SS
+      _h="${_rest%%:*}"; _rest2="${_rest#*:}"; _m="${_rest2%%:*}"; _s="${_rest2#*:}"
+      MCP_ETIMES_CALC=$(( _days * 86400 + _h * 3600 + _m * 60 + _s ))
+    else
+      # MM:SS
+      _m="${_rest%%:*}"; _s="${_rest#*:}"
+      MCP_ETIMES_CALC=$(( _days * 86400 + _m * 60 + _s ))
+    fi
+    [ "$MCP_ETIMES_CALC" -ge 0 ] 2>/dev/null || exit 0
+    MCP_START=$(( NOW_EPOCH - MCP_ETIMES_CALC ))
+  fi
   [ "$MCP_START" -gt 0 ] 2>/dev/null || exit 0
 fi
 

--- a/scripts/hooks/git-push-guard.sh
+++ b/scripts/hooks/git-push-guard.sh
@@ -52,10 +52,20 @@ esac
 #   3. Fall back to $PWD when neither (1) nor (2) match.
 WT_CWD=""
 CD_OVERRIDE=""
+CD_TARGET=""
 
-# Signal 1: explicit `git -C <worktree-path>`
+# Signal 1: explicit `git -C <path> ... push`.
+# Also extract the -C path for later use in git log calls (#368).
 case "$CMD" in
-  *"git -C "*"/.claude/worktrees/"*" push"*) WT_CWD="yes" ;;
+  *"git -C "*" push"*)
+    GIT_C_PATH=$(printf '%s' "$CMD" | sed -nE 's/.*git[[:space:]]+-C[[:space:]]+([^[:space:]]+).*/\1/p')
+    if [ -n "$GIT_C_PATH" ]; then
+      CD_TARGET="$GIT_C_PATH"
+      case "$GIT_C_PATH" in
+        *"/.claude/worktrees/"*) WT_CWD="yes" ;;
+      esac
+    fi
+    ;;
 esac
 
 # Signal 2: leading `cd <path> && ...` overrides $PWD.
@@ -84,8 +94,7 @@ if [ -z "$WT_CWD" ] && [ -z "$CD_OVERRIDE" ] && \
 fi
 
 if [ "$WT_CWD" = "yes" ]; then
-  REASON=$(jq -Rn '"BLOCKED: push from .claude/worktrees/ is forbidden. Bro pushes from the main checkout after reaped the detached-HEAD commits via `git fetch ./.claude/worktrees/<slug> HEAD:<feature>`."')
-  printf '{"decision":"block","reason":%s}\n' "$REASON"
+  jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":"BLOCKED: push from .claude/worktrees/ is forbidden. Bro pushes from the main checkout after reaped the detached-HEAD commits via `git fetch ./.claude/worktrees/<slug> HEAD:<feature>`."}}'
   exit 0
 fi
 
@@ -93,8 +102,7 @@ fi
 # Defense-in-depth fallback: catches non-worktree SWE pushes and cases where
 # CC #97 might strip the agent_type field from the payload.
 if [ "$AGENT_TYPE" = "swe" ]; then
-  REASON=$(jq -Rn '"BLOCKED: SWE must never push (swe.md). Bro handles the push gate at MR-open time. If this push was intended, the calling agent identity (.agent_type) is misconfigured."')
-  printf '{"decision":"block","reason":%s}\n' "$REASON"
+  jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":"BLOCKED: SWE must never push (swe.md). Bro handles the push gate at MR-open time. If this push was intended, the calling agent identity (.agent_type) is misconfigured."}}'
   exit 0
 fi
 
@@ -104,14 +112,26 @@ if [ -z "$DB" ] || ! tmb_have_sqlite; then
   exit 0
 fi
 
+# Determine the git directory to run log/config commands in.
+# Reuse the parsed cd/-C target dir already resolved above (#368): when the
+# command is `cd /other/repo && git push`, $PWD is stale (PreToolUse fires
+# before the cd runs). Running bare `git log` from $PWD would compute the
+# wrong SHA set — a false block or false allow of the pr-reviewer gate.
+GIT_DIR_ARGS=""
+if [ -n "$CD_TARGET" ]; then
+  GIT_DIR_ARGS="-C $CD_TARGET"
+fi
+
 # Determine commits about to be pushed. Use upstream tracking if available.
-PUSH_SHAS=$(git log '@{u}..HEAD' --pretty=%H 2>/dev/null || true)
+# shellcheck disable=SC2086
+PUSH_SHAS=$(git ${GIT_DIR_ARGS} log '@{u}..HEAD' --pretty=%H 2>/dev/null || true)
 if [ -z "$PUSH_SHAS" ]; then
   # No upstream — first push of new branch. Compute commits unique to this
   # branch vs the configured pr_target base.
   PR_TARGET=$(sqlite3 "$DB" "SELECT json_extract(value_json, '$') FROM plugin_config WHERE key='pr_target'" 2>/dev/null | sed -e 's/^"//' -e 's/"$//')
   PR_TARGET="${PR_TARGET:-dev}"
-  PUSH_SHAS=$(git log "origin/${PR_TARGET}..HEAD" --pretty=%H 2>/dev/null || true)
+  # shellcheck disable=SC2086
+  PUSH_SHAS=$(git ${GIT_DIR_ARGS} log "origin/${PR_TARGET}..HEAD" --pretty=%H 2>/dev/null || true)
 fi
 [ -z "$PUSH_SHAS" ] && exit 0
 
@@ -150,12 +170,13 @@ fi
 # Build the block message.
 COUNT=$(echo "$UNSIGNED" | wc -l | tr -d ' ')
 LIST=$(echo "$UNSIGNED" | awk -F'|' '{ printf "  - task_id=%s  %s  (%s)\n", $1, $2, $3 }')
+DENY_REASON="BLOCKED: pushing ${COUNT} unsigned commit(s). The following tasks lack a pr-reviewer pass verdict:
 
-# Single-line JSON for CC's hook decision protocol — but the reason needs
-# multi-line content. We embed \n explicitly via jq for safe escaping.
-REASON=$(jq -Rsn --arg count "$COUNT" --arg list "$LIST" '
-  "BLOCKED: pushing \($count) unsigned commit(s). The following tasks lack a pr-reviewer pass verdict:\n\n\($list)\nRun: @bro review before push\n\nbro will spawn pr-reviewer for each unsigned task. On all-pass the push will proceed. On any fail bro surfaces what needs fixing."
-')
+${LIST}
+Run: @bro review before push
 
-printf '{"decision":"block","reason":%s}\n' "$REASON"
+bro will spawn pr-reviewer for each unsigned task. On all-pass the push will proceed. On any fail bro surfaces what needs fixing."
+
+jq -nc --arg reason "$DENY_REASON" \
+  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":$reason}}'
 exit 0

--- a/scripts/hooks/lib/query-task.sh
+++ b/scripts/hooks/lib/query-task.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # Library: SQLite query helpers for TMB hooks.
 # Sourced (not exec'd) by other hook scripts.
-set -euo pipefail
+# No set -e/-euo/-euo pipefail here — libs must not mutate caller shell options.
+
+# _TMB_DB_PATH_CACHE: process-level memoization of the resolved DB path.
+# Set on first successful resolution; read on subsequent calls.
+_TMB_DB_PATH_CACHE=""
 
 # tmb_db_path
 # Resolve the trajectory DB path:
@@ -25,13 +29,21 @@ set -euo pipefail
 #   4. Tests with per-worktree DB fixtures should set TRAJECTORY_DB_PATH
 #      explicitly to pin the resolution.
 # Prints the path only if the file exists; non-zero exit if no DB found.
+# Memoizes the result in _TMB_DB_PATH_CACHE for the lifetime of the process.
 tmb_db_path() {
+  if [ -n "$_TMB_DB_PATH_CACHE" ]; then
+    echo "$_TMB_DB_PATH_CACHE"
+    return 0
+  fi
   local plugin_name="tmb"
   if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; then
     plugin_name=$(jq -r '.name // "tmb"' "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null || echo "tmb")
   fi
   if [ -n "${TRAJECTORY_DB_PATH:-}" ]; then
-    [ -f "$TRAJECTORY_DB_PATH" ] && echo "$TRAJECTORY_DB_PATH"
+    if [ -f "$TRAJECTORY_DB_PATH" ]; then
+      _TMB_DB_PATH_CACHE="$TRAJECTORY_DB_PATH"
+      echo "$_TMB_DB_PATH_CACHE"
+    fi
     return 0
   fi
   # P0 guard: do NOT walk into the user's HOME from a descendant cwd.
@@ -52,7 +64,8 @@ tmb_db_path() {
     dir="$(dirname "$dir")"
   done
   if [ ${#candidates[@]} -gt 0 ]; then
-    echo "${candidates[${#candidates[@]}-1]}"
+    _TMB_DB_PATH_CACHE="${candidates[${#candidates[@]}-1]}"
+    echo "$_TMB_DB_PATH_CACHE"
     return 0
   fi
   # Sentinel fallback: subagents inherit cwd=~ and lack env vars.
@@ -63,7 +76,8 @@ tmb_db_path() {
     if [ -n "$ws" ]; then
       local sentinel_db="$ws/.claude/$plugin_name/trajectory.db"
       if [ -f "$sentinel_db" ]; then
-        echo "$sentinel_db"
+        _TMB_DB_PATH_CACHE="$sentinel_db"
+        echo "$_TMB_DB_PATH_CACHE"
         return 0
       fi
     fi
@@ -73,6 +87,16 @@ tmb_db_path() {
 
 tmb_have_sqlite() {
   command -v sqlite3 >/dev/null 2>&1
+}
+
+# tmb_sqlite_ro <db> <sql>
+# Read-only sqlite3 with a 500ms busy timeout.
+# Returns the query output, or empty string on error.
+# Never fails the caller.
+tmb_sqlite_ro() {
+  local db="$1"
+  local sql="$2"
+  sqlite3 -readonly -cmd '.timeout 500' "$db" "$sql" 2>/dev/null || true
 }
 
 # Print branch_ids of tasks that are closed and have a commit_sha but
@@ -85,7 +109,7 @@ tmb_unsigned_tasks() {
   db=$(tmb_db_path) || true
   [ -z "$db" ] && return 0
   tmb_have_sqlite || return 0
-  sqlite3 "$db" "
+  tmb_sqlite_ro "$db" "
     SELECT t.branch_id
       FROM tasks t
      WHERE t.status = 'closed'
@@ -98,73 +122,87 @@ tmb_unsigned_tasks() {
   "
 }
 
-# tmb_config_get <key>
+# tmb_config_get <key> [<db>]
 # Prints the scalar value stored in plugin_config for <key>, unquoted.
-# Prints empty string when: key missing, DB absent, sqlite3 unavailable.
+# Prints empty string when: key missing, DB absent, sqlite3 unavailable, DB busy.
+# Optional <db> arg skips re-resolving the path (perf).
 # Never fails the caller.
 tmb_config_get() {
   local key="$1"
-  local db
-  db=$(tmb_db_path) || true
+  local db="${2:-}"
+  if [ -z "$db" ]; then
+    db=$(tmb_db_path) || true
+  fi
   [ -z "$db" ] && return 0
   tmb_have_sqlite || return 0
-  sqlite3 "$db" "
+  tmb_sqlite_ro "$db" "
     SELECT json_extract(value_json, '$')
       FROM plugin_config
      WHERE key = '${key}';
-  " 2>/dev/null || true
+  "
 }
 
-# tmb_config_raw <key>
+# tmb_config_raw <key> [<db>]
 # Prints the raw value_json column for <key> without JSON extraction.
-# Prints empty string when: key missing, DB absent, sqlite3 unavailable.
+# Prints empty string when: key missing, DB absent, sqlite3 unavailable, DB busy.
+# Optional <db> arg skips re-resolving the path (perf).
 # Never fails the caller.
 tmb_config_raw() {
   local key="$1"
-  local db
-  db=$(tmb_db_path) || true
+  local db="${2:-}"
+  if [ -z "$db" ]; then
+    db=$(tmb_db_path) || true
+  fi
   [ -z "$db" ] && return 0
   tmb_have_sqlite || return 0
-  sqlite3 "$db" "
+  tmb_sqlite_ro "$db" "
     SELECT value_json
       FROM plugin_config
      WHERE key = '${key}';
-  " 2>/dev/null || true
+  "
 }
 
-# tmb_config_array <key>
+# tmb_config_array <key> [<db>]
 # Prints one element per line from a JSON-array-valued plugin_config key.
-# Prints nothing when: key missing, DB absent, sqlite3 unavailable.
+# Prints nothing when: key missing, DB absent, sqlite3 unavailable, DB busy.
+# Optional <db> arg skips re-resolving the path (perf).
 # Never fails the caller.
 tmb_config_array() {
   local key="$1"
-  local db raw
-  db=$(tmb_db_path) || true
+  local db="${2:-}"
+  local raw
+  if [ -z "$db" ]; then
+    db=$(tmb_db_path) || true
+  fi
   [ -z "$db" ] && return 0
   tmb_have_sqlite || return 0
-  raw=$(sqlite3 "$db" "
+  raw=$(tmb_sqlite_ro "$db" "
     SELECT value_json
       FROM plugin_config
      WHERE key = '${key}';
-  " 2>/dev/null || true)
+  ")
   [ -z "$raw" ] && return 0
   echo "$raw" | jq -r '.[]' 2>/dev/null || true
 }
 
-# tmb_task_spec_status <task_id>
+# tmb_task_spec_status <task_id> [<db>]
 # Prints two lines: <status>\n<body_len> for the given tasks row.
-# Prints nothing when the row does not exist, DB is absent, or sqlite3 is unavailable.
+# Prints nothing when the row does not exist, DB is absent, sqlite3 is unavailable,
+# or the DB is busy (caller gets empty — treat same as "row missing").
+# Optional <db> arg skips re-resolving the path (perf).
 # Callers must check tmb_db_path / tmb_have_sqlite before calling if they need
 # to distinguish "DB missing" from "row missing".
 tmb_task_spec_status() {
   local task_id="$1"
-  local db
-  db=$(tmb_db_path) || true
+  local db="${2:-}"
+  if [ -z "$db" ]; then
+    db=$(tmb_db_path) || true
+  fi
   [ -z "$db" ] && return 0
   tmb_have_sqlite || return 0
-  sqlite3 "$db" "
+  tmb_sqlite_ro "$db" "
     SELECT status, LENGTH(COALESCE(spec_body, ''))
       FROM tasks
      WHERE id = ${task_id};
-  " 2>/dev/null | tr '|' '\n' || true
+  " | tr '|' '\n'
 }

--- a/scripts/hooks/mcp-health-check.sh
+++ b/scripts/hooks/mcp-health-check.sh
@@ -54,7 +54,15 @@ session_id=$(echo "$INPUT" | jq -r '.session_id // .sessionId // empty' 2>/dev/n
 [ -n "$session_id" ] || session_id="${CLAUDE_SESSION_ID:-unknown}"
 
 if command -v pgrep >/dev/null 2>&1; then
-  pgrep_count=$({ pgrep -f 'trajectory-server/dist/index.js' 2>/dev/null || true; } | wc -l | tr -d ' ')
+  # Scope pgrep to the plugin-root-specific path when CLAUDE_PLUGIN_ROOT is
+  # available (#370): prevents a trajectory-server from another CC project
+  # satisfying the check while this session's MCP is dead.
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    _pgrep_pattern="${CLAUDE_PLUGIN_ROOT}/mcp/trajectory-server/dist/index.js"
+  else
+    _pgrep_pattern="trajectory-server/dist/index.js"
+  fi
+  pgrep_count=$({ pgrep -f "$_pgrep_pattern" 2>/dev/null || true; } | wc -l | tr -d ' ')
   [ -z "$pgrep_count" ] && pgrep_count=0
 else
   pgrep_count=-1
@@ -113,9 +121,18 @@ fi
 
 ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-printf '{"ts":"%s","event":"%s","mcp_alive":%s,"pgrep_count":%s,"mode":%s,"session_id":"%s","db_path":"%s"}\n' \
-  "$ts" "$event" "$mcp_alive_json" "$pgrep_count" "$mode_json" "$session_id" "$db_path" \
-  >> "$LOG_FILE" || true
+# Rotate mcp-health.log at 1 MB (single .1 generation) to prevent unbounded growth (#389).
+if [ -f "$LOG_FILE" ] && [ "$(wc -c < "$LOG_FILE" 2>/dev/null || echo 0)" -gt 1048576 ]; then
+  mv -f "$LOG_FILE" "${LOG_FILE}.1" 2>/dev/null || true
+fi
+
+jq -cn --arg ts "$ts" --arg ev "$event" \
+  --argjson alive "$mcp_alive_json" \
+  --argjson count "$pgrep_count" \
+  --argjson mode "$mode_json" \
+  --arg sid "$session_id" --arg db "$db_path" \
+  '{ts:$ts,event:$ev,mcp_alive:$alive,pgrep_count:$count,mode:$mode,session_id:$sid,db_path:$db}' \
+  >> "$LOG_FILE" 2>/dev/null || true
 
 if [ "$pgrep_count" -eq -1 ]; then
   exit 0

--- a/scripts/hooks/pr-reviewer-after-atomic-close.sh
+++ b/scripts/hooks/pr-reviewer-after-atomic-close.sh
@@ -47,17 +47,38 @@ TASK_ID=$(printf '%s' "$PROMPT" | grep -Eo 'task_id[[:space:]]*=[[:space:]]*[0-9
 DB=$(tmb_db_path 2>/dev/null || true)
 [ -n "$DB" ] && [ -f "$DB" ] || exit 0
 
-STATUS=$(sqlite3 "$DB" "SELECT status FROM tasks WHERE id = $TASK_ID;" 2>/dev/null || true)
+STATUS=$(tmb_sqlite_ro "$DB" "SELECT status FROM tasks WHERE id = $TASK_ID;")
 
-# Task not found? Don't block — let pr-reviewer surface the error itself.
-[ -n "$STATUS" ] || exit 0
+if [ -z "$STATUS" ]; then
+  # Distinguish DB busy from row-missing: re-probe without -readonly.
+  PROBE=$(sqlite3 "$DB" "SELECT COUNT(*) FROM tasks WHERE id=${TASK_ID};" 2>/dev/null || echo "query_failed")
+  if [ "$PROBE" = "query_failed" ]; then
+    jq -nc --arg id "$TASK_ID" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: DB query failed for task_id="+$id+" (DB busy?). Retry the pr-reviewer spawn once the DB lock clears.")}}'
+    exit 0
+  fi
+  # Row missing — let pr-reviewer surface the error itself.
+  exit 0
+fi
 
 if [ "$STATUS" = "closed" ]; then
   exit 0
 fi
 
-REASON=$(jq -Rn --arg id "$TASK_ID" --arg st "$STATUS" '
-  "BLOCKED: pr-reviewer spawn requires task " + $id + " status=closed but actual status=" + $st + ".\n\nPer planning skill Step 5.5 + feedback_pr_reviewer_required_pre_push doctrine, the order is:\n  1. SWE returns status=completed (lifecycle answer, NOT a DB closure).\n  2. bro runs V1 (task_get + git diff), V2 (3 checks), V3 (bro_atomic_close).\n  3. ONLY THEN: spawn pr-reviewer for the push gate.\n\nSWE returning completed does not close the trajectory task — that is bro_atomic_close.\n\nFix: call bro_atomic_close(agent='\''bro'\'', task_id=" + $id + ", commit_sha=<sha>, file_summaries=[...], verification_summary='\''...'\'') first, then retry this spawn."
-')
-printf '{"decision":"block","reason":%s}\n' "$REASON"
+_DENY_REASON="BLOCKED: pr-reviewer spawn requires task ${TASK_ID} status=closed but actual status=${STATUS}.
+
+Per planning skill Step 5.5 + feedback_pr_reviewer_required_pre_push doctrine, the order is:
+  1. SWE returns status=completed (lifecycle answer, NOT a DB closure).
+  2. bro runs V1 (task_get + git diff), V2 (3 checks), V3 (bro_atomic_close).
+  3. ONLY THEN: spawn pr-reviewer for the push gate.
+
+SWE returning completed does not close the trajectory task — that is bro_atomic_close.
+
+Fix: call bro_atomic_close(agent='bro', task_id=${TASK_ID}, commit_sha=<sha>, file_summaries=[...], verification_summary='...') first, then retry this spawn."
+jq -nc --arg reason "$_DENY_REASON" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    denyReason: $reason
+  }
+}'
 exit 0

--- a/scripts/hooks/require-feature-branch-active.sh
+++ b/scripts/hooks/require-feature-branch-active.sh
@@ -50,9 +50,8 @@ if [ -n "$REPO" ]; then
     REPO_ABS="$WORKSPACE_ROOT/$REPO"
   fi
   if [ ! -d "$REPO_ABS/.git" ]; then
-    cat <<EOF
-{"decision":"block","reason":"BLOCKED: cannot resolve repo for task $TASK_ID. tasks.repo='$REPO' does not point to a git repo at '$REPO_ABS'. Verify the path is correct."}
-EOF
+    jq -nc --arg id "$TASK_ID" --arg repo "$REPO" --arg path "$REPO_ABS" \
+      '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: cannot resolve repo for task "+$id+". tasks.repo="+$repo+" does not point to a git repo at "+$path+". Verify the path is correct.")}}'
     exit 0
   fi
 else
@@ -65,9 +64,8 @@ else
     REPO_ABS="$WORKSPACE_ROOT"
   fi
   if [ ! -d "$REPO_ABS/.git" ]; then
-    cat <<EOF
-{"decision":"block","reason":"BLOCKED: cannot resolve repo for task $TASK_ID. tasks.repo IS NULL and tmb_default_repo config is unset. Set via \`config_set tmb_default_repo <inner>\` for multi-repo workspaces."}
-EOF
+    jq -nc --arg id "$TASK_ID" \
+      '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: cannot resolve repo for task "+$id+". tasks.repo IS NULL and tmb_default_repo config is unset. Set via `config_set tmb_default_repo <inner>` for multi-repo workspaces.")}}'
     exit 0
   fi
 fi
@@ -75,9 +73,8 @@ fi
 # Per GIT.md the prerequisite is that <feature> EXISTS (bro pre-created it),
 # not that the main checkout is on it — the main checkout stays on <base>.
 if ! git -C "$REPO_ABS" show-ref --verify --quiet "refs/heads/$EXPECTED"; then
-  cat <<EOF
-{"decision":"block","reason":"BLOCKED: SWE spawn for task $TASK_ID needs branch '$EXPECTED' to exist first — bro pre-creates it ('git -C $REPO_ABS branch $EXPECTED origin/<base>') and stays on <base>; SWE's worktree owns the branch. See docs/architecture/GIT.md."}
-EOF
+  jq -nc --arg id "$TASK_ID" --arg branch "$EXPECTED" --arg repo "$REPO_ABS" \
+    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: SWE spawn for task "+$id+" needs branch "+$branch+" to exist first — bro pre-creates it (\"git -C "+$repo+" branch "+$branch+" origin/<base>\") and stays on <base>; SWE'\''s worktree owns the branch. See docs/architecture/GIT.md.")}}'
   exit 0
 fi
 

--- a/scripts/hooks/require-task-spec.sh
+++ b/scripts/hooks/require-task-spec.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Hook: Block SWE agent spawn unless prompt references a valid tasks row.
 # Reads task_id=<N> from the spawn prompt, queries trajectory.db via SQLite.
-set -euo pipefail
+set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/query-task.sh
-source "$SCRIPT_DIR/lib/query-task.sh"
+. "$SCRIPT_DIR/lib/query-task.sh"
 # shellcheck source=lib/normalize-role.sh
-source "$SCRIPT_DIR/lib/normalize-role.sh"
+. "$SCRIPT_DIR/lib/normalize-role.sh"
 
 INPUT=$(cat)
 
@@ -19,20 +19,27 @@ PROMPT=$(echo "$INPUT" | jq -r '.tool_input.prompt // empty')
 TASK_ID=$(echo "$PROMPT" | grep -oE 'task_id=[0-9]+' | head -1 | sed 's/task_id=//' || true)
 
 if [ -z "$TASK_ID" ]; then
-  echo '{"decision":"block","reason":"BLOCKED: SWE spawn requires task_id=<N> in the prompt pointing at a row in the tasks table. Route through bro (bro plans, then spawns SWE with task_id)."}'
+  jq -nc '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",denyReason:"BLOCKED: SWE spawn requires task_id=<N> in the prompt pointing at a row in the tasks table. Route through bro (bro plans, then spawns SWE with task_id)."}}'
   exit 0
 fi
 
 DB=$(tmb_db_path || true)
 if [ -z "$DB" ] || ! tmb_have_sqlite; then
-  echo '{"decision":"block","reason":"BLOCKED: trajectory.db not found or sqlite3 unavailable. Cannot verify task authorization."}'
+  jq -nc '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",denyReason:"BLOCKED: trajectory.db not found or sqlite3 unavailable. Cannot verify task authorization."}}'
   exit 0
 fi
 
-ROW=$(tmb_task_spec_status "$TASK_ID")
+ROW=$(tmb_task_spec_status "$TASK_ID" "$DB")
 
 if [ -z "$ROW" ]; then
-  echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: task_id=${TASK_ID} does not exist in the tasks table.\"}"
+  # Empty row can mean DB busy (SQLITE_BUSY) or row genuinely missing.
+  # Re-query without -readonly to check whether it's a locking issue.
+  PROBE=$(sqlite3 "$DB" "SELECT COUNT(*) FROM tasks WHERE id=${TASK_ID};" 2>/dev/null || echo "query_failed")
+  if [ "$PROBE" = "query_failed" ]; then
+    jq -nc --arg id "$TASK_ID" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: DB query failed for task_id="+$id+" (DB busy?). Retry the spawn once the DB lock clears.")}}'
+  else
+    jq -nc --arg id "$TASK_ID" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: task_id="+$id+" does not exist in the tasks table.")}}'
+  fi
   exit 0
 fi
 
@@ -40,12 +47,12 @@ STATUS=$(echo "$ROW" | awk 'NR==1')
 BODY_LEN=$(echo "$ROW" | awk 'NR==2')
 
 if [ "$STATUS" != "pending" ] && [ "$STATUS" != "open" ]; then
-  echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: task_id=${TASK_ID} has status='${STATUS}', expected 'pending' or 'open'.\"}"
+  jq -nc --arg id "$TASK_ID" --arg st "$STATUS" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: task_id="+$id+" has status="+$st+", expected pending or open.")}}'
   exit 0
 fi
 
 if [ "${BODY_LEN:-0}" -eq 0 ]; then
-  echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: task_id=${TASK_ID} has empty spec_body. bro must populate spec_body via task_create_batch before SWE can execute.\"}"
+  jq -nc --arg id "$TASK_ID" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: task_id="+$id+" has empty spec_body. bro must populate spec_body via task_create_batch before SWE can execute.")}}'
   exit 0
 fi
 

--- a/scripts/hooks/roundtable-auq-shape.sh
+++ b/scripts/hooks/roundtable-auq-shape.sh
@@ -30,8 +30,8 @@ RT_ID=$(sqlite3 "$DB" "
 
 [ -z "$RT_ID" ] && { exit 0; }
 
-QUESTIONS=$(echo "$INPUT" | jq -c '.tool_input.questions // []' 2>/dev/null)
-Q_COUNT=$(echo "$QUESTIONS" | jq 'length' 2>/dev/null)
+QUESTIONS=$(echo "$INPUT" | jq -c '.tool_input.questions // []' 2>/dev/null || true)
+Q_COUNT=$(echo "$QUESTIONS" | jq 'length' 2>/dev/null || true)
 
 if [ -z "$Q_COUNT" ] || [ "$Q_COUNT" -eq 0 ]; then
   exit 0

--- a/scripts/hooks/session-log-capture.sh
+++ b/scripts/hooks/session-log-capture.sh
@@ -12,6 +12,8 @@ PLUGIN_NAME=$(tmb_resolve_plugin_name)
 # shellcheck source=scripts/hooks/lib/query-task.sh
 . "$SCRIPT_DIR/lib/query-task.sh"
 
+INPUT=$(cat)
+
 DB_PATH=$(tmb_db_path 2>/dev/null) || true
 [ -z "$DB_PATH" ] && exit 0
 
@@ -20,15 +22,18 @@ LOG_DIR="$WORKSPACE/.claude/${PLUGIN_NAME}/logs"
 mkdir -p "$LOG_DIR" 2>/dev/null || exit 0
 
 SENTINEL="$WORKSPACE/.claude/${PLUGIN_NAME}/.current-session-id"
-if [ ! -f "$SENTINEL" ]; then
-  printf '%s' "$(date -u +%Y%m%d-%H%M%S)-$$" > "$SENTINEL" 2>/dev/null || true
+
+# Prefer the session_id CC provides on stdin; fall back to sentinel file (#389).
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null || true)
+if [ -z "$SESSION_ID" ] && [ -f "$SENTINEL" ]; then
+  SESSION_ID=$(cat "$SENTINEL" 2>/dev/null || true)
 fi
-SESSION_ID=$(cat "$SENTINEL" 2>/dev/null)
+if [ -z "$SESSION_ID" ]; then
+  SESSION_ID="$(date -u +%Y%m%d-%H%M%S)-$$"
+fi
 [ -z "$SESSION_ID" ] && exit 0
 
 LOG_FILE="$LOG_DIR/$(date -u +%Y-%m-%d)-${SESSION_ID}.jsonl"
-
-INPUT=$(cat)
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 echo "$INPUT" | jq -c \

--- a/scripts/hooks/swe-atomic-close.sh
+++ b/scripts/hooks/swe-atomic-close.sh
@@ -65,14 +65,20 @@ tmb_parse_transcript_stats() {
 
 INPUT=$(cat)
 
+# Rotate mcp-health.log at 1 MB (single .1 generation) to prevent unbounded growth (#389).
+_LOG_FILE="${HOME}/.claude/${PLUGIN_NAME}/logs/mcp-health.log"
+if [ -f "$_LOG_FILE" ] && [ "$(wc -c < "$_LOG_FILE" 2>/dev/null || echo 0)" -gt 1048576 ]; then
+  mv -f "$_LOG_FILE" "${_LOG_FILE}.1" 2>/dev/null || true
+fi
+
 # Diagnostic entry-log (#94): record every invocation regardless of subagent_type
 # so we can separate "hook ran at all" from "hook decided X".
 ENTRY_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 ENTRY_KEYS=$(echo "$INPUT" | jq -rc '[paths(scalars) | join(".")] | unique // []' 2>/dev/null || echo '[]')
 ENTRY_AGENT=$(echo "$INPUT" | jq -r '.agent_type // .subagent_type // .tool_input.subagent_type // empty' 2>/dev/null || true)
-printf '{"ts":"%s","kind":"swe-atomic-close-entry","keys":%s,"agent_type_resolved":"%s"}\n' \
-  "$ENTRY_TS" "$ENTRY_KEYS" "$ENTRY_AGENT" \
-  >> "${HOME}/.claude/${PLUGIN_NAME}/logs/mcp-health.log" || true
+jq -cn --arg ts "$ENTRY_TS" --argjson keys "$ENTRY_KEYS" --arg agent "$ENTRY_AGENT" \
+  '{ts:$ts,kind:"swe-atomic-close-entry",keys:$keys,agent_type_resolved:$agent}' \
+  >> "$_LOG_FILE" 2>/dev/null || true
 
 # Only act on SWE subagent stops.
 AGENT_TYPE=$(tmb_normalize_role "$(echo "$INPUT" | jq -r '.agent_type // .subagent_type // .tool_input.subagent_type // empty' 2>/dev/null || true)")
@@ -112,16 +118,42 @@ fi
 PR_TARGET=$(tmb_config_get "pr_target" 2>/dev/null || true)
 PR_TARGET="${PR_TARGET:-main}"
 
-# Find the most-recent task in any SWE-relevant status. parent_branch_id is
-# needed to detect commits in the attached-worktree model (branch ref and
-# worktree HEAD advance together; we compare HEAD against the parent branch).
-# tasks.repo (added in MR !122) tells us which inner repo this task belongs
-# to in workspace-pattern projects; resolve via repos.path.
-ROW=$(sqlite3 "$DB" \
-  "SELECT id, status, branch_id, COALESCE(parent_branch_id, ''), COALESCE(repo, '') FROM tasks
-   WHERE status IN ('pending', 'needs_validation', 'completed')
-   ORDER BY updated_at DESC, id DESC LIMIT 1;" \
-  2>/dev/null || true)
+# Extract task_id from the subagent transcript (#369).
+# When two SWEs run in parallel, the most-recently-updated task heuristic
+# can auto-complete the WRONG task. The transcript contains the spawn prompt
+# (first human turn) which includes `task_id=N`; prefer that over the
+# updated_at sort.
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.agent_transcript_path // ""' 2>/dev/null || true)
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH:-}"
+
+TRANSCRIPT_TASK_ID=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  TRANSCRIPT_TASK_ID=$(jq -r '
+    .message.content // [] |
+    .[] | select(.type == "text") | .text // ""
+  ' "$TRANSCRIPT_PATH" 2>/dev/null \
+    | grep -oE 'task_id=[0-9]+' | head -1 | sed 's/task_id=//' || true)
+fi
+
+# Find the task to operate on:
+#   1. task_id extracted from the transcript (authoritative — bound to this SWE).
+#   2. Most-recently-updated task in any SWE-relevant status (fallback only).
+ROW=""
+if [ -n "$TRANSCRIPT_TASK_ID" ]; then
+  ROW=$(sqlite3 "$DB" \
+    "SELECT id, status, branch_id, COALESCE(parent_branch_id, ''), COALESCE(repo, '') FROM tasks
+     WHERE id = ${TRANSCRIPT_TASK_ID}
+       AND status IN ('pending', 'needs_validation', 'completed')
+     LIMIT 1;" \
+    2>/dev/null || true)
+fi
+if [ -z "$ROW" ]; then
+  ROW=$(sqlite3 "$DB" \
+    "SELECT id, status, branch_id, COALESCE(parent_branch_id, ''), COALESCE(repo, '') FROM tasks
+     WHERE status IN ('pending', 'needs_validation', 'completed')
+     ORDER BY updated_at DESC, id DESC LIMIT 1;" \
+    2>/dev/null || true)
+fi
 
 if [ -z "$ROW" ]; then
   exit 0
@@ -226,8 +258,7 @@ fi
 ISSUE_ID=$(sqlite3 "$DB" "SELECT issue_id FROM tasks WHERE id=${TASK_ID} LIMIT 1;" 2>/dev/null || true)
 ISSUE_ID="${ISSUE_ID:-}"
 
-TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.agent_transcript_path // ""' 2>/dev/null || true)
-TRANSCRIPT_PATH="${TRANSCRIPT_PATH:-}"
+# TRANSCRIPT_PATH already resolved above for task_id extraction.
 
 TOKENS_IN=0
 TOKENS_OUT=0
@@ -239,8 +270,9 @@ CACHE_CREATION_TOKENS=0
 if [ -n "$TRANSCRIPT_PATH" ]; then
   STATS=$(tmb_parse_transcript_stats "$TRANSCRIPT_PATH")
   if [ "$STATS" = "0|0|0|0|0|0" ] && [ ! -f "$TRANSCRIPT_PATH" ]; then
-    printf '{"ts":"%s","kind":"agent-runs-stats-parse-failed","reason":"transcript file not found","transcript":"%s"}\n' \
-      "$ts" "$TRANSCRIPT_PATH" >> "${HOME}/.claude/${PLUGIN_NAME}/logs/mcp-health.log" || true
+    jq -cn --arg ts "$ts" --arg tr "$TRANSCRIPT_PATH" \
+      '{ts:$ts,kind:"agent-runs-stats-parse-failed",reason:"transcript file not found",transcript:$tr}' \
+      >> "$_LOG_FILE" 2>/dev/null || true
   else
     TOKENS_IN=$(echo "$STATS" | cut -d'|' -f1)
     TOKENS_OUT=$(echo "$STATS" | cut -d'|' -f2)
@@ -248,9 +280,13 @@ if [ -n "$TRANSCRIPT_PATH" ]; then
     DURATION_MS=$(echo "$STATS" | cut -d'|' -f4)
     CACHE_READ_TOKENS=$(echo "$STATS" | cut -d'|' -f5)
     CACHE_CREATION_TOKENS=$(echo "$STATS" | cut -d'|' -f6)
-    printf '{"ts":"%s","kind":"agent-runs-stats-parsed","task_id":%s,"tokens_total":%s,"cache_read":%s,"cache_creation":%s,"tool_uses":%s,"duration_ms":%s,"transcript":"%s"}\n' \
-      "$ts" "$TASK_ID" "$((TOKENS_IN + TOKENS_OUT))" "$CACHE_READ_TOKENS" "$CACHE_CREATION_TOKENS" "$TOOL_USES" "$DURATION_MS" "$TRANSCRIPT_PATH" \
-      >> "${HOME}/.claude/${PLUGIN_NAME}/logs/mcp-health.log" || true
+    jq -cn --arg ts "$ts" --argjson tid "$TASK_ID" \
+      --argjson tt "$((TOKENS_IN + TOKENS_OUT))" \
+      --argjson cr "$CACHE_READ_TOKENS" --argjson cc "$CACHE_CREATION_TOKENS" \
+      --argjson tu "$TOOL_USES" --argjson dm "$DURATION_MS" \
+      --arg tr "$TRANSCRIPT_PATH" \
+      '{ts:$ts,kind:"agent-runs-stats-parsed",task_id:$tid,tokens_total:$tt,cache_read:$cr,cache_creation:$cc,tool_uses:$tu,duration_ms:$dm,transcript:$tr}' \
+      >> "$_LOG_FILE" 2>/dev/null || true
   fi
 fi
 
@@ -273,18 +309,21 @@ fi
 
 AR_INSERT="INSERT INTO agent_runs (task_id, issue_id, agent_type, tokens_in, tokens_out, tokens_total, cache_read_tokens, cache_creation_tokens, tool_uses, duration_ms, completed_at) VALUES (${TASK_ID}, ${AR_ISSUE_FRAGMENT}, '${AGENT_TYPE}', ${TOKENS_IN}, ${TOKENS_OUT}, ${TOKENS_TOTAL}, ${CACHE_READ_TOKENS}, ${CACHE_CREATION_TOKENS}, ${TOOL_USES}, ${DURATION_MS}, datetime('now'));"
 sqlite3 "$DB" "$AR_INSERT" 2>/dev/null || \
-  printf '{"ts":"%s","kind":"agent-runs-capture-skipped","reason":"sqlite3 insert failed","task_id":%s}\n' \
-    "$ts" "$TASK_ID" >> "${HOME}/.claude/${PLUGIN_NAME}/logs/mcp-health.log" || true
+  jq -cn --arg ts "$ts" --argjson tid "$TASK_ID" \
+    '{ts:$ts,kind:"agent-runs-capture-skipped",reason:"sqlite3 insert failed",task_id:$tid}' \
+    >> "$_LOG_FILE" 2>/dev/null || true
 
 # Log the decision.
 if [ "$DECISION" = "auto-completed" ] || [ "$DECISION" = "auto-complete-failed" ]; then
-  printf '{"ts":"%s","kind":"swe-atomic-close","task_id":%s,"branch":"%s","decision":"%s","commit_sha":"%s"}\n' \
-    "$ts" "$TASK_ID" "$BRANCH" "$DECISION" "$WT_HEAD" \
-    >> "${HOME}/.claude/${PLUGIN_NAME}/logs/mcp-health.log" || true
+  jq -cn --arg ts "$ts" --argjson tid "$TASK_ID" --arg br "$BRANCH" \
+    --arg dec "$DECISION" --arg sha "$WT_HEAD" \
+    '{ts:$ts,kind:"swe-atomic-close",task_id:$tid,branch:$br,decision:$dec,commit_sha:$sha}' \
+    >> "$_LOG_FILE" 2>/dev/null || true
 else
-  printf '{"ts":"%s","kind":"swe-atomic-close","task_id":%s,"branch":"%s","decision":"%s","worktree":"%s"}\n' \
-    "$ts" "$TASK_ID" "$BRANCH" "$DECISION" "$WT_PATH" \
-    >> "${HOME}/.claude/${PLUGIN_NAME}/logs/mcp-health.log" || true
+  jq -cn --arg ts "$ts" --argjson tid "$TASK_ID" --arg br "$BRANCH" \
+    --arg dec "$DECISION" --arg wt "$WT_PATH" \
+    '{ts:$ts,kind:"swe-atomic-close",task_id:$tid,branch:$br,decision:$dec,worktree:$wt}' \
+    >> "$_LOG_FILE" 2>/dev/null || true
 fi
 
 if [ -n "$CONTEXT" ]; then

--- a/tests/l3-integration/hooks/git-push-guard-bro-skip-detection.test.sh
+++ b/tests/l3-integration/hooks/git-push-guard-bro-skip-detection.test.sh
@@ -106,7 +106,7 @@ set_pr_target "$db" "dev"
 insert_closed_task "$db" "$COMMIT_SHA"
 # No validation_attempts row — simulates bro skipping pr-reviewer
 out=$(run_hook "git push -u origin chore/audit-fix-42" "$db")
-assert_contains "$out" '"decision":"block"' "push without pr-reviewer verdict must be blocked"
+assert_contains "$out" '"permissionDecision":"deny"' "push without pr-reviewer verdict must be blocked"
 assert_contains "$out" "task_id=42" "block message must name the unsigned task"
 assert_contains "$out" "review before push" "block message must direct to review path"
 cleanup
@@ -118,7 +118,7 @@ set_pr_target "$db" "dev"
 insert_closed_task "$db" "$COMMIT_SHA"
 sign_task "$db" 42
 out=$(run_hook "git push -u origin chore/audit-fix-42" "$db")
-assert_not_contains "$out" '"decision":"block"' "push with pr-reviewer pass verdict must be allowed"
+assert_not_contains "$out" '"permissionDecision":"deny"' "push with pr-reviewer pass verdict must be allowed"
 cleanup
 
 test_case "!2899 regression: multiple unsigned tasks on new branch — all blocked"
@@ -141,7 +141,7 @@ sqlite3 "$db" "
 " >/dev/null
 # Neither signed
 out=$(run_hook "git push -u origin chore/audit-fix-42" "$db")
-assert_contains "$out" '"decision":"block"' "multiple unsigned tasks must block"
+assert_contains "$out" '"permissionDecision":"deny"' "multiple unsigned tasks must block"
 assert_contains "$out" "task_id=42" "must list task 42"
 assert_contains "$out" "task_id=43" "must list task 43"
 cleanup

--- a/tests/l3-integration/hooks/git-push-guard-first-push.test.sh
+++ b/tests/l3-integration/hooks/git-push-guard-first-push.test.sh
@@ -114,7 +114,7 @@ set_pr_target "$db" "dev"
 insert_task "$db" 1 "$FEATURE_SHA"
 # task NOT signed — hook must block
 out=$(run_hook "git push -u origin feat/my-feature" "$db")
-assert_contains "$out" '"decision":"block"' "first push of unsigned task must be blocked"
+assert_contains "$out" '"permissionDecision":"deny"' "first push of unsigned task must be blocked"
 assert_contains "$out" "task_id=1" "block message must list the unsigned task"
 cleanup
 
@@ -125,7 +125,7 @@ set_pr_target "$db" "dev"
 insert_task "$db" 1 "$FEATURE_SHA"
 sign_task   "$db" 1
 out=$(run_hook "git push -u origin feat/my-feature" "$db")
-assert_not_contains "$out" '"decision":"block"' "first push with pass verdict must be allowed"
+assert_not_contains "$out" '"permissionDecision":"deny"' "first push with pass verdict must be allowed"
 cleanup
 
 test_case "first-push with no task row: ALLOWED (untracked commit, TMB not managing it)"
@@ -134,13 +134,13 @@ db=$(setup_db "$REPO_PATH")
 set_pr_target "$db" "dev"
 # no task row at all
 out=$(run_hook "git push -u origin feat/my-feature" "$db")
-assert_not_contains "$out" '"decision":"block"' "untracked first push must be allowed"
+assert_not_contains "$out" '"permissionDecision":"deny"' "untracked first push must be allowed"
 cleanup
 
 test_case "first-push with no DB: ALLOWED (TMB not active)"
 setup_first_push_repo
 out=$(run_hook "git push -u origin feat/my-feature" "/nonexistent.db")
-assert_not_contains "$out" '"decision":"block"' "missing DB must not block first push"
+assert_not_contains "$out" '"permissionDecision":"deny"' "missing DB must not block first push"
 cleanup
 
 test_case "first-push: schema-default pr_target='main' is used when not overridden in plugin_config"
@@ -153,7 +153,7 @@ db=$(setup_db "$REPO_PATH")
 insert_task "$db" 1 "$FEATURE_SHA"
 out=$(run_hook "git push -u origin feat/my-feature" "$db")
 # origin/main doesn't exist so git log fails gracefully, PUSH_SHAS empty, exits 0
-assert_not_contains "$out" '"decision":"block"' "when origin/pr_target doesn't exist, hook allows (no range to check)"
+assert_not_contains "$out" '"permissionDecision":"deny"' "when origin/pr_target doesn't exist, hook allows (no range to check)"
 cleanup
 
 summarize

--- a/tests/l3-integration/hooks/git-push-guard.test.sh
+++ b/tests/l3-integration/hooks/git-push-guard.test.sh
@@ -109,7 +109,7 @@ cleanup() {
 test_case "non-push command passes through silently"
 setup_repo
 out=$(run_hook "git status")
-assert_not_contains "$out" '"decision":"block"' "git status should not be gated"
+assert_not_contains "$out" '"permissionDecision":"deny"' "git status should not be gated"
 cleanup
 
 test_case "git push --force is delegated to git-guards (this hook allows)"
@@ -117,7 +117,7 @@ setup_repo
 db=$(setup_db "$REPO_PATH")
 insert_task "$db" 1 "$SHA1"  # unsigned task — would block normally
 out=$(run_hook "git push --force origin main" "$db")
-assert_not_contains "$out" '"decision":"block"' "force push should be deferred to git-guards"
+assert_not_contains "$out" '"permissionDecision":"deny"' "force push should be deferred to git-guards"
 cleanup
 
 test_case "git push -f is delegated to git-guards (this hook allows)"
@@ -125,13 +125,13 @@ setup_repo
 db=$(setup_db "$REPO_PATH")
 insert_task "$db" 1 "$SHA1"
 out=$(run_hook "git push -f origin main" "$db")
-assert_not_contains "$out" '"decision":"block"' "force push (-f) should be deferred"
+assert_not_contains "$out" '"permissionDecision":"deny"' "force push (-f) should be deferred"
 cleanup
 
 test_case "no DB: TMB not tracking, push allowed"
 setup_repo
 out=$(run_hook "git push origin main" "/nonexistent.db")
-assert_not_contains "$out" '"decision":"block"' "missing DB should not block"
+assert_not_contains "$out" '"permissionDecision":"deny"' "missing DB should not block"
 cleanup
 
 test_case "no upstream new commits: nothing to gate, allowed"
@@ -140,7 +140,7 @@ db=$(setup_db "$REPO_PATH")
 # Reset HEAD to upstream so @{u}..HEAD is empty
 (cd "$REPO_PATH" && git reset -q --hard origin/main)
 out=$(run_hook "git push origin main" "$db")
-assert_not_contains "$out" '"decision":"block"' "no new commits should not block"
+assert_not_contains "$out" '"permissionDecision":"deny"' "no new commits should not block"
 cleanup
 
 test_case "push with untracked commits (no matching task row): allowed"
@@ -148,7 +148,7 @@ setup_repo
 db=$(setup_db "$REPO_PATH")
 # DB exists but no task row references SHA1 / SHA2 — these commits are pre-TMB
 out=$(run_hook "git push origin main" "$db")
-assert_not_contains "$out" '"decision":"block"' "untracked commits should not block"
+assert_not_contains "$out" '"permissionDecision":"deny"' "untracked commits should not block"
 cleanup
 
 test_case "push with all-signed tracked commits: allowed"
@@ -159,7 +159,7 @@ sign_task   "$db" 1
 insert_task "$db" 2 "$SHA2"
 sign_task   "$db" 2
 out=$(run_hook "git push origin main" "$db")
-assert_not_contains "$out" '"decision":"block"' "all-signed should not block"
+assert_not_contains "$out" '"permissionDecision":"deny"' "all-signed should not block"
 cleanup
 
 test_case "push with one unsigned tracked commit: BLOCKED with helpful reason"
@@ -170,7 +170,7 @@ sign_task   "$db" 1
 insert_task "$db" 2 "$SHA2"
 # task 2 NOT signed
 out=$(run_hook "git push origin main" "$db")
-assert_contains "$out" '"decision":"block"' "unsigned commit must block"
+assert_contains "$out" '"permissionDecision":"deny"' "unsigned commit must block"
 assert_contains "$out" "review before push"   "block message must mention bro review path"
 assert_contains "$out" "task_id=2"            "block message must list the unsigned task"
 cleanup
@@ -182,7 +182,7 @@ insert_task "$db" 1 "$SHA1"
 insert_task "$db" 2 "$SHA2"
 # neither signed
 out=$(run_hook "git push origin main" "$db")
-assert_contains "$out" '"decision":"block"' "unsigned commits must block"
+assert_contains "$out" '"permissionDecision":"deny"' "unsigned commits must block"
 assert_contains "$out" "task_id=1"           "should list task 1"
 assert_contains "$out" "task_id=2"           "should list task 2"
 cleanup
@@ -194,7 +194,7 @@ insert_task "$db" 1 "$SHA1"
 sign_task   "$db" 1
 insert_task "$db" 2 "$SHA2"
 out=$(run_hook "git push origin main" "$db")
-assert_contains "$out" '"decision":"block"'  "mixed should block on unsigned"
+assert_contains "$out" '"permissionDecision":"deny"'  "mixed should block on unsigned"
 assert_contains "$out" "task_id=2"           "should list ONLY the unsigned task 2"
 assert_not_contains "$out" "task_id=1 "      "signed task 1 should not appear in block list"
 cleanup
@@ -217,7 +217,7 @@ sign_task   "$db" 1
 insert_task "$db" 2 "$SHA2"
 sign_task   "$db" 2
 out=$(run_hook_as_swe "git push origin main" "$db" "tmb:swe")
-assert_contains "$out" '"decision":"block"' "SWE push must be blocked even with all-signed commits"
+assert_contains "$out" '"permissionDecision":"deny"' "SWE push must be blocked even with all-signed commits"
 assert_contains "$out" "SWE must never push"  "block message must reference swe.md rule"
 cleanup
 
@@ -225,14 +225,14 @@ test_case "SWE caller (swe): git push BLOCKED (bare agent_type variant)"
 setup_repo
 db=$(setup_db "$REPO_PATH")
 out=$(run_hook_as_swe "git push origin main" "/nonexistent.db" "swe")
-assert_contains "$out" '"decision":"block"' "bare swe agent_type must also be blocked"
+assert_contains "$out" '"permissionDecision":"deny"' "bare swe agent_type must also be blocked"
 cleanup
 
 test_case "SWE caller: git push --force still exits early (force delegated to git-guards before SWE check)"
 setup_repo
 db=$(setup_db "$REPO_PATH")
 out=$(run_hook_as_swe "git push --force origin main" "$db" "tmb:swe")
-assert_not_contains "$out" '"decision":"block"' "force push exits before SWE check (git-guards handles it)"
+assert_not_contains "$out" '"permissionDecision":"deny"' "force push exits before SWE check (git-guards handles it)"
 cleanup
 
 test_case "non-SWE caller: git push NOT blocked by SWE check (bro/regular-claude)"
@@ -243,7 +243,7 @@ sign_task   "$db" 1
 insert_task "$db" 2 "$SHA2"
 sign_task   "$db" 2
 out=$(run_hook "git push origin main" "$db")
-assert_not_contains "$out" '"decision":"block"' "non-SWE caller with all-signed should not be blocked"
+assert_not_contains "$out" '"permissionDecision":"deny"' "non-SWE caller with all-signed should not be blocked"
 cleanup
 
 # ----- worktree-path push detection tests (audit item 14) ----------------
@@ -267,7 +267,7 @@ sign_task   "$db" 1
 insert_task "$db" 2 "$SHA2"
 sign_task   "$db" 2
 out=$(run_hook_from_worktree_cmd "cd $REPO_PATH/.claude/worktrees/feat-x && git push origin feat/x" "$db")
-assert_contains "$out" '"decision":"block"' "push from worktree cd prefix must block even without agent_type"
+assert_contains "$out" '"permissionDecision":"deny"' "push from worktree cd prefix must block even without agent_type"
 assert_contains "$out" ".claude/worktrees/" "block message must reference worktree path"
 cleanup
 
@@ -277,7 +277,7 @@ db=$(setup_db "$REPO_PATH")
 insert_task "$db" 1 "$SHA1"
 sign_task   "$db" 1
 out=$(run_hook_from_worktree_cmd "git -C $REPO_PATH/.claude/worktrees/feat-x push origin feat/x" "$db")
-assert_contains "$out" '"decision":"block"' "push via git -C worktree path must block"
+assert_contains "$out" '"permissionDecision":"deny"' "push via git -C worktree path must block"
 cleanup
 
 test_case "normal push from main checkout (no worktree in cmd): NOT blocked by worktree check"
@@ -288,7 +288,7 @@ sign_task   "$db" 1
 insert_task "$db" 2 "$SHA2"
 sign_task   "$db" 2
 out=$(run_hook_from_worktree_cmd "git push origin main" "$db")
-assert_not_contains "$out" '"decision":"block"' "normal push from main checkout must not be blocked by worktree check"
+assert_not_contains "$out" '"permissionDecision":"deny"' "normal push from main checkout must not be blocked by worktree check"
 cleanup
 
 # ----- $PWD vs `cd` override tests --------------------------------------
@@ -318,7 +318,7 @@ out=$(run_hook_with_pwd \
   "cd $REPO_PATH && git push origin main" \
   "$db" \
   "$REPO_PATH/.claude/worktrees/feat-x")
-assert_not_contains "$out" '"decision":"block"' \
+assert_not_contains "$out" '"permissionDecision":"deny"' \
   "cd to non-worktree path should override stale worktree PWD"
 cleanup
 
@@ -329,7 +329,7 @@ insert_task "$db" 1 "$SHA1"
 sign_task   "$db" 1
 mkdir -p "$REPO_PATH/.claude/worktrees/feat-x"
 out=$(run_hook_with_pwd "git push origin main" "$db" "$REPO_PATH/.claude/worktrees/feat-x")
-assert_contains "$out" '"decision":"block"' \
+assert_contains "$out" '"permissionDecision":"deny"' \
   "plain push with PWD-in-worktree must still block (legitimate worktree push)"
 cleanup
 
@@ -343,7 +343,7 @@ out=$(run_hook_with_pwd \
   "cd $REPO_PATH/.claude/worktrees/feat-x && git push origin feat/x" \
   "$db" \
   "$REPO_PATH")
-assert_contains "$out" '"decision":"block"' \
+assert_contains "$out" '"permissionDecision":"deny"' \
   "cd into worktree should block even when PWD is main"
 cleanup
 
@@ -356,31 +356,31 @@ cleanup
 test_case "false-positive: grep for 'git push' in a file — NOT blocked"
 setup_repo
 out=$(run_hook "grep \"git push\" tests/l1-lint/something.sh")
-assert_not_contains "$out" '"decision":"block"' "grep for 'git push' must not be detected as a push"
+assert_not_contains "$out" '"permissionDecision":"deny"' "grep for 'git push' must not be detected as a push"
 cleanup
 
 test_case "false-positive: echo mentioning 'git push' — NOT blocked"
 setup_repo
 out=$(run_hook "echo \"Don't forget to git push\"")
-assert_not_contains "$out" '"decision":"block"' "echo mentioning 'git push' must not be detected as a push"
+assert_not_contains "$out" '"permissionDecision":"deny"' "echo mentioning 'git push' must not be detected as a push"
 cleanup
 
 test_case "false-positive: cat pipe grep for 'git push' — NOT blocked"
 setup_repo
 out=$(run_hook "cat docs/git-conventions.md | grep \"git push\"")
-assert_not_contains "$out" '"decision":"block"' "cat|grep 'git push' must not be detected as a push"
+assert_not_contains "$out" '"permissionDecision":"deny"' "cat|grep 'git push' must not be detected as a push"
 cleanup
 
 test_case "false-positive: git log --grep='git push' — NOT blocked"
 setup_repo
 out=$(run_hook "git log --grep=\"git push\"")
-assert_not_contains "$out" '"decision":"block"' "git log --grep='git push' must not be detected as a push"
+assert_not_contains "$out" '"permissionDecision":"deny"' "git log --grep='git push' must not be detected as a push"
 cleanup
 
 test_case "false-positive: git commit -m mentioning 'git push' — NOT blocked"
 setup_repo
 out=$(run_hook "git commit -m \"fix: make git push idempotent\"")
-assert_not_contains "$out" '"decision":"block"' "commit message mentioning 'git push' must not be detected as a push"
+assert_not_contains "$out" '"permissionDecision":"deny"' "commit message mentioning 'git push' must not be detected as a push"
 cleanup
 
 # ----- positive regression tests (IS_PUSH MUST trigger) -----------------
@@ -396,31 +396,31 @@ cleanup
 test_case "positive: 'git push origin main' — IS_PUSH triggers (SWE blocked)"
 setup_repo
 out=$(run_hook_as_swe "git push origin main" "/nonexistent.db" "tmb:swe")
-assert_contains "$out" '"decision":"block"' "plain git push must be detected as a push and blocked for SWE"
+assert_contains "$out" '"permissionDecision":"deny"' "plain git push must be detected as a push and blocked for SWE"
 cleanup
 
 test_case "positive: 'git -C /some/path push origin feature' — IS_PUSH triggers (SWE blocked)"
 setup_repo
 out=$(run_hook_as_swe "git -C /some/path push origin feature" "/nonexistent.db" "tmb:swe")
-assert_contains "$out" '"decision":"block"' "git -C push must be detected as a push and blocked for SWE"
+assert_contains "$out" '"permissionDecision":"deny"' "git -C push must be detected as a push and blocked for SWE"
 cleanup
 
 test_case "positive: 'cd /repo && git push' — IS_PUSH triggers (SWE blocked)"
 setup_repo
 out=$(run_hook_as_swe "cd /repo && git push" "/nonexistent.db" "tmb:swe")
-assert_contains "$out" '"decision":"block"' "cd && git push must be detected as a push and blocked for SWE"
+assert_contains "$out" '"permissionDecision":"deny"' "cd && git push must be detected as a push and blocked for SWE"
 cleanup
 
 test_case "positive: 'git status; git push' — IS_PUSH triggers (SWE blocked)"
 setup_repo
 out=$(run_hook_as_swe "git status; git push" "/nonexistent.db" "tmb:swe")
-assert_contains "$out" '"decision":"block"' "semicolon-separated git push must be detected and blocked for SWE"
+assert_contains "$out" '"permissionDecision":"deny"' "semicolon-separated git push must be detected and blocked for SWE"
 cleanup
 
 test_case "positive: 'make build || git push' — IS_PUSH triggers (SWE blocked)"
 setup_repo
 out=$(run_hook_as_swe "make build || git push" "/nonexistent.db" "tmb:swe")
-assert_contains "$out" '"decision":"block"' "|| git push must be detected as a push and blocked for SWE"
+assert_contains "$out" '"permissionDecision":"deny"' "|| git push must be detected as a push and blocked for SWE"
 cleanup
 
 summarize

--- a/tests/l3-integration/hooks/normalize-role-prefix.test.sh
+++ b/tests/l3-integration/hooks/normalize-role-prefix.test.sh
@@ -26,7 +26,7 @@ sqlite3 "$DB_RTS" "
 test_case "require-task-spec: tmb:swe prefix is treated as swe (blocked without task_id)"
 out=$(echo '{"tool_input":{"subagent_type":"tmb:swe","prompt":"do the thing"}}' \
   | TRAJECTORY_DB_PATH="$DB_RTS" bash "$HOOK_RTS" 2>&1 || true)
-assert_contains "$out" '"decision":"block"' "tmb:swe without task_id must be blocked"
+assert_contains "$out" '"permissionDecision":"deny"' "tmb:swe without task_id must be blocked"
 assert_contains "$out" "SWE spawn requires task_id" "block reason cites missing task_id"
 
 test_case "require-task-spec: tmb:swe prefix with valid task passes silently"

--- a/tests/l3-integration/hooks/require-feature-branch-active.test.sh
+++ b/tests/l3-integration/hooks/require-feature-branch-active.test.sh
@@ -87,7 +87,7 @@ db=$(setup_db "$REPO_PATH")
 insert_task "$db" 1 "fix/1-foo"
 payload=$(make_payload "swe" "task_id=1 You are SWE.")
 out=$(run_hook "$payload" "$db")
-assert_not_contains "$out" '"decision":"block"' "branch exists (main stays on base) must not be blocked"
+assert_not_contains "$out" '"permissionDecision":"deny"' "branch exists (main stays on base) must not be blocked"
 cleanup
 
 test_case "branch missing blocks: task expects fix/1-foo but it was never created"
@@ -96,7 +96,7 @@ db=$(setup_db "$REPO_PATH")
 insert_task "$db" 1 "fix/1-foo"
 payload=$(make_payload "swe" "task_id=1 You are SWE.")
 out=$(run_hook "$payload" "$db")
-assert_contains "$out" '"decision":"block"' "missing branch must produce block decision"
+assert_contains "$out" '"permissionDecision":"deny"' "missing branch must produce deny decision"
 assert_contains "$out" "fix/1-foo" "block message must name the expected branch"
 assert_contains "$out" "exist" "block message must say the branch must exist"
 cleanup
@@ -107,7 +107,7 @@ db=$(setup_db "$REPO_PATH")
 insert_task "$db" 1 "fix/1-foo"
 payload=$(make_payload "architect" "task_id=1 You are architect.")
 out=$(run_hook "$payload" "$db")
-assert_not_contains "$out" '"decision":"block"' "non-swe agent must not be blocked"
+assert_not_contains "$out" '"permissionDecision":"deny"' "non-swe agent must not be blocked"
 cleanup
 
 test_case "no task_id in prompt passes: require-task-spec.sh handles it"
@@ -116,14 +116,14 @@ db=$(setup_db "$REPO_PATH")
 insert_task "$db" 1 "fix/1-foo"
 payload=$(make_payload "swe" "You are SWE but no task_id here.")
 out=$(run_hook "$payload" "$db")
-assert_not_contains "$out" '"decision":"block"' "missing task_id must not be blocked by this hook"
+assert_not_contains "$out" '"permissionDecision":"deny"' "missing task_id must not be blocked by this hook"
 cleanup
 
 test_case "missing DB passes: not a TMB project"
 setup_repo "dev"
 payload=$(make_payload "swe" "task_id=1 You are SWE.")
 out=$(run_hook "$payload" "/nonexistent/trajectory.db")
-assert_not_contains "$out" '"decision":"block"' "missing DB must not block"
+assert_not_contains "$out" '"permissionDecision":"deny"' "missing DB must not block"
 cleanup
 
 test_case "bypass env var passes: TMB_ALLOW_BRANCH_MISMATCH=1 overrides block"
@@ -135,7 +135,7 @@ out=$(
   cd "$REPO_PATH" || exit 1
   echo "$payload" | TRAJECTORY_DB_PATH="$db" TMB_ALLOW_BRANCH_MISMATCH=1 bash "$HOOK" 2>&1 || true
 )
-assert_not_contains "$out" '"decision":"block"' "bypass env var must suppress block even on mismatch"
+assert_not_contains "$out" '"permissionDecision":"deny"' "bypass env var must suppress block even on mismatch"
 cleanup
 
 test_case "TMB workspace shape: tasks.repo=null + tmb_default_repo='plugin' + branch exists → passes"
@@ -165,7 +165,7 @@ sqlite3 "$WS_DB" "
 REPO_PATH="$INNER_REPO"
 payload=$(make_payload "swe" "task_id=10 You are SWE.")
 out=$(run_hook "$payload" "$WS_DB")
-assert_not_contains "$out" '"decision":"block"' "TMB workspace shape with default_repo set + branch exists must not block"
+assert_not_contains "$out" '"permissionDecision":"deny"' "TMB workspace shape with default_repo set + branch exists must not block"
 rm -rf "$WORKSPACE"
 REPO_PATH=""
 
@@ -194,7 +194,7 @@ sqlite3 "$WS_DB" "
 REPO_PATH="$WORKSPACE"
 payload=$(make_payload "swe" "task_id=11 You are SWE.")
 out=$(run_hook "$payload" "$WS_DB")
-assert_contains "$out" '"decision":"block"' "TMB workspace with no default_repo and no .git at workspace root must block"
+assert_contains "$out" '"permissionDecision":"deny"' "TMB workspace with no default_repo and no .git at workspace root must block"
 assert_contains "$out" "tmb_default_repo" "block message must mention tmb_default_repo config key"
 assert_contains "$out" "config_set" "block message must suggest config_set remedy"
 rm -rf "$WORKSPACE"

--- a/tests/l3-integration/hooks/require-task-spec.test.sh
+++ b/tests/l3-integration/hooks/require-task-spec.test.sh
@@ -52,27 +52,27 @@ assert_eq "" "$out" "hook output for non-SWE"
 
 test_case "SWE without task_id token in prompt is blocked"
 out=$(run_hook "$(swe_input 'please do the thing')")
-assert_contains "$out" '"decision":"block"' "block decision"
+assert_contains "$out" '"permissionDecision":"deny"' "permissionDecision deny"
 assert_contains "$out" "SWE spawn requires task_id" "reason cites missing task_id"
 
 test_case "SWE with task_id for nonexistent row is blocked"
 out=$(run_hook "$(swe_input 'task_id=9999 please do the thing')")
-assert_contains "$out" '"decision":"block"' "block decision"
+assert_contains "$out" '"permissionDecision":"deny"' "permissionDecision deny"
 assert_contains "$out" "does not exist in the tasks table" "reason cites missing row"
 
 test_case "SWE with task_id referencing a completed task is blocked"
 out=$(run_hook "$(swe_input 'task_id=4 please do the thing')")
-assert_contains "$out" '"decision":"block"' "block decision"
-assert_contains "$out" "has status='completed'" "reason cites wrong status"
+assert_contains "$out" '"permissionDecision":"deny"' "permissionDecision deny"
+assert_contains "$out" "status=completed" "reason cites wrong status"
 
 test_case "SWE with task_id referencing an in_progress task is blocked"
 out=$(run_hook "$(swe_input 'task_id=5 please do the thing')")
-assert_contains "$out" '"decision":"block"' "block decision"
-assert_contains "$out" "has status='in_progress'" "reason cites wrong status"
+assert_contains "$out" '"permissionDecision":"deny"' "permissionDecision deny"
+assert_contains "$out" "status=in_progress" "reason cites wrong status"
 
 test_case "SWE with pending task that has empty spec_body is blocked"
 out=$(run_hook "$(swe_input 'task_id=2 please do the thing')")
-assert_contains "$out" '"decision":"block"' "block decision"
+assert_contains "$out" '"permissionDecision":"deny"' "permissionDecision deny"
 assert_contains "$out" "has empty spec_body" "reason cites missing body"
 
 test_case "SWE with pending task and non-empty body passes silently"
@@ -89,7 +89,7 @@ assert_eq "" "$out" "first token is valid -> passes"
 
 test_case "missing trajectory.db is blocked with clear reason"
 out=$(run_hook_env "$(swe_input 'task_id=1')" "TRAJECTORY_DB_PATH" "$TMPDIR/nonexistent.db")
-assert_contains "$out" '"decision":"block"' "block decision"
+assert_contains "$out" '"permissionDecision":"deny"' "permissionDecision deny"
 assert_contains "$out" "trajectory.db not found" "reason cites missing DB"
 
 summarize

--- a/tests/l3-integration/hooks/session-log-capture.test.sh
+++ b/tests/l3-integration/hooks/session-log-capture.test.sh
@@ -27,13 +27,11 @@ run_hook() {
 
 # ---- happy path ----
 
-test_case "creates log file and appends JSONL event line"
+test_case "creates log file and appends JSONL event line (stdin session_id)"
 WS="$TMPDIR/ws1"
 setup_workspace "$WS"
-SENTINEL="$WS/.claude/tmb/.current-session-id"
-printf 'test-session-001' > "$SENTINEL"
 
-INPUT='{"prompt":"hello world","additionalContext":"some ctx"}'
+INPUT='{"prompt":"hello world","additionalContext":"some ctx","session_id":"test-session-001"}'
 out=$(run_hook "$INPUT")
 assert_contains "$out" '"continue": true' "emits continue"
 
@@ -50,33 +48,42 @@ assert_contains "$LINE" '"ts"' "timestamp field present"
 test_case "appends multiple lines on repeated invocation"
 WS="$TMPDIR/ws2"
 setup_workspace "$WS"
-SENTINEL="$WS/.claude/tmb/.current-session-id"
-printf 'test-session-002' > "$SENTINEL"
 
-run_hook '{"prompt":"first"}' >/dev/null
-run_hook '{"prompt":"second"}' >/dev/null
+run_hook '{"prompt":"first","session_id":"test-session-002"}' >/dev/null
+run_hook '{"prompt":"second","session_id":"test-session-002"}' >/dev/null
 
 TODAY=$(date -u +%Y-%m-%d)
 LOG="$WS/.claude/tmb/logs/${TODAY}-test-session-002.jsonl"
 LINE_COUNT=$(wc -l < "$LOG" | tr -d ' ')
 assert_eq "2" "$LINE_COUNT" "two lines in log"
 
-test_case "auto-creates session sentinel if missing"
+test_case "falls back to sentinel file when no session_id on stdin"
 WS="$TMPDIR/ws3"
+setup_workspace "$WS"
+SENTINEL="$WS/.claude/tmb/.current-session-id"
+printf 'sentinel-session-003' > "$SENTINEL"
+
+run_hook '{"prompt":"sentinel fallback"}' >/dev/null
+
+TODAY=$(date -u +%Y-%m-%d)
+LOG="$WS/.claude/tmb/logs/${TODAY}-sentinel-session-003.jsonl"
+if [ -f "$LOG" ]; then _pass; else _fail "log file not found at $LOG using sentinel session_id"; fi
+
+test_case "generates fallback session_id when neither stdin nor sentinel available"
+WS="$TMPDIR/ws4"
 setup_workspace "$WS"
 SENTINEL="$WS/.claude/tmb/.current-session-id"
 [ ! -f "$SENTINEL" ] || rm "$SENTINEL"
 
 run_hook '{"prompt":"auto session"}' >/dev/null
 
-[ -f "$SENTINEL" ] || { echo "FAIL: sentinel not created"; exit 1; }
-SESSION_ID=$(cat "$SENTINEL")
-[ -n "$SESSION_ID" ] || { echo "FAIL: sentinel is empty"; exit 1; }
-
 TODAY=$(date -u +%Y-%m-%d)
-LOG="$WS/.claude/tmb/logs/${TODAY}-${SESSION_ID}.jsonl"
-[ -f "$LOG" ] || { echo "FAIL: log file not found at $LOG"; exit 1; }
-echo "  sentinel=$SESSION_ID"
+LOG_COUNT=$(ls "$WS/.claude/tmb/logs/${TODAY}-"*.jsonl 2>/dev/null | wc -l | tr -d ' ')
+if [ "$LOG_COUNT" -ge 1 ]; then
+  _pass
+else
+  _fail "no log file created for auto-generated session_id"
+fi
 
 # ---- no-op path ----
 

--- a/tests/l3-integration/hooks/swe-atomic-close.test.sh
+++ b/tests/l3-integration/hooks/swe-atomic-close.test.sh
@@ -563,4 +563,76 @@ assert_contains "$out" "stopped without committing" "warn body present"
 nw3_status=$(sqlite3 "$NW3_DB" "SELECT status FROM tasks WHERE id=102;")
 assert_eq "pending" "$nw3_status" "task stays pending"
 
+# ========================================================
+# #202 / #369: transcript-based task_id extraction prevents
+# wrong-task auto-close when two SWEs run in parallel.
+# SWE-A commits but never calls task_update_status. On SubagentStop,
+# the hook extracts task_id from the transcript and auto-completes
+# the correct task (not the most-recently-updated OTHER task).
+# ========================================================
+
+echo '--- Test: #202/#369: transcript task_id extraction targets the correct task ---'
+
+PARALLEL_REPO="$TMPDIR/parallel-repo"
+git init -q -b dev "$PARALLEL_REPO"
+git -C "$PARALLEL_REPO" config user.email t@t.io
+git -C "$PARALLEL_REPO" config user.name t
+echo base > "$PARALLEL_REPO/base.txt"
+git -C "$PARALLEL_REPO" add .
+git -C "$PARALLEL_REPO" commit -qm "base"
+
+PAR_DB="$PARALLEL_REPO/.claude/tmb/trajectory.db"
+mkdir -p "$(dirname "$PAR_DB")"
+sqlite3 "$PAR_DB" "
+  CREATE TABLE tasks (id INTEGER PRIMARY KEY, issue_id INTEGER NOT NULL DEFAULT 1, branch_id TEXT NOT NULL, parent_branch_id TEXT, title TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'pending', attempts INTEGER NOT NULL DEFAULT 0, spec_body TEXT NOT NULL DEFAULT '', commit_sha TEXT, repo TEXT, created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')), completed_at TEXT);
+  CREATE TABLE repos (name TEXT PRIMARY KEY, path TEXT NOT NULL, file_count INTEGER NOT NULL DEFAULT 0, last_scanned_at TEXT NOT NULL DEFAULT '');
+  CREATE TABLE agent_runs (id INTEGER PRIMARY KEY AUTOINCREMENT, task_id INTEGER NOT NULL, issue_id INTEGER, agent_type TEXT NOT NULL DEFAULT 'swe', tokens_in INTEGER NOT NULL DEFAULT 0, tokens_out INTEGER NOT NULL DEFAULT 0, tokens_total INTEGER NOT NULL DEFAULT 0, tool_uses INTEGER NOT NULL DEFAULT 0, duration_ms INTEGER NOT NULL DEFAULT 0, completed_at TEXT NOT NULL DEFAULT (datetime('now')));
+  CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT NOT NULL DEFAULT '\"\"');
+  INSERT INTO tasks (id, branch_id, parent_branch_id, status, updated_at)
+    VALUES (200, 'fix/swe-a-task', 'dev', 'pending', datetime('now', '+1 second'));
+  INSERT INTO tasks (id, branch_id, parent_branch_id, status, updated_at)
+    VALUES (201, 'fix/swe-b-task', 'dev', 'pending', datetime('now', '+99 seconds'));
+  INSERT INTO plugin_config (key, value_json) VALUES ('pr_target', '\"dev\"');
+"
+
+# SWE-A worktree for task 200.
+git -C "$PARALLEL_REPO" branch fix/swe-a-task HEAD
+git -C "$PARALLEL_REPO" branch fix/swe-b-task HEAD
+PAR_WTA="$PARALLEL_REPO/.claude/worktrees/swe-a-task"
+PAR_WTB="$PARALLEL_REPO/.claude/worktrees/swe-b-task"
+git -C "$PARALLEL_REPO" worktree add -q "$PAR_WTA" fix/swe-a-task
+git -C "$PARALLEL_REPO" worktree add -q "$PAR_WTB" fix/swe-b-task
+
+# SWE-A commits in its worktree but forgets to call task_update_status.
+echo "swe-a work" > "$PAR_WTA/swe-a.txt"
+git -C "$PAR_WTA" add swe-a.txt
+git -C "$PAR_WTA" commit -qm "feat: swe-a work"
+PAR_WTA_HEAD=$(git -C "$PAR_WTA" rev-parse HEAD)
+
+# SWE-B is more recently updated (simulates parallel SWE-B working).
+# Without transcript-based extraction, the hook would pick task 201 (SWE-B).
+# With transcript-based extraction, it targets task 200 (SWE-A's task).
+PAR_TRANSCRIPT="$TMPDIR/par-transcript.jsonl"
+cat > "$PAR_TRANSCRIPT" <<JSONL
+{"timestamp":"2026-01-01T00:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"task_id=200 worktree=/tmp/swe-a You are SWE. Implement fix for task 200."}]}}
+{"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","usage":{"input_tokens":100,"output_tokens":50},"content":[]}}
+JSONL
+
+par_swe_input() {
+  local tp="$1"
+  jq -n --arg tp "$tp" '{agent_type:"tmb:swe",hook_event_name:"SubagentStop",agent_transcript_path:$tp}'
+}
+
+test_case "#202/#369: transcript task_id extraction: auto-completes SWE-A task (200), not most-recent (201)"
+out=$(run_hook_in_dir "$PARALLEL_REPO" "$(par_swe_input "$PAR_TRANSCRIPT")" "$PAR_DB")
+assert_eq "" "$out" "no additionalContext on auto-close"
+par_status_200=$(sqlite3 "$PAR_DB" "SELECT status FROM tasks WHERE id=200;")
+assert_eq "completed" "$par_status_200" "task 200 (SWE-A) auto-closed via transcript extraction"
+par_sha_200=$(sqlite3 "$PAR_DB" "SELECT commit_sha FROM tasks WHERE id=200;")
+assert_eq "$PAR_WTA_HEAD" "$par_sha_200" "commit_sha from SWE-A worktree written to task 200"
+
+test_case "#202/#369: task 201 (SWE-B) NOT touched by SWE-A's SubagentStop"
+par_status_201=$(sqlite3 "$PAR_DB" "SELECT status FROM tasks WHERE id=201;")
+assert_eq "pending" "$par_status_201" "task 201 (SWE-B) stays pending — not auto-closed"
+
 summarize

--- a/tests/l3-integration/hooks/worktree-create.test.sh
+++ b/tests/l3-integration/hooks/worktree-create.test.sh
@@ -186,4 +186,73 @@ assert_contains "$out" '"continue":false' "second fire still returns a worktreeP
 assert_contains "$out" '789-single' "reused path contains slug"
 assert_not_contains "$out" 'failed' "no git worktree-add failure on the second fire"
 
+# --- multi-repo: session dir is parent of repo (#330) -----------------------
+# Layout: WORKSPACE_MR/ (not a git repo — session launch dir)
+#           .claude/tmb/trajectory.db
+#           plugin/                   (the inner git repo tasks point at)
+# tasks.repo = 'plugin' — the hook must git -C plugin/ worktree add
+# and create the worktree at WORKSPACE_MR/.claude/worktrees/<slug>,
+# NOT inside the inner repo.
+
+MR_WORKSPACE="$TMPDIR/mrsession"
+MR_REPO="$MR_WORKSPACE/plugin"
+mkdir -p "$MR_REPO"
+git init -q -b main "$MR_REPO"
+git -C "$MR_REPO" config user.email t@t.io && git -C "$MR_REPO" config user.name t
+echo init > "$MR_REPO/README.md"
+git -C "$MR_REPO" add . && git -C "$MR_REPO" commit -qm init
+
+MR_DB="$MR_WORKSPACE/.claude/tmb/trajectory.db"
+mkdir -p "$(dirname "$MR_DB")"
+sqlite3 "$MR_DB" "
+  CREATE TABLE tasks (
+    id INTEGER PRIMARY KEY,
+    branch_id TEXT NOT NULL,
+    status TEXT,
+    repo TEXT
+  );
+  CREATE TABLE plugin_config (
+    key TEXT PRIMARY KEY,
+    value_json TEXT NOT NULL
+  );
+  INSERT INTO tasks (id, branch_id, status, repo)
+    VALUES (10, 'fix/330-subdir', 'pending', 'plugin');
+"
+git -C "$MR_REPO" branch fix/330-subdir HEAD
+
+run_hook_mr() {
+  echo "$1" | TRAJECTORY_DB_PATH="$MR_DB" bash "$HOOK" 2>&1
+}
+MR_WT="$MR_WORKSPACE/.claude/worktrees/330-subdir"
+
+test_case "#330: multi-repo (session dir is parent of repo subdir): worktree created"
+out=$(run_hook_mr "$(input_event 'fix/330-subdir')")
+assert_contains "$out" '"continue":false' "subdir-repo → hook creates worktree"
+assert_contains "$out" '330-subdir' "worktree path contains slug"
+if [ -d "$MR_WT" ]; then _pass; else _fail "worktree not created at $MR_WT"; fi
+
+test_case "#330: subdir-repo worktree HEAD is on the named branch"
+MR_HB=$(git -C "$MR_WT" rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [ "$MR_HB" = "fix/330-subdir" ]; then _pass; else _fail "expected HEAD on fix/330-subdir, got '$MR_HB'"; fi
+
+test_case "#330: worktree is workspace-rooted (not inside inner repo)"
+MR_INNER_WT="$MR_REPO/.claude/worktrees/330-subdir"
+if [ -d "$MR_INNER_WT" ]; then
+  _fail "worktree must NOT be created inside inner repo at $MR_INNER_WT"
+else
+  _pass
+fi
+
+test_case "#330: SWE commit in multi-repo worktree advances inner repo branch ref"
+echo "swe-330" > "$MR_WT/swe-330.txt"
+git -C "$MR_WT" add swe-330.txt
+git -C "$MR_WT" -c user.email=swe@t.io -c user.name=swe commit -qm "swe: 330 fix"
+MR_SWE_HEAD=$(git -C "$MR_WT" rev-parse HEAD)
+MR_BRANCH_TIP=$(git -C "$MR_REPO" rev-parse fix/330-subdir)
+if [ "$MR_SWE_HEAD" = "$MR_BRANCH_TIP" ]; then
+  _pass
+else
+  _fail "expected fix/330-subdir to point at worktree HEAD ($MR_SWE_HEAD); got $MR_BRANCH_TIP"
+fi
+
 summarize


### PR DESCRIPTION
Fixes #367, #368, #369, #370, #371, #372, #389, #330; Refs #202 (audit-batch B2).

- sourced libs no longer leak set -e; advisory jq guarded (PreToolUse can't hard-block on malformed input)
- sqlite read wrapper (-readonly, 500ms busy timeout); deny gates distinguish DB-busy from row-missing
- tmb_db_path memoized per process; git-push-guard gates the cd/-C target dir
- swe-atomic-close attributes by transcript task_id (parallel-SWE-safe — also the structural fix for the #202 violation, verified by a two-task test)
- pgrep scoped to this plugin's server; deferred-tools-drift portable off BSD date; session-id from stdin + 1MB log rotation + jq-escaped JSONL
- #330 adjudicated by reviewer: root cause was already fixed by #315; positive subdir-routing test added — safe to close
- legacy decision-format migrated in the 4 remaining gates
- Rider: drop unused TASK_ID in bro-turn-usage.sh (dev shellcheck breakage from the telemetry merge)

shellcheck-hooks PASS, targeted hook suites green (full runner blocked only by pre-existing #417 flake). pr-reviewer verdict: PASS (task 15, attempt 1). First SWE attempt died uncommitted; resumed and completed by a second — combined diff reviewed coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)