### PR TITLE
✨ feat(enforcement): brief gate fences Edit/Write pre-brief; grading doctrine in DETERMINISM.md

### DIFF
--- a/docs/prompt-engineering/DETERMINISM.md
+++ b/docs/prompt-engineering/DETERMINISM.md
@@ -122,6 +122,51 @@ The canonical fix lives in `scripts/hooks/lib/normalize-role.sh` — source it a
 
 ---
 
+## Grading doctrine — scoring a prompt surface
+
+Use these five tests to grade every line in an agent file, skill, or CLAUDE.md.
+
+### The five tests
+
+| Test | Pass condition |
+|---|---|
+| **(A) Mechanism test** | Sequencing, defaulting, constraining, or measuring migrates to mechanisms 1–6. Only judgment stays. |
+| **(B) If/else test** | Anything you can write as an if/else statement must live in hooks/MCP, never in prompt prose. |
+| **(C) Natural-language test** | LLMs are built on natural language: if the Human cannot read a prompt line as natural language, it is machine-spec in disguise — migrate it or rewrite it. |
+| **(D) Placement test** | 100%-required judgment belongs in the always-loaded body; optional judgment in trigger-loaded skills; deterministic logic in code. CLAUDE.md is the reference implementation. |
+| **(E) Persona test** | Every agent opens with a plain-language identity sentence ("You are a senior software engineer. You execute tasks assigned by bro."). |
+
+### Four-way line disposition
+
+| What the line does | Action |
+|---|---|
+| Encodeable as if/else AND enforced by a gate | **DELETE** — the gate already guarantees the behavior. |
+| Encodeable as if/else, NOT yet enforced | **KEEP** as readable prose, rewrite naturally, file a migration issue. |
+| Required judgment (100% of runs) | **BODY** — move to the always-loaded agent file. |
+| Optional/situational judgment | **SKILL** — trigger-loaded, not burned on every turn. |
+
+### A–F rubric
+
+| Grade | What it means |
+|---|---|
+| **A** | Every line passes all five tests. No machine-spec, no redundant enforcement prose. |
+| **B** | Compliant architecture with residual machine-spec or minor duplication. |
+| **C** | Procedures wearing a prompt costume — readable but enforceable. |
+| **D** | Prompt is doing enforcement's job for at least one workflow step. |
+| **F** | Agent can act against policy before any gate fires. |
+
+### The gate-strength principle
+
+**A prompt line is only deletable when its gate actually guarantees the behavior — grade the system, not the prose.**
+
+If deleting a line would let an agent act before any gate catches it, the gate is too weak. Strengthen the gate first, then delete the line. Prompts must never be the load-bearing patch for a weak gate, and gates must teach their recovery in the deny message.
+
+### Worked example
+
+The swe.md file once carried a "load task_brief before proceeding" instruction. The gate at the time blocked only trajectory-server MCP calls, so an SWE could Read and Edit files before calling task_brief — implementing blind. The prompt line was load-bearing because the gate was weak. Fix: extend the gate to also deny Edit/Write pre-brief (with recovery instruction in the deny message). Once the gate guarantees the behavior, the prompt line becomes redundant and is deletable.
+
+---
+
 ## See also
 
 - `plugin/docs/architecture/RESPONSIBILITIES.md` — agent layer model + role boundaries

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -180,6 +180,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/swe-brief-gate.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/no-source-edit-from-main.sh",
             "timeout": 5
           },

--- a/scripts/hooks/swe-brief-gate.sh
+++ b/scripts/hooks/swe-brief-gate.sh
@@ -3,17 +3,27 @@
 #
 # CC's PreToolUse hook contract does NOT support updatedInput (prompt mutation).
 # The deterministic fallback: block SWE from calling any trajectory-server MCP
-# tool other than task_brief until task_brief has been called for that task.
-# When task_brief fires, write an audit sentinel 'swe_brief_fetched' so
-# subsequent MCP calls are allowed.
+# tool other than task_brief — AND from calling Edit/Write/NotebookEdit — until
+# task_brief has been called for that task. When task_brief fires, write an
+# audit sentinel 'swe_brief_fetched' so subsequent calls are allowed.
 #
-# Fires on: PreToolUse — matcher: mcp__.*trajectory-server__.*
+# Fires on: PreToolUse — matchers:
+#   mcp__.*trajectory-server__.*   (original MCP gate)
+#   Edit|Write|NotebookEdit        (file-mutation gate, new)
 #
