### PR TITLE
🐛 fix(hooks): SWE spawn gate accepts 'task_id: N' (separator-agnostic)

### DIFF
--- a/scripts/hooks/require-task-spec.sh
+++ b/scripts/hooks/require-task-spec.sh
@@ -16,7 +16,7 @@ PROMPT=$(echo "$INPUT" | jq -r '.tool_input.prompt // empty')
 
 [ "$AGENT_TYPE" != "swe" ] && exit 0
 
-TASK_ID=$(echo "$PROMPT" | grep -oE 'task_id=[0-9]+' | head -1 | sed 's/task_id=//' || true)
+TASK_ID=$(echo "$PROMPT" | grep -oE 'task_id[=:][[:space:]]*[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
 
 if [ -z "$TASK_ID" ]; then
   jq -nc '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",denyReason:"BLOCKED: SWE spawn requires task_id=<N> in the prompt pointing at a row in the tasks table. Route through bro (bro plans, then spawns SWE with task_id)."}}'

--- a/tests/l3-integration/hooks/require-task-spec.test.sh
+++ b/tests/l3-integration/hooks/require-task-spec.test.sh
@@ -79,6 +79,11 @@ test_case "SWE with pending task and non-empty body passes silently"
 out=$(run_hook "$(swe_input 'task_id=1 please do the thing')")
 assert_eq "" "$out" "silent pass"
 
+test_case "SWE with colon-form 'task_id: N' passes silently (separator-agnostic parser)"
+out=$(run_hook "$(swe_input 'task_id: 1
+please do the thing')")
+assert_eq "" "$out" "silent pass for colon form"
+
 test_case "SWE with open task and non-empty body passes silently"
 out=$(run_hook "$(swe_input 'task_id=3 please do the thing')")
 assert_eq "" "$out" "silent pass"


### PR DESCRIPTION
Closes #455. L6 run G step 12: a semantically-correct SWE spawn ('task_id: 4', valid pending task) was denied because the gate grepped only the equals form; bro rationalized the deny as test-mode design and the task stayed pending. Parser now accepts = or : with optional whitespace; colon-form regression case added and bite-proven (17/17). Code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)