### PR TITLE
🐛 fix(tests): naming-lint dot extensions + bounded rescan test, hang-proof runner

### DIFF
--- a/scripts/hooks/naming-lint.sh
+++ b/scripts/hooks/naming-lint.sh
@@ -52,7 +52,7 @@ case "$TARGET" in
 esac
 
 is_snake() { echo "$1" | grep -qE '^[a-z][a-z0-9_]*$'; }
-is_kebab() { echo "$1" | grep -qE '^[a-z][a-z0-9-]*$'; }
+is_kebab() { echo "$1" | grep -qE '^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)*$'; }
 is_pascal() { echo "$1" | grep -qE '^[A-Z][A-Za-z0-9]*$'; }
 
 VIOLATION=""

--- a/tests/l3-integration/hooks/naming-lint.test.sh
+++ b/tests/l3-integration/hooks/naming-lint.test.sh
@@ -165,4 +165,25 @@ out=$(run_hook "$input")
 event=$(echo "$out" | jq -r '.hookSpecificOutput.hookEventName' 2>/dev/null || echo "")
 assert_eq "PreToolUse" "$event" "hookEventName is PreToolUse"
 
+# ──────────────────────────────────────────────────────────────
+# Case 17: double-extension .test.sh passes silently (#416)
+# ──────────────────────────────────────────────────────────────
+test_case "kebab-base .test.sh passes silently (double-extension)"
+input=$(make_write "$TMPDIR_NL/commit-msg-lint.test.sh")
+out=$(run_hook "$input")
+assert_eq "" "$out" "commit-msg-lint.test.sh produces no output"
+
+test_case "another .test.sh (naming-lint.test.sh) passes silently"
+input=$(make_write "$TMPDIR_NL/naming-lint.test.sh")
+out=$(run_hook "$input")
+assert_eq "" "$out" "naming-lint.test.sh produces no output"
+
+# ──────────────────────────────────────────────────────────────
+# Case 18: bad base before .test.sh still triggers advisory (#416)
+# ──────────────────────────────────────────────────────────────
+test_case "snake_case before .test.sh emits advisory"
+input=$(make_write "$TMPDIR_NL/my_script.test.sh")
+out=$(run_hook "$input")
+assert_contains "$out" "additionalContext" "my_script.test.sh triggers advisory"
+
 summarize

--- a/tests/l3-integration/hooks/post-task-close-rescan.test.sh
+++ b/tests/l3-integration/hooks/post-task-close-rescan.test.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$HERE/../../lib/assert.sh"
+. "$HERE/../../l5-l6/lib/timeout-shim.sh"
 PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
 INVOKER="$PLUGIN_ROOT/scripts/maintenance/run-scan.mjs"
 
@@ -55,7 +56,9 @@ test_case "rescan from worktree cwd finds ≥1 repo (session_dir walk-up)"
 # Run the invoker with cwd set to the worktree path (inner path).
 # The invoker should walk up from the worktree, find the DB at WS, derive
 # session_dir=$WS, and discover repo-a.
-OUT=$( (cd "$WT" && node --experimental-sqlite "$INVOKER" 2>&1) || true )
+# Hard timeout of 60s: if scan hangs (kuzu init, lock, git-log) the test
+# fails loudly instead of stalling the entire runner.
+OUT=$( (cd "$WT" && _l5_timeout 60 node --experimental-sqlite "$INVOKER" 2>&1) || true )
 
 # The invoker emits a summary line on stderr on success. Check for it.
 if echo "$OUT" | grep -q "\[post-close-rescan\] OK"; then

--- a/tests/l3-integration/hooks/run.sh
+++ b/tests/l3-integration/hooks/run.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 # Run every *.test.sh in tests/l3-integration/hooks/ and aggregate pass/fail.
+# Each test file is wrapped with a 120s per-test timeout so a single stuck
+# test reports FAIL and the runner continues.
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../l5-l6/lib/timeout-shim.sh"
+
 FAILED=0
 TOTAL=0
 
@@ -10,10 +14,14 @@ for t in "$HERE"/*.test.sh; do
   [ -f "$t" ] || continue
   TOTAL=$((TOTAL + 1))
   printf "\n=== %s ===\n" "$(basename "$t")"
-  if bash "$t"; then
+  if _l5_timeout 120 bash "$t"; then
     :
   else
+    rc=$?
     FAILED=$((FAILED + 1))
+    if [ "$rc" -eq 124 ]; then
+      printf "TIMEOUT %s — killed after 120s\n" "$(basename "$t")"
+    fi
   fi
 done
 


### PR DESCRIPTION
Fixes #416, #417 (audit-batch B18, final follow-ups).

- naming-lint accepts dot-separated kebab segments (.test.sh files clean; snake/pascal bases still flagged)
- rescan test bounded at 60s via timeout-shim (root cause: no wall-clock bound on the node scan invocation in /tmp-detached worktrees)
- l3 runner wraps every test at 120s — reports TIMEOUT and continues instead of hanging

Verified in normal checkout AND /tmp-detached copy: 40/40 hook tests, shellcheck PASS. pr-reviewer verdict: PASS (task 25, attempt 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)