### PR TITLE
🐛 fix(hooks): stale §-refs after the v0.7.1 skill restructure; spawn hint emits absolute worktree path

### DIFF
--- a/scripts/hooks/post-task-create-spawn-hint.sh
+++ b/scripts/hooks/post-task-create-spawn-hint.sh
@@ -13,6 +13,10 @@
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/query-task.sh
+. "$SCRIPT_DIR/lib/query-task.sh"
+
 INPUT=$(cat 2>/dev/null) || exit 0
 command -v jq >/dev/null 2>&1 || exit 0
 
@@ -40,12 +44,34 @@ RESPONSE_TEXT=$(echo "$INPUT" | jq -r '.tool_response.content[0].text // ""' 2>/
 TASK_LIST=$(echo "$RESPONSE_TEXT" | jq -r 'if type == "array" then map("  - task_id=\(.id) branch_id=\(.branch_id)") | join("\n") else "" end' 2>/dev/null)
 [ -n "$TASK_LIST" ] || exit 0
 
-REASON="🚀 SWE-spawn hint: ${TOOL_NAME##*__} created the following tasks. Per tmb_planning Step 5, the next step is to spawn SWE via the Agent tool for each task — production sessions where this step was skipped left tasks stuck at status='pending' forever.
+# Resolve workspace_root from the trajectory DB path: DB lives at
+# <workspace_root>/.claude/<plugin>/trajectory.db, so dirname 3 times.
+WORKSPACE_ROOT=""
+_DB=$(tmb_db_path 2>/dev/null || true)
+if [ -n "$_DB" ]; then
+  WORKSPACE_ROOT="$(dirname "$(dirname "$(dirname "$_DB")")")"
+fi
+
+# Build per-task worktree path entries. For each task, slug = branch_id
+# minus its type/ prefix (e.g. feat/my-feature → my-feature).
+TASK_LIST_WITH_PATHS=$(echo "$RESPONSE_TEXT" | jq -r --arg ws "$WORKSPACE_ROOT" '
+  if type == "array" then
+    map(
+      . as $t |
+      ($t.branch_id | ltrimstr("feat/") | ltrimstr("fix/") | ltrimstr("chore/") | ltrimstr("docs/") | ltrimstr("test/") | ltrimstr("refactor/")) as $slug |
+      (if $ws != "" then $ws + "/.claude/worktrees/" + $slug else ".claude/worktrees/" + $slug end) as $wt |
+      "  - task_id=\($t.id) branch_id=\($t.branch_id) worktree=\($wt)"
+    ) | join("\n")
+  else "" end
+' 2>/dev/null)
+[ -n "$TASK_LIST_WITH_PATHS" ] || TASK_LIST_WITH_PATHS="$TASK_LIST"
+
+REASON="🚀 SWE-spawn hint: ${TOOL_NAME##*__} created the following tasks. Per tmb_planning Step 4, the next step is to spawn SWE via the Agent tool for each task — production sessions where this step was skipped left tasks stuck at status='pending' forever.
 
 Tasks created:
-${TASK_LIST}
+${TASK_LIST_WITH_PATHS}
 
-For each: \`Agent(subagent_type='swe', isolation='worktree', prompt='task_id=<N> worktree=.claude/worktrees/<slug>')\`. The branch is already pre-created (branch_id_proposed audit + git switch); SWE attaches to it.
+For each: \`Agent(subagent_type='swe', isolation='worktree', prompt='task_id=<N> worktree=<absolute-worktree-path>')\`. The branch is already pre-created (branch_id_proposed audit + git switch); SWE attaches to it.
 
 If you intentionally want to halt before SWE (e.g. user requested review), surface that reason explicitly so future sessions don't see this as a stuck-task bug."
 

--- a/scripts/hooks/pr-reviewer-after-atomic-close.sh
+++ b/scripts/hooks/pr-reviewer-after-atomic-close.sh
@@ -3,10 +3,11 @@
 # happens AFTER bro_atomic_close: the task referenced by task_id=N in the
 # spawn prompt must have status='closed' in the trajectory DB.
 #
-# Doctrine source: feedback_pr_reviewer_required_pre_push memory + planning
-# skill Step 5.5 — "After bro_atomic_close succeeds, BEFORE pushing the
-# branch, spawn pr-reviewer". The order is non-negotiable: bro_atomic_close
-# is the in-DB closure that produces the artifact pr-reviewer evaluates.
+# Doctrine source: feedback_pr_reviewer_required_pre_push memory + tmb_planning
+# Step 5 (verify + close, then pr-reviewer per tmb_review §B) — "After
+# bro_atomic_close succeeds, BEFORE pushing the branch, spawn pr-reviewer".
+# The order is non-negotiable: bro_atomic_close is the in-DB closure that
+# produces the artifact pr-reviewer evaluates.
 #
 # Non-deterministic bro flakiness has shipped CI runs where bro inferred
 # "SWE completed and closed the task" from SWE's status return and skipped
@@ -68,7 +69,7 @@ fi
 
 _DENY_REASON="BLOCKED: pr-reviewer spawn requires task ${TASK_ID} status=closed but actual status=${STATUS}.
 
-Per planning skill Step 5.5 + feedback_pr_reviewer_required_pre_push doctrine, the order is:
+Per tmb_planning Step 5 (verify + close, then pr-reviewer per tmb_review §B) + feedback_pr_reviewer_required_pre_push doctrine, the order is:
   1. SWE returns status=completed (lifecycle answer, NOT a DB closure).
   2. bro runs V1 (task_get + git diff), V2 (3 checks), V3 (bro_atomic_close).
   3. ONLY THEN: spawn pr-reviewer for the push gate.

--- a/scripts/hooks/pr-reviewer-spawn-prompt-shape.sh
+++ b/scripts/hooks/pr-reviewer-spawn-prompt-shape.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # PreToolUse hook on Agent. Blocks pr-reviewer spawns whose prompt violates
-# the §C discipline from tmb_review: MUST contain the four bare anchors
+# the §B discipline from tmb_review: MUST contain the four bare anchors
 # (task_id, commit_sha, branch_id, repo) and MUST NOT contain prior-verdict
 # shortcuts that allow rubber-stamping.
 #
@@ -64,7 +64,7 @@ PHRASES
 
 if [ -n "$RUBBER_STAMP_FOUND" ]; then
   REASON=$(jq -Rn --arg phrase "$RUBBER_STAMP_FOUND" '
-    "BLOCKED: pr-reviewer spawn prompt contains a rubber-stamp shortcut (matched: \"" + $phrase + "\").\n\nPer tmb_review §C, the prompt MUST NOT contain the prior verdict text or shortcuts that allow rubber-stamping. The reviewer must derive findings from the spec + diff itself."
+    "BLOCKED: pr-reviewer spawn prompt contains a rubber-stamp shortcut (matched: \"" + $phrase + "\").\n\nPer tmb_review §B, the prompt MUST NOT contain the prior verdict text or shortcuts that allow rubber-stamping. The reviewer must derive findings from the spec + diff itself."
   ')
   jq -nc --argjson r "$REASON" \
     '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'

--- a/tests/l3-integration/hooks/post-task-create-spawn-hint.test.sh
+++ b/tests/l3-integration/hooks/post-task-create-spawn-hint.test.sh
@@ -78,6 +78,21 @@ assert_contains "$out" "SWE-spawn hint" "hint mentions SWE-spawn"
 assert_contains "$out" "task_id=42" "hint lists task id 42"
 assert_contains "$out" "task_id=43" "hint lists task id 43"
 assert_contains "$out" "branch_id=feat/my-feature" "hint lists branch_id"
+assert_contains "$out" "Step 4" "hint cites tmb_planning Step 4"
+
+# ──────────────────────────────────────────────────────────────
+# Case 4b: absolute worktree path derived from trajectory DB location
+# ──────────────────────────────────────────────────────────────
+test_case "worktree path is absolute and starts with workspace root"
+FIXTURE_WS="$(mktemp -d)"
+FIXTURE_DB_DIR="$FIXTURE_WS/.claude/tmb"
+mkdir -p "$FIXTURE_DB_DIR"
+touch "$FIXTURE_DB_DIR/trajectory.db"
+input=$(make_input "mcp__tmb__trajectory-server__task_create_batch" "$TASK_ARRAY")
+out=$(echo "$input" | TRAJECTORY_DB_PATH="$FIXTURE_DB_DIR/trajectory.db" bash "$HOOK" 2>&1 || true)
+assert_contains "$out" "$FIXTURE_WS/.claude/worktrees/" "emitted path starts with fixture workspace root"
+assert_contains "$out" "worktree=$FIXTURE_WS/.claude/worktrees/my-feature" "slug strips type/ prefix for feat/my-feature"
+rm -rf "$FIXTURE_WS"
 
 # ──────────────────────────────────────────────────────────────
 # Case 5: response text is non-array JSON — passes silently


### PR DESCRIPTION
Fixes #468 defects 4+6: pr-reviewer-spawn-prompt-shape (§C→§B ×2), post-task-create-spawn-hint (Step 5→4), pr-reviewer-after-atomic-close (Step 5.5→Step 5/§B); the spawn hint now resolves workspace_root via tmb_db_path and emits the ABSOLUTE per-task worktree path, killing the relative-vs-absolute drift against tmb_planning. l3 16/16 incl. new fixture-DB path case. Gate trail: task 4, pr-reviewer PASS (row 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)