### PR TITLE
🐛 fix(hooks): Linux portability — digit-guard token sanitization, bracket-class ERE literals

### DIFF
--- a/scripts/hooks/bro-turn-usage.sh
+++ b/scripts/hooks/bro-turn-usage.sh
@@ -69,12 +69,12 @@ DURATION_MS=$(echo "$STATS" | cut -d'|' -f4)
 CACHE_READ_TOKENS=$(echo "$STATS" | cut -d'|' -f5)
 CACHE_CREATION_TOKENS=$(echo "$STATS" | cut -d'|' -f6)
 
-TOKENS_IN=$(printf '%d' "${TOKENS_IN}" 2>/dev/null || echo "0")
-TOKENS_OUT=$(printf '%d' "${TOKENS_OUT}" 2>/dev/null || echo "0")
-TOOL_USES=$(printf '%d' "${TOOL_USES}" 2>/dev/null || echo "0")
-DURATION_MS=$(printf '%d' "${DURATION_MS}" 2>/dev/null || echo "0")
-CACHE_READ_TOKENS=$(printf '%d' "${CACHE_READ_TOKENS}" 2>/dev/null || echo "0")
-CACHE_CREATION_TOKENS=$(printf '%d' "${CACHE_CREATION_TOKENS}" 2>/dev/null || echo "0")
+case "${TOKENS_IN}" in (''|*[!0-9]*) TOKENS_IN=0 ;; esac
+case "${TOKENS_OUT}" in (''|*[!0-9]*) TOKENS_OUT=0 ;; esac
+case "${TOOL_USES}" in (''|*[!0-9]*) TOOL_USES=0 ;; esac
+case "${DURATION_MS}" in (''|*[!0-9]*) DURATION_MS=0 ;; esac
+case "${CACHE_READ_TOKENS}" in (''|*[!0-9]*) CACHE_READ_TOKENS=0 ;; esac
+case "${CACHE_CREATION_TOKENS}" in (''|*[!0-9]*) CACHE_CREATION_TOKENS=0 ;; esac
 TOKENS_TOTAL=$((TOKENS_IN + TOKENS_OUT))
 
 sqlite3 "$DB_PATH" \

--- a/scripts/hooks/code-quality-lint.sh
+++ b/scripts/hooks/code-quality-lint.sh
@@ -93,7 +93,7 @@ case "$EXT" in
       push "catch (e: any) — use 'unknown' and narrow with instanceof"
     fi
     # template-string SQL with interpolation
-    if echo "$CONTENT" | grep -qE '\`(SELECT|INSERT|UPDATE|DELETE|MERGE)[^`]*\$\{'; then
+    if echo "$CONTENT" | grep -qE '\`(SELECT|INSERT|UPDATE|DELETE|MERGE)[^`]*[$][{]'; then
       push "template-string SQL with \${...} — use parameterized queries"
     fi
     # setTimeout with string

--- a/scripts/hooks/swe-atomic-close.sh
+++ b/scripts/hooks/swe-atomic-close.sh
@@ -297,12 +297,12 @@ if [ -n "$TRANSCRIPT_PATH" ]; then
 fi
 
 # Sanitize: ensure all values are integers (default 0 if not)
-TOKENS_IN=$(printf '%d' "${TOKENS_IN}" 2>/dev/null || echo "0")
-TOKENS_OUT=$(printf '%d' "${TOKENS_OUT}" 2>/dev/null || echo "0")
-TOOL_USES=$(printf '%d' "${TOOL_USES}" 2>/dev/null || echo "0")
-DURATION_MS=$(printf '%d' "${DURATION_MS}" 2>/dev/null || echo "0")
-CACHE_READ_TOKENS=$(printf '%d' "${CACHE_READ_TOKENS}" 2>/dev/null || echo "0")
-CACHE_CREATION_TOKENS=$(printf '%d' "${CACHE_CREATION_TOKENS}" 2>/dev/null || echo "0")
+case "${TOKENS_IN}" in (''|*[!0-9]*) TOKENS_IN=0 ;; esac
+case "${TOKENS_OUT}" in (''|*[!0-9]*) TOKENS_OUT=0 ;; esac
+case "${TOOL_USES}" in (''|*[!0-9]*) TOOL_USES=0 ;; esac
+case "${DURATION_MS}" in (''|*[!0-9]*) DURATION_MS=0 ;; esac
+case "${CACHE_READ_TOKENS}" in (''|*[!0-9]*) CACHE_READ_TOKENS=0 ;; esac
+case "${CACHE_CREATION_TOKENS}" in (''|*[!0-9]*) CACHE_CREATION_TOKENS=0 ;; esac
 
 TOKENS_TOTAL=$((TOKENS_IN + TOKENS_OUT))
 


### PR DESCRIPTION
Closes #463. The release-gate's Ubuntu runner caught two macOS-only assumptions in hooks that had never run on Linux: (1) printf '%d' partial-parse + || echo 0 concatenation turned an injection probe into '10' instead of 0 — replaced with pure-shell digit guards at all 12 sites in both telemetry hooks; (2) the template-SQL advisory's \$\{ ERE is POSIX-undefined — GNU grep exits 2 and the rule never fired; bracket-class [$][{] now. Affected suites 10/10, 45/45, 24/24 locally. Code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)