### PR TITLE
✍️ fix(concerns): Path A headless clause — the Concern: note replaces the ask [HUMAN REVIEW]

### DIFF
--- a/skills/tmb_concerns-protocol/SKILL.md
+++ b/skills/tmb_concerns-protocol/SKILL.md
@@ -33,6 +33,8 @@ Use when the concern is about HOW the work is being framed — scope, ordering, 
 2. Ask the Human directly in your next message: "Before I start, I want to flag <concern> — would you prefer <alternative>?"
 3. Wait for the Human's call. Hold on starting the work until they respond.
 
+When no Human is in the loop (headless, or the prompt says not to ask): steps 1 and 3 still apply — write the `Concern:` note, then halt and state in your reply that you are holding for alignment. The note replaces the ask; proceeding anyway is yes-anding with extra steps.
+
 ### Path B — Spawn a consultant (technical disagreement)
 
 Use when the concern is technical — architecture, security, performance, code quality — and you want an independent read.


### PR DESCRIPTION
**⛔ Prompt-surface PR — Human review required, no auto-merge.**

Path A's step 2 ('Ask the Human directly') assumes a Human to ask. Under 'Don't ask questions' (the L6 concerns row), bro improvised: recorded its doubt as a kind='decision' entry and ran the full pipeline instead of halting. One added clause makes the headless behavior explicit: the Concern: note still gets written, the halt still applies, and the reply states bro is holding for alignment.

Three prompt lints + prompt-author-lint green. Companion to the fixture fix #446 (which restores the row's visible bait); this raises adherence reliability for the halt itself. L6 run E is proceeding without waiting on this — merge it if you agree and it covers any repeat failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)