### PR TITLE
✨ feat(hooks): SessionStart auto-runs the deterministic scan when the world model is cold

### DIFF
--- a/scripts/hooks/session-start-prescan.sh
+++ b/scripts/hooks/session-start-prescan.sh
@@ -9,6 +9,9 @@
 
 set -uo pipefail
 
+# Bypass for tests: TMB_SKIP_AUTO_PRESCAN=1 suppresses the auto-fire.
+SKIP_AUTO_PRESCAN="${TMB_SKIP_AUTO_PRESCAN:-0}"
+
 DB_PATH="${TRAJECTORY_DB_PATH:-}"
 if [ -z "$DB_PATH" ]; then
   PLUGIN_NAME="tmb"
@@ -69,8 +72,21 @@ WORLD_MODEL_SCANNED=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM audit WHERE event
 SOURCE_FILE_COUNT=$(git ls-files 2>/dev/null | grep -cvE '^(\.claude/|node_modules/|dist/|build/|\.git/)' || echo 0)
 
 WORLD_MODEL_STATE="warm"
+COLD_NOTE=""
 if [ "$WORLD_MODEL_SCANNED" = "0" ] && [ "$SOURCE_FILE_COUNT" != "0" ]; then
   WORLD_MODEL_STATE="cold"
+
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  SCAN_SH="$SCRIPT_DIR/../scan.sh"
+  INVOKER="$SCRIPT_DIR/../maintenance/run-scan-initial.mjs"
+
+  if [ "$SKIP_AUTO_PRESCAN" != "1" ] && [ -f "$SCAN_SH" ] && [ -f "$INVOKER" ] && command -v node >/dev/null 2>&1; then
+    node --experimental-sqlite "$INVOKER" >/dev/null 2>&1 &
+    disown
+    COLD_NOTE="world model was cold — a deterministic scan is running in the background; re-read world_model_get before planning"
+  else
+    COLD_NOTE="world model is cold — run /scan before planning so world_model_get has a project map"
+  fi
 fi
 
 LAST_5=$(printf '%s' "$LAST_5_RAW" | head -5 | sed 's/^/  /')
@@ -79,6 +95,10 @@ LAST_5=$(printf '%s' "$LAST_5_RAW" | head -5 | sed 's/^/  /')
 # STABLE fields first (same across sessions): dirs, stacks, arch docs, world model state.
 # VOLATILE fields last (change per session/turn): branch, counts, commits.
 # This order maximises CC prompt-cache reuse — cache breaks at the first byte-difference.
+COLD_SUFFIX=""
+[ -n "$COLD_NOTE" ] && COLD_SUFFIX="
+$COLD_NOTE"
+
 INVENTORY=$(cat <<EOF
 === Project Inventory (auto, deterministic) ===
 Top-level dirs:    ${TOPLEVEL}
@@ -90,9 +110,7 @@ Open issues:       ${OPEN_ISSUES}
 Pending tasks:     ${PENDING_TASKS}
 Last 5 commits:
 ${LAST_5}
-================================================
-If World model is cold on the first code-touching ask, tell the Human to run /scan
-— world_model_get cannot navigate an empty project map.
+================================================${COLD_SUFFIX}
 EOF
 )
 

