### PR TITLE
🧪 test(l6): step 6 chain_setup exposes the unmerged CLI branch

### DIFF
--- a/tests/l5-l6/l6-chain/chain-manifest.json
+++ b/tests/l5-l6/l6-chain/chain-manifest.json
@@ -61,7 +61,9 @@
       "partial_test": false,
       "seed_before": null,
       "seed_after": null,
-      "halt_on_fail": true
+      "halt_on_fail": true,
+      "chain_setup_command": "b=$(git for-each-ref --format='%(refname:short)' refs/heads | while read -r br; do git ls-tree -r --name-only \"$br\" | grep -qx 'src/cli.py' && { echo \"$br\"; break; }; done); [ -n \"$b\" ] && git checkout -q \"$b\"",
+      "chain_setup_note": "Expose the implemented-but-unmerged CLI: prior steps leave src/cli.py on its task branch (the checkout rests on the base per stay-on-base doctrine); the Human inspecting in-flight work checks the branch out. L5 standalone seeds the file directly."
     },
     {
       "step": 7,


### PR DESCRIPTION
Refs #427. Chain rows 4-7 were authored when the main checkout lingered on feature branches between steps; the enforcement campaign made the runtime doctrine-correct (checkout rests on base until the push-gate merge), so step 6's documented pre-state (src/cli.py on disk) no longer held in-chain. Uses the runner's existing chain_setup_command — whose doc comment names exactly this case — with a dynamic branch lookup (bro names the branch at step 4). dev never moves (snapshot taken after setup, scorer-verified); L5 standalone unaffected. Independent review PASS incl. eval-safety + worktree-contention checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)