### PR TITLE
🔖 chore(release): bump to 0.7.1 — promote rc.1 to stable

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.7.1-rc.1",
+  "version": "0.7.1",
   "description": "TMB plugin \u2014 bro orchestrates SWE + pr-reviewer in two gates (task gate, push gate) backed by a SQLite trajectory MCP server.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.7.1 — 2026-06-11
+
+Promotes `v0.7.1-rc.1` to stable, plus the fixes the first Linux release-gate runs surfaced after the rc tag: bro-turn-usage digit-guard token sanitization and code-quality-lint bracket-class ERE literals + unescaped-backtick repair (#463–#465), and CI actions bumped to Node-24-ready majors (#466). See `v0.7.1-rc.1` below for the full milestone rollup (~80 issues, PRs #392–#459). Release gate green on the rc tag: L6 chain 13/13.
+
 ## v0.7.1-rc.1 — 2026-06-10
 
 The full-repo audit release: the entire v0.7.1 milestone (~80 issues — a 50-issue audit, 18 pre-existing, plus everything the burn-down itself surfaced) resolved across PRs #392–#459. L6 chain 13/13.

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.7.1-rc.1",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.7.1-rc.1",
+  "version": "0.7.1",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Release-prep for v0.7.1: bumps the three version manifests (plugin.json, mcp package.json, workspace-root package.json) from 0.7.1-rc.1 to 0.7.1 and inserts the stable `## v0.7.1` CHANGELOG section promoting rc.1 + the post-rc Linux-portability fixes (#463–#466).

Gate trail: SWE task 2 (local issue 2), bro V1–V3 pass, pr-reviewer PASS (validation row id=1). Release-gate green on the rc tag (run 27313921690, L6 chain 13/13); Human signed off on the smoke gate citing that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)