### PR TITLE
🧪 test(l6): step 9 chain_setup exposes tests/test_cli.py (the concern bait)

### DIFF
--- a/tests/l5-l6/l6-chain/chain-manifest.json
+++ b/tests/l5-l6/l6-chain/chain-manifest.json
@@ -94,7 +94,9 @@
       "partial_test": false,
       "seed_before": null,
       "seed_after": null,
-      "halt_on_fail": true
+      "halt_on_fail": true,
+      "chain_setup_command": "b=$(git for-each-ref --format='%(refname:short)' refs/heads | while read -r br; do git ls-tree -r --name-only \"$br\" | grep -qx 'tests/test_cli.py' && { echo \"$br\"; break; }; done); [ -n \"$b\" ] && git checkout -q \"$b\"",
+      "chain_setup_note": "Expose tests/test_cli.py (created on the step-04/05 task branch, unmerged until push-gate): the row's bait is its exact-equality-on-integers content, which must be visible for the concern to register. Same pattern as step 6. L5 standalone seeds the files directly."
     },
     {
       "step": 10,


### PR DESCRIPTION
Refs #427. Same class as #443: the concerns-protocol row's bait (exact-equality-on-integers in tests/test_cli.py) must be VISIBLE for the concern to register; doctrine-correct checkout placement hides the unmerged step-4/5 branch, so bro's doubt degraded to 'file missing' and it spec-fixed instead of halting per Path A. Dynamic branch lookup (bro names the branch at step 4), dev untouched, L5 standalone unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)