### PR TITLE
🐛 fix(hooks): roundtable postcheck fires on roundtable_close_with_decisions

### DIFF
--- a/scripts/hooks/roundtable-cleanup-postcheck.sh
+++ b/scripts/hooks/roundtable-cleanup-postcheck.sh
@@ -14,7 +14,7 @@ INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
 
 case "$TOOL_NAME" in
-  *roundtable_close) ;;
+  *roundtable_close|*roundtable_close_with_decisions) ;;
   *) exit 0 ;;
 esac
 

--- a/tests/l3-integration/hooks/roundtable-cleanup-postcheck.test.sh
+++ b/tests/l3-integration/hooks/roundtable-cleanup-postcheck.test.sh
@@ -68,6 +68,14 @@ sqlite3 "$DB" "UPDATE roundtables SET state='closed', outcome='proceed' WHERE id
 out=$(run_hook 1)
 assert_not_contains "$out" "roundtable.status=closed" "closed state must not appear in MISSING list"
 
+# ── roundtable_close_with_decisions: hook fires ──────────────────────────────
+
+test_case "roundtable_close_with_decisions tool name fires the postcheck"
+sqlite3 "$DB" "UPDATE roundtables SET state='collecting', outcome='' WHERE id=1;" >/dev/null
+out=$(echo '{"tool_name":"mcp__plugin_tmb_trajectory-server__roundtable_close_with_decisions","tool_input":{"roundtable_id":1}}' \
+  | TRAJECTORY_DB_PATH="$DB" bash "$HOOK" 2>&1 || true)
+assert_contains "$out" "additionalContext" "advisory fires for roundtable_close_with_decisions"
+
 # ── wrong tool name: silent no-op ────────────────────────────────────────────
 
 test_case "wrong tool name is silent no-op"


### PR DESCRIPTION
Fixes #468 defect 1: the case-glob `*roundtable_close)` required the tool name to END with roundtable_close, so the documented composite close path silently skipped the five-surface capture check. Now the explicit two-pattern form; new l3 case proves the composite name fires the hook (8/8). Gate trail: task 3, pr-reviewer PASS (row 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)