### PR TITLE
🔖 chore(release): workspace-root package.json → 0.7.1-rc.1 (version-sync)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmb-plugin",
-  "version": "0.7.0",
-  "description": "TMB multi-agent Claude Code plugin — workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
+  "version": "0.7.1-rc.1",
+  "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [
     "mcp/trajectory-server"


### PR DESCRIPTION
Release-gate caught the workspace-root package.json still at 0.7.0 (the version-sync lint checks three files; the bump PR #461 covered two). All three now agree; lint PASS locally. Tag will be re-pointed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)