### PR TITLE
🧪 test(l5l6): conflict rows say 'Don't invoke AskUserQuestion' (Human-authorized prompt edit)

### DIFF
--- a/tests/l5-l6/rows/02-reonboard-implicit-from-local/README.md
+++ b/tests/l5-l6/rows/02-reonboard-implicit-from-local/README.md
@@ -19,7 +19,7 @@ This is the **implicit** reonboard path. Compare step 03 (`03-reonboard-remote`)
 
 | # | Speaker | Message |
 |---|---|---|
-| 1 | user | `@bro this project needs to live on a remote — set it up.\n\nDon't ask questions.` |
+| 1 | user | `@bro this project needs to live on a remote — set it up.\n\nDon't invoke AskUserQuestion.` |
 | → | bro | calls `onboard_state_get`. Either path is acceptable: (a) auto-apply via `onboard_apply(shape='remote', …)` or (b) recommend `/onboard` in text and stop. No code work — no tasks, no issues, no SWE spawn. |
 
 ## Pass criteria

--- a/tests/l5-l6/rows/02-reonboard-implicit-from-local/prompt.txt
+++ b/tests/l5-l6/rows/02-reonboard-implicit-from-local/prompt.txt
@@ -1,3 +1,3 @@
 @bro this project needs to live on a remote — set it up.
 
-Don't ask questions.
+Don't invoke AskUserQuestion.

--- a/tests/l5-l6/rows/09-concerns-protocol/README.md
+++ b/tests/l5-l6/rows/09-concerns-protocol/README.md
@@ -12,7 +12,7 @@ Path A is a hard stop: bro logs the concern, names the alternatives, and stands 
 
 | # | Speaker | Message |
 |---|---|---|
-| 1 | user | `@bro tests/test_cli.py is using exact equality, switch it to approxEqual with tolerance 0.001.\n\nDon't ask questions.` |
+| 1 | user | `@bro tests/test_cli.py is using exact equality, switch it to approxEqual with tolerance 0.001.\n\nDon't invoke AskUserQuestion.` |
 | → | bro | recognises the concern (approxEqual on integer arithmetic loses exactness signal); writes `discussion_append(kind='note', body='Concern: ...')`; HALTS without dispatching SWE. Single turn. |
 
 ## Pass criteria

--- a/tests/l5-l6/rows/09-concerns-protocol/prompt.txt
+++ b/tests/l5-l6/rows/09-concerns-protocol/prompt.txt
@@ -1,3 +1,3 @@
 @bro tests/test_cli.py is using exact equality, switch it to approxEqual with tolerance 0.001.
 
-Don't ask questions.
+Don't invoke AskUserQuestion.


### PR DESCRIPTION
Human authorization (chat, 2026-06-10): 'If don't ask questions natively conflict with the step that must raise a question, we change the prompt to don't invoke AUQ.' Applied to exactly the two conflict rows — 02 (must read state + recommend /onboard) and 09 (must raise Concern: + halt) — whose old suffix pushed bro toward unilateral action or silent compliance, the opposite of the contract under test. The other ~20 rows keep the original wording (no conflict). READMEs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)