### PR TITLE
🔖 chore(release): bump to 0.7.1-rc.1 so the rc channel shows the rc version

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tmb",
-  "version": "0.7.0",
-  "description": "TMB plugin — bro orchestrates SWE + pr-reviewer in two gates (task gate, push gate) backed by a SQLite trajectory MCP server.",
+  "version": "0.7.1-rc.1",
+  "description": "TMB plugin \u2014 bro orchestrates SWE + pr-reviewer in two gates (task gate, push gate) backed by a SQLite trajectory MCP server.",
   "author": {
     "name": "trustmybot",
     "url": "https://github.com/trustmybot"

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.7.0",
+  "version": "0.7.1-rc.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Per the rc convention learned on the 0.7.0 cycle: the marketplace UI surfaces plugin.json's version. plugin.json + mcp package.json (+lock) → 0.7.1-rc.1. The v0.7.1-rc.1 tag will be re-pointed at this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)