### PR TITLE
🧪 test(hooks+l4): discriminating quoted-slug injection case; L4 flow migration to the batch object shape

### DIFF
--- a/tests/l3-integration/hooks/git-guards.test.sh
+++ b/tests/l3-integration/hooks/git-guards.test.sh
@@ -184,10 +184,12 @@ out=$(run_hook_in_repo "cd $REPO_PATH/.claude/worktrees/cli-todo && git commit -
 assert_not_contains "$out" '"permissionDecision":"block"' "no DB match must not block (fail-open)"
 cleanup_repo
 
-test_case "injection: worktree basename with a single quote neither errors nor blocks"
-# The slug feeds the Rule-2 DB lookup (branch_id LIKE '%/<slug>'). A quote in
-# the basename must be escaped via tmb_sql_quote — the lookup still resolves
-# feat/o'brien-cli (non-protected) and the hook stays silent.
+test_case "injection: quote-bearing slug resolves a PROTECTED branch and BLOCKS the commit"
+# Discriminating case for the Rule-2 DB lookup (branch_id LIKE '%/<slug>').
+# The quoted slug resolves to feat/o'brien-cli, which IS protected — so
+# correct tmb_sql_quote escaping makes the lookup succeed and Rule 2 block.
+# Broken escaping breaks the SQL instead (error → empty branch → fail-open,
+# NO block), so the block assertion below fails the moment escaping regresses.
 dir=$(mktemp -d -t tmb-guards-quote-XXXX)
 (
   cd "$dir" || exit 1
@@ -205,12 +207,15 @@ dir=$(mktemp -d -t tmb-guards-quote-XXXX)
       VALUES (1, 'test', 'test', 'open', datetime('now'), datetime('now'));
     INSERT INTO tasks (id, issue_id, branch_id, title, description, status, spec_body, created_at, updated_at)
       VALUES (1, 1, 'feat/o''brien-cli', 'test task', 'd', 'pending', '', datetime('now'), datetime('now'));
+    UPDATE plugin_config
+       SET value_json = '[\"main\", \"feat/o''brien-cli\"]'
+     WHERE key = 'protected_branches';
   " >/dev/null
 )
 REPO_PATH="$dir"
 out=$(run_hook_in_repo "cd $REPO_PATH/.claude/worktrees/o'brien-cli && git commit -m 'feat: add x'")
-assert_not_contains "$out" '"permissionDecision":"block"' "quote-bearing slug must not block the feature-branch commit"
-assert_eq "" "$out" "quote-bearing slug must produce no output (no errors)"
+assert_contains "$out" '"permissionDecision":"block"' "quote-bearing protected slug must BLOCK — empty means the lookup SQL errored out"
+assert_contains "$out" "feat/o'brien-cli" "block message must name the quoted branch resolved via DB lookup"
 cleanup_repo
 
 # ---- #347: Rule 3 force-push token matching ---------------------------------

--- a/tests/l4-workflow-sim/flow-03-difficult-task.test.mjs
+++ b/tests/l4-workflow-sim/flow-03-difficult-task.test.mjs
@@ -126,7 +126,7 @@ test('Flow 3 negative — task creation WITHOUT scope-gate Q+A is rejected', asy
     tasks: [{
       branch_id: 'refactor/x',
       title: 't', description: 'd',
-      spec_body: '## body',
+      spec_body: '## Files\n- src/x.py\n## Success Criteria\n- x refactored\n## Verification\n```\npytest tests/x\n```',
     }],
   });
   assert.equal(batch.ok, false,

--- a/tests/l4-workflow-sim/flow-06-push-gate.test.mjs
+++ b/tests/l4-workflow-sim/flow-06-push-gate.test.mjs
@@ -38,13 +38,14 @@ test('Flow 6 — push gate: bro closes → unsigned commits → pr-reviewer sign
     waive_decision_gate: true,
     waive_decision_gate_reason: 'workflow-sim test; triage gate not under test in this flow',
     tasks: [
-      { branch_id: 'feat/a', title: 'A', description: 'd', spec_body: '## A' },
-      { branch_id: 'feat/b', title: 'B', description: 'd', spec_body: '## B' },
+      { branch_id: 'feat/a', title: 'A', description: 'd', spec_body: '## Files\n- src/a.js\n## Success Criteria\n- A works\n## Verification\n```\nbun test tests/a\n```' },
+      { branch_id: 'feat/b', title: 'B', description: 'd', spec_body: '## Files\n- src/b.js\n## Success Criteria\n- B works\n## Verification\n```\nbun test tests/b\n```' },
     ],
   });
   assert.equal(batch.ok, true, JSON.stringify(batch));
