### PR TITLE
🐛 fix(hooks): unescaped backtick in the template-SQL ERE — GNU treats the escape as a buffer anchor

### DIFF
--- a/scripts/hooks/code-quality-lint.sh
+++ b/scripts/hooks/code-quality-lint.sh
@@ -93,7 +93,7 @@ case "$EXT" in
       push "catch (e: any) — use 'unknown' and narrow with instanceof"
     fi
     # template-string SQL with interpolation
-    if echo "$CONTENT" | grep -qE '\`(SELECT|INSERT|UPDATE|DELETE|MERGE)[^`]*[$][{]'; then
+    if echo "$CONTENT" | grep -qE '`(SELECT|INSERT|UPDATE|DELETE|MERGE)[^`]*[$][{]'; then
       push "template-string SQL with \${...} — use parameterized queries"
     fi
     # setTimeout with string


### PR DESCRIPTION
Refs #463 (round 2). The bracket-class fix wasn't enough: the same regex's escaped backtick is a literal on BSD but the start-of-buffer anchor on GNU, so the rule still never matched mid-file on the Ubuntu runner. Plain backtick is literal on both. 24/24 locally. Code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)