### PR TITLE
🐛 fix(hooks): worktree-create conforms to the documented WorktreeCreate contract

### DIFF
--- a/scripts/hooks/post-task-create-spawn-hint.sh
+++ b/scripts/hooks/post-task-create-spawn-hint.sh
@@ -71,7 +71,9 @@ REASON="🚀 SWE-spawn hint: ${TOOL_NAME##*__} created the following tasks. Per 
 Tasks created:
 ${TASK_LIST_WITH_PATHS}
 
-For each: \`Agent(subagent_type='swe', isolation='worktree', prompt='task_id=<N> worktree=<absolute-worktree-path>')\`. The branch is already pre-created (branch_id_proposed audit + git switch); SWE attaches to it.
+For each task, run the two-step proven flow:
+1. Pre-create the worktree: \`printf '{\"branch\":\"<branch_id>\"}' | bash \${CLAUDE_PLUGIN_ROOT}/scripts/hooks/worktree-create.sh\` — capture the printed path.
+2. Spawn SWE: \`Agent(subagent_type='swe', prompt='task_id=<N> worktree=<absolute-worktree-path>')\` — no isolation= parameter.
 
 If you intentionally want to halt before SWE (e.g. user requested review), surface that reason explicitly so future sessions don't see this as a stuck-task bug."
 

--- a/scripts/hooks/worktree-create.sh
+++ b/scripts/hooks/worktree-create.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# WorktreeCreate hook (#110 Phase 2). Routes worktree creation to the correct
-# git repo when tasks.repo is set.
+# WorktreeCreate hook. Routes worktree creation to the correct git repo.
+#
+# Contract (CC WorktreeCreate): stdout = bare absolute worktree path on success;
+# exit 0 = success, non-zero = fail. No JSON dialect, no continue/defer.
 #
 # Reads CC's WorktreeCreate hook input (JSON via stdin). Extracts the
 # requested branch name, then looks up the task by branch_id in the
@@ -11,9 +13,16 @@
 #   2. tmb_default_repo (plugin_config) — used when CWD is not a git repo
 #   3. WORKSPACE_ROOT — fallback for single-repo layouts where workspace IS the repo
 #
+# No-match (branch not in tasks table):
+#   Create the worktree in the resolution-order repo (tasks.repo unavailable →
+#   tmb_default_repo → workspace root), creating the branch if it does not exist.
+#
+# DB-absent (non-TMB project):
+#   Create under <cwd>/.claude/worktrees/<sanitized-branch> from the cwd repo.
+#
 # Runs `git -C <repo> worktree add <path> <branch>` inside the resolved repo.
 # The worktree attaches to the named branch so SWE's commits advance the branch
-# ref directly and pushes carry the commits (#2869 / #2879).
+# ref directly and pushes carry the commits.
 #
 # Worktree path: <workspace_root>/.claude/worktrees/<slug>
 # where slug strips the <type>/ prefix (fix/123-foo → 123-foo).
@@ -21,14 +30,10 @@
 # Resolves <repo> relative to the workspace root (dir containing
 # .claude/<plugin>/trajectory.db), found via tmb_db_path walk-up.
 #
-# Silent pass-through (continue: true) when:
-#   - no branch in input
-#   - no matching task found
-#   - trajectory DB absent (not a TMB project)
-#
 # Exits non-zero when:
-#   - resolved repo is not a git work tree (DB present = known TMB project)
-#   - git worktree add fails (branch does not exist pre-created)
+#   - no branch in input (nothing to create)
+#   - resolved repo is not a git work tree
+#   - git worktree add fails
 
 set -uo pipefail
 
@@ -39,44 +44,65 @@ PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 INPUT=$(cat)
 
 BRANCH_NAME=$(echo "$INPUT" | jq -r '.branch // ""' 2>/dev/null)
-[ -n "$BRANCH_NAME" ] || { echo '{"continue":true}'; exit 0; }
+if [ -z "$BRANCH_NAME" ]; then
+  printf 'tmb worktree-create: no branch in input — nothing to create\n' >&2
+  exit 1
+fi
+
+# Slug: strip type/ prefix (fix/123-foo → 123-foo)
+SLUG="${BRANCH_NAME#*/}"
 
 DB_PATH=$(tmb_db_path 2>/dev/null) || true
+
+# DB-absent: non-TMB project — create from cwd repo
 if [ -z "$DB_PATH" ] || [ ! -f "$DB_PATH" ]; then
-  echo '{"continue":true}'
+  CWD_REPO="$(pwd)"
+  WORKTREE_PATH="$CWD_REPO/.claude/worktrees/$SLUG"
+  if ! git -C "$CWD_REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    printf 'tmb worktree-create: no trajectory DB and cwd %s is not a git repo\n' \
+      "$CWD_REPO" >&2
+    exit 1
+  fi
+  mkdir -p "$(dirname "$WORKTREE_PATH")"
+  if [ -e "$WORKTREE_PATH/.git" ]; then
+    printf 'tmb worktree-create: reusing existing worktree %s for branch %s\n' \
+      "$WORKTREE_PATH" "$BRANCH_NAME" >&2
+    echo "$WORKTREE_PATH"
+    exit 0
+  fi
+  if ! git -C "$CWD_REPO" show-ref --verify --quiet "refs/heads/$BRANCH_NAME" 2>/dev/null; then
+    git -C "$CWD_REPO" branch "$BRANCH_NAME" HEAD >/dev/null 2>&1 \
+      || { printf 'tmb worktree-create: could not create branch %s in %s\n' \
+             "$BRANCH_NAME" "$CWD_REPO" >&2; exit 1; }
+    printf 'tmb worktree-create: auto-created branch %s in %s\n' \
+      "$BRANCH_NAME" "$CWD_REPO" >&2
+  fi
+  if ! git -C "$CWD_REPO" worktree add "$WORKTREE_PATH" "$BRANCH_NAME" >/dev/null 2>&1; then
+    printf 'tmb worktree-create: git worktree add failed for branch %s in %s\n' \
+      "$BRANCH_NAME" "$CWD_REPO" >&2
+    exit 1
+  fi
+  printf 'tmb worktree-create: created worktree %s for branch %s (no-DB path)\n' \
+    "$WORKTREE_PATH" "$BRANCH_NAME" >&2
+  echo "$WORKTREE_PATH"
   exit 0
 fi
 
-tmb_have_sqlite || { echo '{"continue":true}'; exit 0; }
+tmb_have_sqlite || {
+  printf 'tmb worktree-create: sqlite3 unavailable\n' >&2
+  exit 1
+}
+
+WORKSPACE_ROOT="$(dirname "$(dirname "$(dirname "$DB_PATH")")")"
 
 SAFE_BRANCH="$(printf '%s' "$BRANCH_NAME" | sed "s/'/''/g")"
 TASK_COUNT=$(sqlite3 "$DB_PATH" \
   "SELECT COUNT(*) FROM tasks WHERE branch_id='$SAFE_BRANCH';" \
   2>/dev/null || echo 0)
 
-# No matching task → not a TMB-managed branch; defer to the harness default.
 if [ "$TASK_COUNT" = "0" ]; then
-  echo '{"continue":true}'
-  exit 0
-fi
-
-REPO=$(sqlite3 "$DB_PATH" \
-  "SELECT COALESCE(repo,'') FROM tasks WHERE branch_id='$SAFE_BRANCH' LIMIT 1;" \
-  2>/dev/null || true)
-
-WORKSPACE_ROOT="$(dirname "$(dirname "$(dirname "$DB_PATH")")")"
-DEFAULT_REPO=""
-
-# Resolve the repo that owns the branch.
-# Priority: tasks.repo → tmb_default_repo (plugin_config) → WORKSPACE_ROOT.
-if [ -n "$REPO" ]; then
-  # tasks.repo is set: may be relative or absolute
-  case "$REPO" in
-    /*) REPO_ABS="$REPO" ;;
-    *)  REPO_ABS="$WORKSPACE_ROOT/$REPO" ;;
-  esac
-else
-  DEFAULT_REPO=$(tmb_config_get "tmb_default_repo" 2>/dev/null || true)
+  # No matching task — create in the default-repo resolution order
+  DEFAULT_REPO=$(tmb_config_get "tmb_default_repo" "$DB_PATH" 2>/dev/null || true)
   if [ -n "$DEFAULT_REPO" ]; then
     case "$DEFAULT_REPO" in
       /*) REPO_ABS="$DEFAULT_REPO" ;;
@@ -85,36 +111,60 @@ else
   else
     REPO_ABS="$WORKSPACE_ROOT"
   fi
+  WORKTREE_PATH="$WORKSPACE_ROOT/.claude/worktrees/$SLUG"
+else
+  REPO=$(sqlite3 "$DB_PATH" \
+    "SELECT COALESCE(repo,'') FROM tasks WHERE branch_id='$SAFE_BRANCH' LIMIT 1;" \
+    2>/dev/null || true)
+
+  DEFAULT_REPO=""
+  if [ -n "$REPO" ]; then
+    case "$REPO" in
+      /*) REPO_ABS="$REPO" ;;
+      *)  REPO_ABS="$WORKSPACE_ROOT/$REPO" ;;
+    esac
+  else
+    DEFAULT_REPO=$(tmb_config_get "tmb_default_repo" "$DB_PATH" 2>/dev/null || true)
+    if [ -n "$DEFAULT_REPO" ]; then
+      case "$DEFAULT_REPO" in
+        /*) REPO_ABS="$DEFAULT_REPO" ;;
+        *)  REPO_ABS="$WORKSPACE_ROOT/$DEFAULT_REPO" ;;
+      esac
+    else
+      REPO_ABS="$WORKSPACE_ROOT"
+    fi
+  fi
+
+  WORKTREE_PATH="$WORKSPACE_ROOT/.claude/worktrees/$SLUG"
 fi
 
-# If the resolved repo isn't a git work tree, fail loudly — silently continuing
-# into the harness default produces an opaque "not a directory" error from CC.
+# If the resolved repo isn't a git work tree, fail loudly
 if ! git -C "$REPO_ABS" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  printf 'tmb worktree-create: resolved repo %s is not a git work tree (task repo=%s, default_repo=%s, workspace=%s)\n' \
-    "$REPO_ABS" "${REPO:-}" "$DEFAULT_REPO" "$WORKSPACE_ROOT" >&2
+  printf 'tmb worktree-create: resolved repo %s is not a git work tree\n' \
+    "$REPO_ABS" >&2
   exit 1
 fi
 
-SLUG="${BRANCH_NAME#*/}"
-
-# Worktree path is workspace-rooted (not repo-rooted) so .claude/ state stays
-# out of inner git repos. The worktree is still git-attached to <repo> via
-# `git -C <repo>` — git tracks it in <repo>/.git/worktrees/<slug>; the checkout
-# files live at <workspace_root>/.claude/worktrees/<slug>/.
-WORKTREE_PATH="$WORKSPACE_ROOT/.claude/worktrees/$SLUG"
-
 mkdir -p "$(dirname "$WORKTREE_PATH")"
 
-# Idempotent: if a worktree already lives at the canonical path, reuse it
-# instead of a second `git worktree add` that fails "already exists" (#306).
+# Idempotent: reuse an existing worktree at the canonical path
 if [ -e "$WORKTREE_PATH/.git" ]; then
   printf 'tmb worktree-create: reusing existing worktree %s for branch %s\n' \
     "$WORKTREE_PATH" "$BRANCH_NAME" >&2
-  jq -nc --arg path "$WORKTREE_PATH" '{"continue":false,"worktreePath":$path}'
+  echo "$WORKTREE_PATH"
   exit 0
 fi
 
-if ! git -C "$REPO_ABS" worktree add "$WORKTREE_PATH" "$BRANCH_NAME" 2>&1; then
+# Create the branch if it does not exist (harness expects creation to succeed)
+if ! git -C "$REPO_ABS" show-ref --verify --quiet "refs/heads/$BRANCH_NAME" 2>/dev/null; then
+  git -C "$REPO_ABS" branch "$BRANCH_NAME" HEAD >/dev/null 2>&1 \
+    || { printf 'tmb worktree-create: could not create branch %s in %s\n' \
+           "$BRANCH_NAME" "$REPO_ABS" >&2; exit 1; }
+  printf 'tmb worktree-create: auto-created branch %s in %s\n' \
+    "$BRANCH_NAME" "$REPO_ABS" >&2
+fi
+
+if ! git -C "$REPO_ABS" worktree add "$WORKTREE_PATH" "$BRANCH_NAME" >/dev/null 2>&1; then
   printf 'tmb worktree-create: git worktree add failed for branch %s in repo %s\n' \
     "$BRANCH_NAME" "$REPO_ABS" >&2
   exit 1
@@ -123,4 +173,4 @@ fi
 printf 'tmb worktree-create: created worktree %s for branch %s in repo %s\n' \
   "$WORKTREE_PATH" "$BRANCH_NAME" "$REPO_ABS" >&2
 
-jq -nc --arg path "$WORKTREE_PATH" '{"continue":false,"worktreePath":$path}'
+echo "$WORKTREE_PATH"

--- a/tests/l3-integration/hooks/post-task-create-spawn-hint.test.sh
+++ b/tests/l3-integration/hooks/post-task-create-spawn-hint.test.sh
@@ -79,6 +79,9 @@ assert_contains "$out" "task_id=42" "hint lists task id 42"
 assert_contains "$out" "task_id=43" "hint lists task id 43"
 assert_contains "$out" "branch_id=feat/my-feature" "hint lists branch_id"
 assert_contains "$out" "Step 4" "hint cites tmb_planning Step 4"
+assert_contains "$out" "worktree-create.sh" "hint includes worktree-create pre-create step"
+assert_contains "$out" "CLAUDE_PLUGIN_ROOT" "hint uses CLAUDE_PLUGIN_ROOT variable"
+assert_not_contains "$out" "isolation='worktree'" "hint must not use isolation='worktree' in recipe"
 
 # ──────────────────────────────────────────────────────────────
 # Case 4b: absolute worktree path derived from trajectory DB location

--- a/tests/l3-integration/hooks/worktree-create.test.sh
+++ b/tests/l3-integration/hooks/worktree-create.test.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 # Tests for scripts/hooks/worktree-create.sh.
-# Hook contract: WorktreeCreate event. It is the SOLE worktree-creation path
-# (#306 — bro no longer pre-creates one manually). When task.repo is set,
-# creates the worktree inside that repo; when repo is NULL/empty it falls back
-# to the workspace root as the repo (single-repo CC). Returns {"continue":true}
-# only when there's no matching task or the resolved repo isn't a git work tree.
+# Hook contract: WorktreeCreate event. stdout = bare absolute worktree path on
+# success; exit 0 = success, non-zero = fail. No JSON dialect. Informational
+# output is stderr-only.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -58,46 +56,110 @@ input_event() {
   jq -n --arg branch "$branch" '{branch: $branch}'
 }
 
-run_hook() {
-  echo "$1" | bash "$HOOK" 2>&1
+# run_hook_stdout: stdout only, stderr suppressed; returns exit code via $?
+run_hook_stdout() {
+  echo "$1" | bash "$HOOK" 2>/dev/null || return $?
+}
+
+# run_hook_stderr: stderr only, stdout suppressed; always exits 0 for capture
+run_hook_stderr() {
+  echo "$1" | bash "$HOOK" 2>&1 >/dev/null || true
 }
 
 # --- tests -------------------------------------------------------------------
 
-test_case "no branch in input: continue=true"
-out=$(run_hook '{}')
-assert_contains "$out" '"continue":true' "no branch → no-op"
+test_case "no branch in input: exits non-zero, empty stdout"
+no_branch_stdout=$(echo '{}' | bash "$HOOK" 2>/dev/null || true)
+assert_eq "" "$no_branch_stdout" "no branch → empty stdout"
+no_branch_exit=0
+echo '{}' | bash "$HOOK" 2>/dev/null || no_branch_exit=$?
+if [ "$no_branch_exit" -ne 0 ]; then _pass; else _fail "expected non-zero exit for no-branch input"; fi
 
-test_case "branch with no matching task: continue=true"
-out=$(run_hook "$(input_event 'feat/999-unknown')")
-assert_contains "$out" '"continue":true' "unknown branch → no-op"
+test_case "informational output is stderr-only on success path"
+git -C "$INNER_REPO" branch feat/999-for-stderr-test HEAD 2>/dev/null || true
+sqlite3 "$DB" "INSERT OR IGNORE INTO tasks (id, branch_id, status, repo) VALUES (99, 'feat/999-for-stderr-test', 'pending', 'inner');"
+stdout_only=$(echo "$(input_event 'feat/999-for-stderr-test')" | bash "$HOOK" 2>/dev/null)
+case "$stdout_only" in
+  /*)  _pass ;;
+  *)   _fail "stdout is not an absolute path: '$stdout_only'" ;;
+esac
+assert_not_contains "$stdout_only" '"continue"' "stdout must not contain JSON"
+assert_not_contains "$stdout_only" 'tmb worktree-create' "informational text must be on stderr"
 
-test_case "repo=NULL, no tmb_default_repo, workspace root is not a git repo: exit 1 with clear error"
-# repo=NULL + no default + workspace root is not a git repo → fail loudly
-# rather than silently continue into a harness "not a directory" error.
-out=$(run_hook "$(input_event 'feat/456-no-repo')" || true)
-assert_contains "$out" 'not a git work tree' "unroutable null repo → loud error"
+test_case "no-match + no default repo + workspace not git: exit non-zero with stderr reason"
+# feat/888-unknown not in tasks; workspace root is not a git repo; no tmb_default_repo
+no_match_exit=0
+echo "$(input_event 'feat/888-unknown')" | TRAJECTORY_DB_PATH="$DB" bash "$HOOK" 2>/dev/null || no_match_exit=$?
+if [ "$no_match_exit" -ne 0 ]; then _pass; else _fail "expected non-zero when workspace root is not a git repo"; fi
+no_match_stderr=$(run_hook_stderr "$(input_event 'feat/888-unknown')")
+assert_contains "$no_match_stderr" 'not a git work tree' "stderr explains why creation failed"
 
-test_case "repo=NULL, tmb_default_repo set, workspace root is not a git repo: worktree created in default repo"
-# Inject tmb_default_repo = 'inner' into the DB so the hook can resolve the repo.
+test_case "no-match with tmb_default_repo set: worktree created, bare path on stdout"
 sqlite3 "$DB" "
   INSERT OR REPLACE INTO plugin_config (key, value_json)
     VALUES ('tmb_default_repo', '\"inner\"');
 "
-git -C "$INNER_REPO" branch feat/456-no-repo HEAD
-out=$(run_hook "$(input_event 'feat/456-no-repo')")
-assert_contains "$out" '"continue":false' "default_repo set → hook creates worktree"
-assert_contains "$out" '456-no-repo' "worktree path contains slug"
-DEFAULT_WT="$WORKSPACE/.claude/worktrees/456-no-repo"
-if [ -d "$DEFAULT_WT" ]; then _pass; else _fail "worktree not created at $DEFAULT_WT"; fi
-# Clean up so downstream tests are not affected
+git -C "$INNER_REPO" branch feat/777-nomatch HEAD 2>/dev/null || true
+no_match_path=$(echo "$(input_event 'feat/777-nomatch')" | bash "$HOOK" 2>/dev/null)
+case "$no_match_path" in
+  /*)  _pass "stdout is absolute path" ;;
+  *)   _fail "stdout is not an absolute path: '$no_match_path'" ;;
+esac
+assert_contains "$no_match_path" '777-nomatch' "path contains slug"
+NOMATCH_WT="$WORKSPACE/.claude/worktrees/777-nomatch"
+if [ -d "$NOMATCH_WT" ]; then _pass; else _fail "worktree not created at $NOMATCH_WT"; fi
 sqlite3 "$DB" "DELETE FROM plugin_config WHERE key='tmb_default_repo';"
 
-test_case "branch matching task with repo set: worktree created at workspace-rooted path"
-out=$(run_hook "$(input_event 'fix/123-with-repo')")
-assert_not_contains "$out" '"continue":true' "repo set → not a no-op"
-assert_contains "$out" '"continue":false' "repo set → continue=false"
-assert_contains "$out" '123-with-repo' "worktree path contains slug"
+test_case "no-match with tmb_default_repo set: branch auto-created when missing"
+sqlite3 "$DB" "
+  INSERT OR REPLACE INTO plugin_config (key, value_json)
+    VALUES ('tmb_default_repo', '\"inner\"');
+"
+# feat/666-autocreate does not exist as a branch in inner repo
+autocreate_path=$(echo "$(input_event 'feat/666-autocreate')" | bash "$HOOK" 2>/dev/null)
+case "$autocreate_path" in
+  /*)  _pass "stdout is absolute path" ;;
+  *)   _fail "stdout is not an absolute path: '$autocreate_path'" ;;
+esac
+AUTOCREATE_WT="$WORKSPACE/.claude/worktrees/666-autocreate"
+if [ -d "$AUTOCREATE_WT" ]; then _pass; else _fail "worktree not created at $AUTOCREATE_WT"; fi
+if git -C "$INNER_REPO" show-ref --verify --quiet "refs/heads/feat/666-autocreate" 2>/dev/null; then
+  _pass "branch auto-created in inner repo"
+else
+  _fail "branch feat/666-autocreate not auto-created"
+fi
+sqlite3 "$DB" "DELETE FROM plugin_config WHERE key='tmb_default_repo';"
+
+test_case "repo=NULL, no tmb_default_repo, workspace root is not a git repo: exit 1 with clear error"
+null_repo_exit=0
+echo "$(input_event 'feat/456-no-repo')" | TRAJECTORY_DB_PATH="$DB" bash "$HOOK" 2>/dev/null || null_repo_exit=$?
+if [ "$null_repo_exit" -ne 0 ]; then _pass; else _fail "expected non-zero exit"; fi
+null_repo_stderr=$(run_hook_stderr "$(input_event 'feat/456-no-repo')")
+assert_contains "$null_repo_stderr" 'not a git work tree' "unroutable null repo → loud error"
+
+test_case "repo=NULL, tmb_default_repo set: worktree created in default repo, bare path on stdout"
+sqlite3 "$DB" "
+  INSERT OR REPLACE INTO plugin_config (key, value_json)
+    VALUES ('tmb_default_repo', '\"inner\"');
+"
+git -C "$INNER_REPO" branch feat/456-no-repo HEAD 2>/dev/null || true
+no_repo_path=$(echo "$(input_event 'feat/456-no-repo')" | bash "$HOOK" 2>/dev/null)
+case "$no_repo_path" in
+  /*)  _pass "stdout is absolute path" ;;
+  *)   _fail "stdout is not an absolute path: '$no_repo_path'" ;;
+esac
+assert_contains "$no_repo_path" '456-no-repo' "path contains slug"
+if [ -d "$WORKSPACE/.claude/worktrees/456-no-repo" ]; then _pass; else _fail "worktree not created"; fi
+sqlite3 "$DB" "DELETE FROM plugin_config WHERE key='tmb_default_repo';"
+
+test_case "branch matching task with repo set: stdout is bare absolute path"
+task_path=$(echo "$(input_event 'fix/123-with-repo')" | bash "$HOOK" 2>/dev/null)
+case "$task_path" in
+  /*)  _pass "stdout is absolute path" ;;
+  *)   _fail "stdout is not an absolute path: '$task_path'" ;;
+esac
+assert_not_contains "$task_path" '"continue"' "stdout must not contain JSON"
+assert_contains "$task_path" '123-with-repo' "path contains slug"
 
 WORKTREE_PATH="$WORKSPACE/.claude/worktrees/123-with-repo"
 if [ -d "$WORKTREE_PATH" ]; then
@@ -107,9 +169,6 @@ else
 fi
 
 test_case "worktree path is workspace-rooted, not repo-rooted, when workspace != repo"
-# Workspace at $WORKSPACE, inner repo at $WORKSPACE/inner.
-# tasks.repo='inner' → worktree must land at $WORKSPACE/.claude/worktrees/<slug>,
-# NOT at $WORKSPACE/inner/.claude/worktrees/<slug>.
 REPO_ROOTED_PATH="$INNER_REPO/.claude/worktrees/123-with-repo"
 if [ -d "$REPO_ROOTED_PATH" ]; then
   _fail "worktree must NOT be created inside inner repo at $REPO_ROOTED_PATH"
@@ -125,9 +184,6 @@ else
 fi
 
 test_case "REGRESSION (#2879): worktree HEAD is on the named branch"
-# The hook must produce a worktree where `git rev-parse --abbrev-ref HEAD`
-# returns the branch name. Branch ownership lives in the worktree so SWE's
-# commits advance the branch ref directly and pushes carry the work.
 HEAD_BRANCH=$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ "$HEAD_BRANCH" = "fix/123-with-repo" ]; then
   _pass
@@ -148,9 +204,6 @@ else
 fi
 
 # --- single-repo fixture (#306) ---------------------------------------------
-# Layout where the workspace root IS the git repo and the task has repo=NULL.
-# This is the common single-repo case: the hook must still create the canonical
-# .claude/worktrees/<slug> checkout (bro no longer does it manually).
 SINGLE="$TMPDIR/single"
 mkdir -p "$SINGLE"
 git init -q -b main "$SINGLE"
@@ -165,35 +218,32 @@ sqlite3 "$SDB" "
 "
 git -C "$SINGLE" branch fix/789-single HEAD
 
-run_hook_single() {
-  echo "$1" | TRAJECTORY_DB_PATH="$SDB" bash "$HOOK" 2>&1
-}
 SINGLE_WT="$SINGLE/.claude/worktrees/789-single"
 
-test_case "#306: single-repo (workspace root is the repo), repo=NULL: worktree created"
-out=$(run_hook_single "$(input_event 'fix/789-single')")
-assert_contains "$out" '"continue":false' "single-repo repo=NULL → hook creates worktree"
-assert_contains "$out" '789-single' "worktree path contains slug"
+test_case "#306: single-repo (workspace root is the repo), repo=NULL: worktree created, bare path on stdout"
+single_path=$(echo "$(input_event 'fix/789-single')" | TRAJECTORY_DB_PATH="$SDB" bash "$HOOK" 2>/dev/null)
+case "$single_path" in
+  /*)  _pass "stdout is absolute path" ;;
+  *)   _fail "stdout is not an absolute path: '$single_path'" ;;
+esac
+assert_not_contains "$single_path" '"continue"' "stdout must not contain JSON"
+assert_contains "$single_path" '789-single' "path contains slug"
 if [ -d "$SINGLE_WT" ]; then _pass; else _fail "worktree not created at $SINGLE_WT"; fi
 
 test_case "#306: single-repo worktree HEAD is on the named branch"
 HB=$(git -C "$SINGLE_WT" rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ "$HB" = "fix/789-single" ]; then _pass; else _fail "expected HEAD on fix/789-single, got '$HB'"; fi
 
-test_case "#306: idempotent — second fire reuses the existing worktree, no error"
-out=$(run_hook_single "$(input_event 'fix/789-single')")
-assert_contains "$out" '"continue":false' "second fire still returns a worktreePath"
-assert_contains "$out" '789-single' "reused path contains slug"
-assert_not_contains "$out" 'failed' "no git worktree-add failure on the second fire"
+test_case "#306: idempotent — second fire reuses the existing worktree, bare path on stdout"
+single_path2=$(echo "$(input_event 'fix/789-single')" | TRAJECTORY_DB_PATH="$SDB" bash "$HOOK" 2>/dev/null)
+case "$single_path2" in
+  /*)  _pass "stdout is absolute path on second call" ;;
+  *)   _fail "stdout is not an absolute path on second call: '$single_path2'" ;;
+esac
+assert_contains "$single_path2" '789-single' "reused path contains slug"
+assert_not_contains "$single_path2" 'failed' "no error message in stdout"
 
 # --- multi-repo: session dir is parent of repo (#330) -----------------------
-# Layout: WORKSPACE_MR/ (not a git repo — session launch dir)
-#           .claude/tmb/trajectory.db
-#           plugin/                   (the inner git repo tasks point at)
-# tasks.repo = 'plugin' — the hook must git -C plugin/ worktree add
-# and create the worktree at WORKSPACE_MR/.claude/worktrees/<slug>,
-# NOT inside the inner repo.
-
 MR_WORKSPACE="$TMPDIR/mrsession"
 MR_REPO="$MR_WORKSPACE/plugin"
 mkdir -p "$MR_REPO"
@@ -220,15 +270,16 @@ sqlite3 "$MR_DB" "
 "
 git -C "$MR_REPO" branch fix/330-subdir HEAD
 
-run_hook_mr() {
-  echo "$1" | TRAJECTORY_DB_PATH="$MR_DB" bash "$HOOK" 2>&1
-}
 MR_WT="$MR_WORKSPACE/.claude/worktrees/330-subdir"
 
-test_case "#330: multi-repo (session dir is parent of repo subdir): worktree created"
-out=$(run_hook_mr "$(input_event 'fix/330-subdir')")
-assert_contains "$out" '"continue":false' "subdir-repo → hook creates worktree"
-assert_contains "$out" '330-subdir' "worktree path contains slug"
+test_case "#330: multi-repo (session dir is parent of repo subdir): bare path on stdout"
+mr_path=$(echo "$(input_event 'fix/330-subdir')" | TRAJECTORY_DB_PATH="$MR_DB" bash "$HOOK" 2>/dev/null)
+case "$mr_path" in
+  /*)  _pass "stdout is absolute path" ;;
+  *)   _fail "stdout is not an absolute path: '$mr_path'" ;;
+esac
+assert_not_contains "$mr_path" '"continue"' "stdout must not contain JSON"
+assert_contains "$mr_path" '330-subdir' "path contains slug"
 if [ -d "$MR_WT" ]; then _pass; else _fail "worktree not created at $MR_WT"; fi
 
 test_case "#330: subdir-repo worktree HEAD is on the named branch"


### PR DESCRIPTION
Fixes #475: bare-path stdout (stderr-only info, JSON dialect gone), no-match input now CREATES in the resolution-order repo with branch auto-create (the harness has no defer semantics), DB-absent cwd fallback; spawn-hint recipe teaches pre-create + isolation-free spawn (isolation='worktree' can never land SWE on the task branch per the documented contract). 41/41 + 19/19. Gate trail: task 18, pr-reviewer PASS (row 14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)