### PR TITLE
✍️ fix(onboard): headless path keeps Step 1 — the halt-reply cites current shape [HUMAN REVIEW]

### DIFF
--- a/commands/onboard.md
+++ b/commands/onboard.md
@@ -130,7 +130,7 @@ Re-render Round 1 once. Trust the user's second answer.
 
 ## Headless mode
 
-`/onboard` is interactive by definition. If `TMB_HEADLESS=1` or AskUserQuestion errors:
+`/onboard` is interactive by definition. If `TMB_HEADLESS=1` or AskUserQuestion errors, Step 1 (`onboard_state_get`) still runs — the halt-reply must cite the current shape. Then:
 
 ```
 audit_log(agent='bro', from_node='bro', issue_id='-1',


### PR DESCRIPTION
**⛔ Prompt-surface PR — your review, no auto-merge.** (Reworked per your comment — the defaults table was the wrong drawer; /onboard is a command, not a skill.)

The command's own Headless mode section is what bro followed verbatim in L6 run I step 3 — it jumps straight to log-and-halt, skipping the ceremony's Step 1 (onboard_state_get). One clause keeps Step 1 in the headless branch so the halt-reply cites the current shape. Since CC injects the command file on /onboard, this is guaranteed-delivered (no skill-loading judgment involved).

Single file, single clause. On your merge I relaunch the chain (run J).