--- a/scripts/maintenance/run-scan-initial.mjs
+++ b/scripts/maintenance/run-scan-initial.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Standalone scan invoker for the cold-world-model SessionStart prescan.
+// Mirrors run-scan.mjs but uses source='bro_auto_initial' so the audit
+// row is distinct from the post-close rescan source.
+// Silent on failure — the hook never blocks session start.
+
+import { dirname } from 'node:path';
+import { TrajectoryDB, resolveDbPath } from '../../mcp/trajectory-server/dist/db.js';
+import { WorldModelGraph, resolveGraphDbPath } from '../../mcp/trajectory-server/dist/graph-db.js';
+import { scanTools } from '../../mcp/trajectory-server/dist/tools/scan.js';
+
+function resolveSessionDir() {
+  const dbPath = resolveDbPath();
+  if (!dbPath || dbPath === ':memory:') return process.cwd();
+  return dirname(dirname(dirname(dbPath)));
+}
+
+async function main() {
+  const dbPath = resolveDbPath();
+  const db = new TrajectoryDB(dbPath);
+
+  let graph = null;
+  try {
+    const graphPath = resolveGraphDbPath(dbPath);
+    graph = new WorldModelGraph(graphPath);
+  } catch {
+    // kuzu unavailable — scan proceeds without world-model writes.
+  }
+
+  try {
+    const tools = scanTools(db, graph, dbPath);
+    const handler = tools.handlers.scan_run;
+    const sessionDir = resolveSessionDir();
+
+    const result = await handler({
+      agent: 'bro',
+      session_dir: sessionDir,
+      source: 'bro_auto_initial',
+    });
+    if (result.isError) {
+      console.error(`[prescan-initial] scan_run error: ${result.content?.[0]?.text ?? '?'}`);
+      return;
+    }
+    const summary = JSON.parse(result.content[0].text);
+    console.error(
+      `[prescan-initial] OK — discovered ${summary.repos_discovered} repos, ` +
+        `upserted ${summary.repos_upserted}, retired ${summary.repos_retired ?? 0}; ` +
+        `${summary.dirs_upserted} dirs upserted, ${summary.dirs_retired ?? 0} retired`,
+    );
+  } finally {
+    graph?.close();
+    db.close();
+  }
+}
+
+main().catch((e) => {
+  console.error(`[prescan-initial] invoker error: ${e instanceof Error ? e.message : String(e)}`);
+  process.exit(0);
+});

--- a/tests/l3-integration/hooks/fixtures/session-start-prescan.golden.txt
+++ b/tests/l3-integration/hooks/fixtures/session-start-prescan.golden.txt
@@ -8,5 +8,3 @@ Open issues: __VOLATILE__
 Pending tasks: __VOLATILE__
 Last 5 commits: __VOLATILE__
 ================================================
-If World model is cold on the first code-touching ask, tell the Human to run /scan
-— world_model_get cannot navigate an empty project map.

--- a/tests/l3-integration/hooks/session-start-prescan.test.sh
+++ b/tests/l3-integration/hooks/session-start-prescan.test.sh
@@ -13,34 +13,51 @@ TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 DB="$TMPDIR/trajectory.db"
 
-export TRAJECTORY_DB_PATH="$DB"
+# ---- fixture workspace --------------------------------------------------
+# A hermetic git repo with benign commits.  Every hook invocation must run
+# from $FIXTURE_WS so that git, glob, and stack-detect all read fixture data
+# only — never the real workspace, home dir, or test runner's cwd.
+FIXTURE_WS="$TMPDIR/fixture-workspace"
+mkdir -p "$FIXTURE_WS/src"
+touch "$FIXTURE_WS/README.txt"
+touch "$FIXTURE_WS/src/main.sh"
+git -C "$FIXTURE_WS" init -q
+git -C "$FIXTURE_WS" config user.email "test@example.com"
+git -C "$FIXTURE_WS" config user.name "Test"
+git -C "$FIXTURE_WS" add .
+git -C "$FIXTURE_WS" commit -q -m "initial commit"
 
-sqlite3 "$DB" "
-  CREATE TABLE issues (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    objective TEXT NOT NULL,
-    status TEXT NOT NULL DEFAULT 'open',
-    created_at TEXT NOT NULL DEFAULT (datetime('now'))
-  );
-  CREATE TABLE tasks (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    issue_id INTEGER NOT NULL,
-    status TEXT NOT NULL DEFAULT 'pending',
-    created_at TEXT NOT NULL DEFAULT (datetime('now'))
-  );
-  CREATE TABLE audit (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    event_type TEXT NOT NULL,
-    payload TEXT,
-    created_at TEXT NOT NULL DEFAULT (datetime('now'))
-  );
-  INSERT INTO issues (objective, status) VALUES ('test issue', 'open');
-  INSERT INTO tasks (issue_id, status) VALUES (1, 'pending');
-"
-
+# Helper: run the real hook from the fixture workspace with explicit DB.
 run_hook() {
-  bash "$HOOK" 2>/dev/null || true
+  (cd "$FIXTURE_WS" && env TRAJECTORY_DB_PATH="$DB" bash "$HOOK" 2>/dev/null) || true
 }