-# Decision logic:
-#   1. Non-SWE caller        → allow (pass-through)
-#   2. Tool is task_brief     → write sentinel if not yet set, then allow
-#   3. Sentinel exists        → allow (brief already fetched for this task)
-#   4. No sentinel + non-task_brief → DENY with instruction to call task_brief
+# Boundary choice — why Read/Bash are allowed pre-brief:
+#   Read-only exploration (Read, Glob, Grep) is legitimate pre-brief work;
+#   an SWE may need to orient itself before locating the spec. Bash is
+#   similarly allowed because build invocations and greps are pure exploration
+#   — they mutate nothing inside the worktree. Only irreversible mutations
+#   (Edit, Write, NotebookEdit) are blocked, because implementing blind is
+#   exactly the failure mode the gate must prevent.
+#
+# Decision logic (both matchers share the same sentinel check):
+#   1. Non-SWE caller             → allow (pass-through)
+#   2. Tool is task_brief          → write sentinel if not yet set, then allow
+#   3. Sentinel exists             → allow (brief already fetched for this task)
+#   4. No sentinel + blocked tool  → DENY with recovery instruction
 #
 # Skips:
 #   - Non-SWE callers (bro, pr-reviewer, etc.)
@@ -64,9 +74,19 @@ if [ -z "$TASK_ID" ]; then
 fi
 
 IS_TASK_BRIEF=""
+IS_BLOCKED_MUTATION=""
+IS_MCP_TRAJECTORY=""
 case "${TOOL_NAME:-}" in
-  *task_brief*) IS_TASK_BRIEF="yes" ;;
+  *task_brief*)                       IS_TASK_BRIEF="yes" ;;
+  Edit|Write|NotebookEdit)            IS_BLOCKED_MUTATION="yes" ;;
+  mcp__*trajectory-server__*)        IS_MCP_TRAJECTORY="yes" ;;
 esac
+
+# Only gate the two matched surfaces: trajectory-server MCP tools and file mutations.
+# Read, Bash, Glob, Grep etc. are exploration tools — pass through silently.
+if [ -z "$IS_TASK_BRIEF" ] && [ -z "$IS_BLOCKED_MUTATION" ] && [ -z "$IS_MCP_TRAJECTORY" ]; then
+  exit 0
+fi
 
 if [ "$IS_TASK_BRIEF" = "yes" ]; then
   # Write sentinel on first task_brief call for this task.
@@ -91,7 +111,7 @@ if [ "$IS_TASK_BRIEF" = "yes" ]; then
   exit 0
 fi
 