-  const taskA = batch.data[0].id;
-  const taskB = batch.data[1].id;
+  const created = Array.isArray(batch.data) ? batch.data : batch.data.tasks;
+  const taskA = created[0].id;
+  const taskB = created[1].id;
 
   // SWE completes both, bro closes both
   for (const [id, sha] of [[taskA, 'aaa1111111111111111111111111111111111111'], [taskB, 'bbb2222222222222222222222222222222222222']]) {
@@ -117,9 +118,9 @@ test('Flow 6 fail-path — pr-reviewer FAIL verdict triggers retry signal in nex
     waive_intent_gate_reason: 'workflow-sim test; intent gate not under test in this flow',
     waive_decision_gate: true,
     waive_decision_gate_reason: 'workflow-sim test; triage gate not under test in this flow',
-    tasks: [{ branch_id: 'fix/x', title: 't', description: 'd', spec_body: '## body' }],
+    tasks: [{ branch_id: 'fix/x', title: 't', description: 'd', spec_body: '## Files\n- src/x.js\n## Success Criteria\n- x fixed\n## Verification\n```\nbun test tests/x\n```' }],
   });
-  const taskId = batch.data[0].id;
+  const taskId = Array.isArray(batch.data) ? batch.data[0]?.id : batch.data.tasks?.[0]?.id;
 
   await call(client, 'task_update_status', {
     agent: 'swe', task_id: taskId, status: 'completed',

--- a/tests/l4-workflow-sim/flow-08-swe-retry.test.mjs
+++ b/tests/l4-workflow-sim/flow-08-swe-retry.test.mjs
@@ -24,9 +24,9 @@ async function setupClosedTask(client, branch, sha) {
     waive_intent_gate_reason: 'workflow-sim test; intent gate not under test in this flow',
     waive_decision_gate: true,
     waive_decision_gate_reason: 'workflow-sim test; triage gate not under test in this flow',
-    tasks: [{ branch_id: branch, title: 't', description: 'd', spec_body: '## body' }],
+    tasks: [{ branch_id: branch, title: 't', description: 'd', spec_body: '## Files\n- src/x.js\n## Success Criteria\n- bug fixed\n## Verification\n```\nbun test tests/x\n```' }],
   });
-  const taskId = batch.data[0].id;
+  const taskId = Array.isArray(batch.data) ? batch.data[0]?.id : batch.data.tasks?.[0]?.id;
   await call(client, 'task_update_status', {
     agent: 'swe', task_id: taskId, status: 'completed', commit_sha: sha,
   });

--- a/tests/l4-workflow-sim/flow-09-anonymous-cold-restart.test.mjs
+++ b/tests/l4-workflow-sim/flow-09-anonymous-cold-restart.test.mjs
@@ -61,7 +61,7 @@ test('Flow 09b — Bro forbidden from validation_record (issue #96 server enforc
     }],
   });
   assert.equal(task.ok, true);
-  const taskId = task.data[0].id;
+  const taskId = Array.isArray(task.data) ? task.data[0]?.id : task.data.tasks?.[0]?.id;
 
   // The invariant: bro calling validation_record must be rejected
   const result = await call(client, 'validation_record', {
@@ -111,11 +111,12 @@ test('Flow 09c — Bro task-gate uses audit_log(bro_verification_pass), not vali
       branch_id: 'feat/audit-event-test',
       title: 'audit event test',
       description: 'fixture',
-      spec_body: '## Description\nfixture',
+      spec_body: '## Description\nfixture\n## Files\n- none\n## Success Criteria\n- none\n## Verification\n```\necho ok\n```',
     }],
   });
-  const taskId = task.data[0].id;
-  const branchId = task.data[0].branch_id;
+  const createdTask = Array.isArray(task.data) ? task.data[0] : task.data.tasks?.[0];
+  const taskId = createdTask.id;
+  const branchId = createdTask.branch_id;
 
   // SWE finishes the work first — bro can only close verified ('completed')
   // work, never jump a pending task straight to closed (#278).


### PR DESCRIPTION
Fixes #436; also fixes the L4-layer fallout of the debt-gates batch (4 flows used the old task_create_batch array shape + abbreviated specs the new spec-shape gate rejects — same approved migration as l3, all UPGRADES no waivers).

- git-guards injection case is now discriminating: protected quoted branch must BLOCK; broken escaping demonstrably fails the test (revert-proof run twice, independently)
- flow-03/06/08/09 fixtures upgraded; 12/12 across all 6 flows; flow-03's scope-gate assertion verified to fire for the scope reason, not spec-shape

Independent verification: PASS on all 4 checks (scope, discrimination, flows, static).

🤖 Generated with [Claude Code](https://claude.com/claude-code)