### PR TITLE
🐛 fix(tests): prescan non-empty assertion checked length-contains-zero, not emptiness

### DIFF
--- a/tests/l3-integration/hooks/session-start-prescan.test.sh
+++ b/tests/l3-integration/hooks/session-start-prescan.test.sh
@@ -47,9 +47,8 @@ OUT=$(run_hook)
 # ---- basic output shape ----
 
 test_case "hook emits non-empty output"
-assert_not_contains "${#OUT}" "0" "output should be non-empty"
 
-# Check non-empty differently
+# Check output is non-empty
 if [ -z "$OUT" ]; then
   _fail "hook produced empty output"
 else


### PR DESCRIPTION
Refs #427. The session-start-prescan non-empty assertion tested whether the output LENGTH (e.g. 1301) contains the digit '0' — an aggregate-only false fail (B14 review flagged it). Deleted; the if [ -z $OUT ] block below is the real check. Full hooks suite 45/45. pr-reviewer: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)