-# Not task_brief — check if sentinel exists.
+# Check if sentinel exists before denying.
 SENTINEL=$(tmb_sqlite_ro "$DB" "
   SELECT COUNT(*) FROM audit
    WHERE event_type = 'swe_brief_fetched'
@@ -103,7 +123,7 @@ if [ "${SENTINEL:-0}" -gt 0 ]; then
   exit 0
 fi
 
-DENY_REASON="BLOCKED: SWE must call task_brief(agent='swe', task_id=${TASK_ID}) before any other trajectory-server tool call. task_brief delivers the spec, worktree path, and decision thread in one deterministic call."
+DENY_REASON="BLOCKED: SWE must call task_brief(agent='swe', task_id=${TASK_ID}) before ${TOOL_NAME:-this tool}. task_brief delivers the spec, worktree path, and decision thread in one deterministic call. Recovery: task_brief(agent='swe', task_id=${TASK_ID})"
 
 jq -nc --arg reason "$DENY_REASON" \
   '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":$reason}}'

--- a/tests/l3-integration/hooks/swe-brief-gate.test.sh
+++ b/tests/l3-integration/hooks/swe-brief-gate.test.sh
@@ -215,4 +215,88 @@ assert_eq "" "$out" "injected task_brief should pass through silently"
 AUDIT_AFTER=$(sqlite3 "$DB" "SELECT COUNT(*) FROM audit;")
 assert_eq "$AUDIT_BEFORE" "$AUDIT_AFTER" "injected task_brief should not write a sentinel row"
 
+# ---- Edit denied pre-brief --------------------------------------------------
+test_case "SWE caller: Edit DENIED pre-brief with teaching message"
+sqlite3 "$DB" "INSERT INTO tasks VALUES (50, 1, 'feat/edit-deny', 'pending', 'spec');" 2>/dev/null || true
+TR=$(make_transcript 50)
+INPUT=$(jq -n --arg tr "$TR" '{
+  agent_type: "swe",
+  tool_name: "Edit",
+  agent_transcript_path: $tr,
+  tool_input: {}
+}')
+out=$(run_hook "$INPUT")
+assert_contains "$out" '"permissionDecision":"deny"' "Edit should be denied pre-brief"
+assert_contains "$out" "task_brief" "deny reason must mention task_brief recovery"
+assert_contains "$out" "50" "deny reason must mention the task_id"
+
+# ---- Write denied pre-brief -------------------------------------------------
+test_case "SWE caller: Write DENIED pre-brief with teaching message"
+TR=$(make_transcript 50)
+INPUT=$(jq -n --arg tr "$TR" '{
+  agent_type: "swe",
+  tool_name: "Write",
+  agent_transcript_path: $tr,
+  tool_input: {}
+}')
+out=$(run_hook "$INPUT")
+assert_contains "$out" '"permissionDecision":"deny"' "Write should be denied pre-brief"
+assert_contains "$out" "task_brief" "deny reason must mention task_brief recovery"
+
+# ---- Read allowed pre-brief -------------------------------------------------
+test_case "SWE caller: Read allowed pre-brief (read-only exploration is legitimate)"
+TR=$(make_transcript 50)
+INPUT=$(jq -n --arg tr "$TR" '{
+  agent_type: "swe",
+  tool_name: "Read",
+  agent_transcript_path: $tr,
+  tool_input: {}
+}')
+out=$(run_hook "$INPUT")
+assert_not_contains "$out" '"permissionDecision":"deny"' "Read must be allowed pre-brief"
+
+# ---- Bash allowed pre-brief -------------------------------------------------
+test_case "SWE caller: Bash allowed pre-brief (exploration, no worktree mutation)"
+TR=$(make_transcript 50)
+INPUT=$(jq -n --arg tr "$TR" '{
+  agent_type: "swe",
+  tool_name: "Bash",
+  agent_transcript_path: $tr,
+  tool_input: {}
+}')
+out=$(run_hook "$INPUT")
+assert_not_contains "$out" '"permissionDecision":"deny"' "Bash must be allowed pre-brief"
+
+# ---- Edit allowed post-brief ------------------------------------------------
+test_case "SWE caller: Edit allowed after brief sentinel exists"
+TR=$(make_transcript 50)
+INPUT=$(jq -n --arg tr "$TR" '{
+  agent_type: "swe",
+  tool_name: "mcp__tmb__trajectory-server__task_brief",
+  agent_transcript_path: $tr,
+  tool_input: {}
+}')
+run_hook "$INPUT" >/dev/null
+INPUT=$(jq -n --arg tr "$TR" '{
+  agent_type: "swe",
+  tool_name: "Edit",
+  agent_transcript_path: $tr,
+  tool_input: {}
+}')
+out=$(run_hook "$INPUT")
+assert_not_contains "$out" '"permissionDecision":"deny"' "Edit must be allowed after task_brief"
+
+# ---- bro Edit never denied --------------------------------------------------
+test_case "bro caller: Edit never denied (gate must not affect bro)"
+sqlite3 "$DB" "INSERT INTO tasks VALUES (60, 1, 'feat/bro-edit', 'pending', 'spec');" 2>/dev/null || true
+TR=$(make_transcript 60)
+INPUT=$(jq -n --arg tr "$TR" '{
+  agent_type: "bro",
+  tool_name: "Edit",
+  agent_transcript_path: $tr,
+  tool_input: {}
+}')
+out=$(run_hook "$INPUT")
+assert_eq "" "$out" "bro Edit must never be denied by brief gate"
+
 summarize


### PR DESCRIPTION
Refs #426.

- swe-brief-gate now denies Edit/Write/NotebookEdit until the task brief is fetched (closes the implement-blind hole: previously only MCP calls were fenced, so an uninstructed SWE could explore and edit before ever seeing the spec). Read/Glob/Grep/Bash exploration stays allowed — boundary reasoned in the hook header. Teaching deny preserved; bro/pr-reviewer unaffected; SQLi hardening intact. 29/29 gate tests.
- DETERMINISM.md gains '## Grading doctrine': the five tests (mechanism, if/else, natural-language, placement, persona), the four-way line disposition, the A–F rubric, and the gate-strength principle ('a prompt line is only deletable when its gate actually guarantees the behavior — grade the system, not the prose') with a worked example.

This unlocks the A-grade cut of agents/swe.md on PR #395. pr-reviewer verdict: PASS (task 28, attempt 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)