### PR TITLE
🐛 fix(l5l6): bare test remote lives outside bro project tree (reonboard decoy)

### DIFF
--- a/tests/l5-l6/lib/sandbox.sh
+++ b/tests/l5-l6/lib/sandbox.sh
@@ -38,7 +38,8 @@ tmb_test_sandbox_init() {
 GITCFG
   mkdir -p "$HOME/.ssh"
 
-  export TMB_TEST_REMOTE="$scratch/_remote.git"
+  TMB_TEST_REMOTE="$(dirname "$scratch")/$(basename "$scratch")_remote.git"
+  export TMB_TEST_REMOTE
   git init --bare "$TMB_TEST_REMOTE" >/dev/null 2>&1
 
   # Cleaner failure for any git HTTPS push attempt: don't hang asking for a
@@ -56,5 +57,6 @@ GITCFG
 tmb_test_sandbox_teardown() {
   export PATH="${TMB_SANDBOX_ORIG_PATH:-$PATH}"
   export HOME="${TMB_SANDBOX_ORIG_HOME:-$HOME}"
+  [ -n "${TMB_TEST_REMOTE:-}" ] && rm -rf "$TMB_TEST_REMOTE" 2>/dev/null || true
   unset TMB_SANDBOX_ORIG_PATH TMB_SANDBOX_ORIG_HOME TMB_TEST_REMOTE GIT_TERMINAL_PROMPT TRAJECTORY_DB_PATH 2>/dev/null || true
 }


### PR DESCRIPTION
Refs #427. sandbox.sh placed _remote.git INSIDE the project dir bro cds into — a real remote is never a subdir of the working tree. On reonboard rows ('this project needs to live on a remote — set it up'), bro saw a wireable bare repo in its own tree and sometimes skipped onboard_state_get to wire it directly (the L6 step-2 failures). Relocated to a sibling path; teardown removes it; push-gate L5 row verified green with the relocated remote; isolation harness-verified. Residual reonboard non-determinism (1-in-3 post-fix) surfaced to Human separately. pr-reviewer: PASS (task 35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)