+
+make_db() {
+  sqlite3 "$1" "
+    CREATE TABLE issues (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      objective TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'open',
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE tasks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      issue_id INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE audit (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_type TEXT NOT NULL,
+      payload TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    INSERT INTO issues (objective, status) VALUES ('test issue', 'open');
+    INSERT INTO tasks (issue_id, status) VALUES (1, 'pending');
+  "
+}
+
+make_db "$DB"
 
 OUT=$(run_hook)
 
@@ -136,32 +153,11 @@ fi
 
 test_case "missing DB: hook exits silently (no output)"
 rm -f "$DB"
-out_no_db=$(bash "$HOOK" 2>/dev/null || true)
+out_no_db=$((cd "$FIXTURE_WS" && env TRAJECTORY_DB_PATH="$DB" bash "$HOOK" 2>/dev/null) || true)
 assert_eq "" "$out_no_db" "no output when DB missing"
 
 # Re-create DB for the remaining cold/warm tests.
-sqlite3 "$DB" "
-  CREATE TABLE issues (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    objective TEXT NOT NULL,
-    status TEXT NOT NULL DEFAULT 'open',
-    created_at TEXT NOT NULL DEFAULT (datetime('now'))
-  );
-  CREATE TABLE tasks (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    issue_id INTEGER NOT NULL,
-    status TEXT NOT NULL DEFAULT 'pending',
-    created_at TEXT NOT NULL DEFAULT (datetime('now'))
-  );
-  CREATE TABLE audit (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    event_type TEXT NOT NULL,
-    payload TEXT,
-    created_at TEXT NOT NULL DEFAULT (datetime('now'))
-  );
-  INSERT INTO issues (objective, status) VALUES ('test issue', 'open');
-  INSERT INTO tasks (issue_id, status) VALUES (1, 'pending');
-"
+make_db "$DB"
 
 # ---- cold session: auto-scan fires ----
 # Build a fake invoker that records its invocation without actually running a scan.
@@ -188,7 +184,7 @@ FAKE_HOOK="$FAKE_SCRIPTS/hooks/session-start-prescan.sh"
 
 test_case "cold + invoker present: context says scan started"
 rm -f "$INVOCATION_FLAG"
-COLD_OUT=$(TRAJECTORY_DB_PATH="$DB" INVOCATION_FLAG="$INVOCATION_FLAG" TMB_SKIP_AUTO_PRESCAN=0 bash "$FAKE_HOOK" 2>/dev/null || true)
+COLD_OUT=$((cd "$FIXTURE_WS" && env TRAJECTORY_DB_PATH="$DB" INVOCATION_FLAG="$INVOCATION_FLAG" TMB_SKIP_AUTO_PRESCAN=0 bash "$FAKE_HOOK" 2>/dev/null) || true)
 COLD_CTX=$(echo "$COLD_OUT" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
 assert_contains "$COLD_CTX" "scan is running in the background" "cold context mentions background scan"
 
@@ -208,7 +204,7 @@ assert_not_contains "$COLD_CTX" "tell the Human to run /scan" "no manual scan in
 
 test_case "cold + TMB_SKIP_AUTO_PRESCAN=1: context says world model is cold"
 rm -f "$INVOCATION_FLAG"
-SKIP_OUT=$(TRAJECTORY_DB_PATH="$DB" TMB_SKIP_AUTO_PRESCAN=1 bash "$FAKE_HOOK" 2>/dev/null || true)
+SKIP_OUT=$((cd "$FIXTURE_WS" && env TRAJECTORY_DB_PATH="$DB" TMB_SKIP_AUTO_PRESCAN=1 bash "$FAKE_HOOK" 2>/dev/null) || true)
 SKIP_CTX=$(echo "$SKIP_OUT" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
 assert_contains "$SKIP_CTX" "cold" "skip context mentions cold"
 
@@ -224,19 +220,17 @@ test_case "cold + TMB_SKIP_AUTO_PRESCAN=1: no background scan message"
 assert_not_contains "$SKIP_CTX" "scan is running in the background" "no background scan message when bypassed"
 
 # ---- warm session: no scan, no cold note ----
-# Run in $TMPDIR (not the live repo) so git output is empty and cannot
-# contain commit messages with "world model is cold" text.
 
 test_case "warm: context shows warm world model"
 sqlite3 "$DB" "INSERT INTO audit (event_type) VALUES ('deep_scan_completed');"
-WARM_OUT=$(cd "$TMPDIR" && TRAJECTORY_DB_PATH="$DB" bash "$FAKE_HOOK" 2>/dev/null || true)
+WARM_OUT=$((cd "$FIXTURE_WS" && env TRAJECTORY_DB_PATH="$DB" bash "$HOOK" 2>/dev/null) || true)
 WARM_CTX=$(echo "$WARM_OUT" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
 assert_contains "$WARM_CTX" "warm" "warm context shows warm"
 
 test_case "warm: no background scan note in context"
 assert_not_contains "$WARM_CTX" "scan is running in the background" "no scan note in warm session"
 
-test_case "warm: no cold message in context"
+test_case "warm: no cold-world-model note in context"
 assert_not_contains "$WARM_CTX" "world model is cold" "no cold message in warm session"
 
 summarize

--- a/tests/l3-integration/hooks/session-start-prescan.test.sh
+++ b/tests/l3-integration/hooks/session-start-prescan.test.sh
@@ -224,15 +224,19 @@ test_case "cold + TMB_SKIP_AUTO_PRESCAN=1: no background scan message"
 assert_not_contains "$SKIP_CTX" "scan is running in the background" "no background scan message when bypassed"
 
 # ---- warm session: no scan, no cold note ----
+# Run in $TMPDIR (not the live repo) so git output is empty and cannot
+# contain commit messages with "world model is cold" text.
 
 test_case "warm: context shows warm world model"
 sqlite3 "$DB" "INSERT INTO audit (event_type) VALUES ('deep_scan_completed');"
-WARM_OUT=$(TRAJECTORY_DB_PATH="$DB" bash "$HOOK" 2>/dev/null || true)
+WARM_OUT=$(cd "$TMPDIR" && TRAJECTORY_DB_PATH="$DB" bash "$FAKE_HOOK" 2>/dev/null || true)
 WARM_CTX=$(echo "$WARM_OUT" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
 assert_contains "$WARM_CTX" "warm" "warm context shows warm"
 
-test_case "warm: no cold note in context"
+test_case "warm: no background scan note in context"
 assert_not_contains "$WARM_CTX" "scan is running in the background" "no scan note in warm session"
+
+test_case "warm: no cold message in context"
 assert_not_contains "$WARM_CTX" "world model is cold" "no cold message in warm session"
 
 summarize

--- a/tests/l3-integration/hooks/session-start-prescan.test.sh
+++ b/tests/l3-integration/hooks/session-start-prescan.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Tests for scripts/hooks/session-start-prescan.sh.
-# Covers: output is valid JSON, additionalContext is emitted, and cache-friendly
-# ordering — stable inventory markers appear before volatile count markers.
+# Covers: output is valid JSON, additionalContext is emitted, cache-friendly
+# ordering, cold-session auto-scan launch, bypass env, and warm-session path.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -138,5 +138,101 @@ test_case "missing DB: hook exits silently (no output)"
 rm -f "$DB"
 out_no_db=$(bash "$HOOK" 2>/dev/null || true)
 assert_eq "" "$out_no_db" "no output when DB missing"
+
+# Re-create DB for the remaining cold/warm tests.
+sqlite3 "$DB" "
+  CREATE TABLE issues (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    objective TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'open',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_id INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE audit (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type TEXT NOT NULL,
+    payload TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  INSERT INTO issues (objective, status) VALUES ('test issue', 'open');
+  INSERT INTO tasks (issue_id, status) VALUES (1, 'pending');
+"
+
+# ---- cold session: auto-scan fires ----
+# Build a fake invoker that records its invocation without actually running a scan.
+FAKE_INVOKER_DIR="$TMPDIR/fake-maintenance"
+mkdir -p "$FAKE_INVOKER_DIR"
+INVOCATION_FLAG="$TMPDIR/invoked"
+cat > "$FAKE_INVOKER_DIR/run-scan-initial.mjs" <<'FAKE'
+#!/usr/bin/env node
+import { writeFileSync } from 'node:fs';
+// Record invocation and exit cleanly.
+writeFileSync(process.env.INVOCATION_FLAG, '1');
+FAKE
+
+# Build a fake scripts tree: hooks/, maintenance/, and scan.sh (availability sentinel).
+FAKE_SCRIPTS="$TMPDIR/fake-scripts"
+mkdir -p "$FAKE_SCRIPTS/hooks"
+mkdir -p "$FAKE_SCRIPTS/maintenance"
+cp "$PLUGIN_ROOT/scripts/hooks/session-start-prescan.sh" "$FAKE_SCRIPTS/hooks/session-start-prescan.sh"
+cp "$FAKE_INVOKER_DIR/run-scan-initial.mjs" "$FAKE_SCRIPTS/maintenance/run-scan-initial.mjs"
+# Provide a stub scan.sh so the hook's availability check passes.
+echo '#!/usr/bin/env bash' > "$FAKE_SCRIPTS/scan.sh"
+chmod +x "$FAKE_SCRIPTS/scan.sh"
+FAKE_HOOK="$FAKE_SCRIPTS/hooks/session-start-prescan.sh"
+
+test_case "cold + invoker present: context says scan started"
+rm -f "$INVOCATION_FLAG"
+COLD_OUT=$(TRAJECTORY_DB_PATH="$DB" INVOCATION_FLAG="$INVOCATION_FLAG" TMB_SKIP_AUTO_PRESCAN=0 bash "$FAKE_HOOK" 2>/dev/null || true)
+COLD_CTX=$(echo "$COLD_OUT" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+assert_contains "$COLD_CTX" "scan is running in the background" "cold context mentions background scan"
+
+test_case "cold + invoker present: scan process was invoked"
+# Give the background node process a moment to write the flag.
+sleep 0.5
+if [ -f "$INVOCATION_FLAG" ]; then
+  _pass
+else
+  _fail "fake invoker was not called (flag missing at $INVOCATION_FLAG)"
+fi
+
+test_case "cold + invoker present: no Human-directed /scan instruction"
+assert_not_contains "$COLD_CTX" "tell the Human to run /scan" "no manual scan instruction"
+
+# ---- cold + TMB_SKIP_AUTO_PRESCAN=1: warn only, no invocation ----
+
+test_case "cold + TMB_SKIP_AUTO_PRESCAN=1: context says world model is cold"
+rm -f "$INVOCATION_FLAG"
+SKIP_OUT=$(TRAJECTORY_DB_PATH="$DB" TMB_SKIP_AUTO_PRESCAN=1 bash "$FAKE_HOOK" 2>/dev/null || true)
+SKIP_CTX=$(echo "$SKIP_OUT" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+assert_contains "$SKIP_CTX" "cold" "skip context mentions cold"
+
+test_case "cold + TMB_SKIP_AUTO_PRESCAN=1: invoker not called"
+sleep 0.2
+if [ -f "$INVOCATION_FLAG" ]; then
+  _fail "invoker was called despite TMB_SKIP_AUTO_PRESCAN=1"
+else
+  _pass
+fi
+
+test_case "cold + TMB_SKIP_AUTO_PRESCAN=1: no background scan message"
+assert_not_contains "$SKIP_CTX" "scan is running in the background" "no background scan message when bypassed"
+
+# ---- warm session: no scan, no cold note ----
+
+test_case "warm: context shows warm world model"
+sqlite3 "$DB" "INSERT INTO audit (event_type) VALUES ('deep_scan_completed');"
+WARM_OUT=$(TRAJECTORY_DB_PATH="$DB" bash "$HOOK" 2>/dev/null || true)
+WARM_CTX=$(echo "$WARM_OUT" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+assert_contains "$WARM_CTX" "warm" "warm context shows warm"
+
+test_case "warm: no cold note in context"
+assert_not_contains "$WARM_CTX" "scan is running in the background" "no scan note in warm session"
+assert_not_contains "$WARM_CTX" "world model is cold" "no cold message in warm session"
 
 summarize


### PR DESCRIPTION
Implements #309: session-start-prescan backgrounds the deterministic scan on a cold world model (TMB_SKIP_AUTO_PRESCAN bypass for tests) and reports it started, replacing the tell-the-Human /scan instruction that contradicted tmb_planning §1. Hermetic test suite (25/25 from repo root, /tmp, and $HOME). Gate trail: task 16, pr-reviewer PASS (row 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)