### PR TITLE
🔒 fix(ci): restore main-source-guard + CODEOWNERS into dev; l1 lint guards their presence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS — main branch protection routes review to the @trustmybot/admin team.
+# Any team member`s approval satisfies the "Require review from Code Owners" gate.
+* @trustmybot/admin

--- a/.github/workflows/main-source-guard.yml
+++ b/.github/workflows/main-source-guard.yml
@@ -1,0 +1,27 @@
+# main-source-guard — only PRs from `dev` may target `main`.
+#
+# Enforces the gitflow doctrine: feature branches go through dev; only the
+# dev branch promotes to main. Any other source branch fails this check,
+# blocking the merge.
+name: main source guard
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR source is dev
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [ "$HEAD_REF" != "dev" ]; then
+            echo "::error::PR to main must come from dev. This PR is from '${HEAD_REF}' — open it against dev first, then promote dev → main."
+            exit 1
+          fi
+          echo "✓ PR source is dev"

--- a/tests/l1-lint/main-guard-files-present.sh
+++ b/tests/l1-lint/main-guard-files-present.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Assert that .github/workflows/main-source-guard.yml and .github/CODEOWNERS
+# are present in the tree and that the workflow name is exactly 'main source guard'.
+#
+# Self-test: copies both files to a temp dir, removes them one at a time,
+# and verifies this script exits non-zero in each case.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$HERE/../.." && pwd)"
+
+WORKFLOW="$PLUGIN_ROOT/.github/workflows/main-source-guard.yml"
+CODEOWNERS="$PLUGIN_ROOT/.github/CODEOWNERS"
+
+FAIL=0
+
+check_files() {
+  local root="$1"
+  local wf="$root/.github/workflows/main-source-guard.yml"
+  local co="$root/.github/CODEOWNERS"
+  local fail=0
+
+  if [ ! -f "$wf" ]; then
+    printf 'MISSING: .github/workflows/main-source-guard.yml\n' >&2
+    fail=1
+  else
+    local name_line
+    name_line="$(grep -E '^name:' "$wf" | head -1 || true)"
+    local name_val
+    name_val="$(printf '%s' "$name_line" | sed -E 's/^name:[[:space:]]*//' | sed "s/^['\"]//; s/['\"]$//")"
+    if [ "$name_val" != "main source guard" ]; then
+      printf 'WRONG workflow name: got "%s", expected "main source guard"\n' "$name_val" >&2
+      fail=1
+    fi
+  fi
+
+  if [ ! -f "$co" ]; then
+    printf 'MISSING: .github/CODEOWNERS\n' >&2
+    fail=1
+  fi
+
+  return "$fail"
+}
+
+run_self_test() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  mkdir -p "$tmpdir/.github/workflows"
+  cp "$WORKFLOW" "$tmpdir/.github/workflows/main-source-guard.yml"
+  cp "$CODEOWNERS" "$tmpdir/.github/CODEOWNERS"
+
+  local self_fail=0
+
+  # Both present — must pass
+  if ! check_files "$tmpdir"; then
+    printf 'self-test FAIL: both-present case should pass\n' >&2
+    self_fail=1
+  fi
+
+  # Remove workflow — must fail
+  rm "$tmpdir/.github/workflows/main-source-guard.yml"
+  if check_files "$tmpdir" 2>/dev/null; then
+    printf 'self-test FAIL: missing workflow not detected\n' >&2
+    self_fail=1
+  fi
+
+  # Restore workflow, remove CODEOWNERS — must fail
+  cp "$WORKFLOW" "$tmpdir/.github/workflows/main-source-guard.yml"
+  rm "$tmpdir/.github/CODEOWNERS"
+  if check_files "$tmpdir" 2>/dev/null; then
+    printf 'self-test FAIL: missing CODEOWNERS not detected\n' >&2
+    self_fail=1
+  fi
+
+  # Wrong name — must fail
+  cp "$CODEOWNERS" "$tmpdir/.github/CODEOWNERS"
+  sed 's/^name:.*/name: wrong name/' "$WORKFLOW" > "$tmpdir/.github/workflows/main-source-guard.yml"
+  if check_files "$tmpdir" 2>/dev/null; then
+    printf 'self-test FAIL: wrong workflow name not detected\n' >&2
+    self_fail=1
+  fi
+
+  if [ "$self_fail" -eq 0 ]; then
+    printf 'main-guard-files-present --self-test: PASS\n'
+    exit 0
+  else
+    printf 'main-guard-files-present --self-test: FAIL\n' >&2
+    exit 1
+  fi
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  run_self_test
+fi
+
+if ! check_files "$PLUGIN_ROOT"; then
+  FAIL=1
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  printf 'main-guard-files-present: FAIL\n' >&2
+  exit 1
+fi
+
+printf 'main-guard-files-present: PASS\n'

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -72,6 +72,7 @@ run_step "L1 lint: RAG schema invariants"             bash "$HERE/l1-lint/rag-sc
 run_step "L1 lint: tool-description byte budget"      bash "$HERE/l1-lint/tool-description-budget.sh"
 run_step "L1 lint: dir toolchain allowlist"           bash "$HERE/l1-lint/dir-toolchain.sh"
 run_step "L1 lint: no raw SQL interpolation in hooks" bash "$HERE/l1-lint/no-raw-sql-interpolation.sh"
+run_step "L1 lint: main-source-guard + CODEOWNERS present" bash "$HERE/l1-lint/main-guard-files-present.sh"
 
 # ----- L1-adjacent: benchmark selftest (fast, deterministic) ------------
 


### PR DESCRIPTION
Fixes #472: the v0.7.0 squash-promotion deleted main's only copies, orphaning the required 'main source guard' check (all PRs to main hard-blocked since). Restored INTO dev so they survive promotions, with one security fix (head_ref bound via env — injection sink in the historical file) and an l1 lint asserting presence + exact check name. Gate trail: task 10, pr-reviewer PASS (row 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)