### PR TITLE
🔒 feat(hooks,tests): pr-reviewer push denied by role; self-safe no-secrets l1 lint

### DIFF
--- a/scripts/hooks/git-push-guard.sh
+++ b/scripts/hooks/git-push-guard.sh
@@ -106,6 +106,14 @@ if [ "$AGENT_TYPE" = "swe" ]; then
   exit 0
 fi
 
+# Block any git push from pr-reviewer context.
+# pr-reviewer renders a verdict row; the push decision belongs to bro
+# after that verdict — pr-reviewer itself must never initiate a push.
+if [ "$AGENT_TYPE" = "pr-reviewer" ]; then
+  jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":"BLOCKED: pr-reviewer must not push. The push decision belongs to bro after the verdict row. Bro reads the validation_attempts verdict and handles the push when all tasks are signed."}}'
+  exit 0
+fi
+
 DB=$(tmb_db_path || true)
 if [ -z "$DB" ] || ! tmb_have_sqlite; then
   # No DB or no sqlite3 — TMB isn't tracking anything in this project; let push through.

--- a/tests/l1-lint/no-secrets-in-source.sh
+++ b/tests/l1-lint/no-secrets-in-source.sh
@@ -84,12 +84,23 @@ run_self_test() {
 
   local fail=0
 
-  # Seed one file per pattern class
-  printf 'AWS_KEY=AKIAIOSFODNN7EXAMPLE\n'                    > "$tmpdir/aws.sh"
-  printf 'token=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg123\n' > "$tmpdir/ghp.sh"
-  printf 'pat=github_pat_ABCDEFGHIJKLMNOPQRSTUVWXYZ1\n'      > "$tmpdir/pat.sh"
-  printf '%s\n' '-----BEGIN RSA PRIVATE KEY-----'             > "$tmpdir/privkey.pem"
-  printf 'api_key = "abcdefghijklmnopqrstuvwxyz12345"\n'     > "$tmpdir/generic.sh"
+  # Seed one file per pattern class.
+  # Seeds are built via string concatenation so no raw secret-shaped literal
+  # exists in this file (which is excluded from the live-tree scan).
+  local A1="AKIA" A2="IOSFODNN7EXAMPLE"
+  printf 'AWS_KEY=%s\n' "${A1}${A2}"                                          > "$tmpdir/aws.sh"
+
+  local G1="ghp_" G2="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg123"
+  printf 'token=%s\n' "${G1}${G2}"                                             > "$tmpdir/ghp.sh"
+
+  local P1="github_pat_" P2="ABCDEFGHIJKLMNOPQRSTUVWXYZ1"
+  printf 'pat=%s\n' "${P1}${P2}"                                               > "$tmpdir/pat.sh"
+
+  local PK1="-----BEGIN RSA " PK2="PRIVATE KEY-----"
+  printf '%s\n' "${PK1}${PK2}"                                                 > "$tmpdir/privkey.pem"
+
+  local AK1="api_key" AK2=' = "abcdefghijklmnopqrstuvwxyz12345"'
+  printf '%s%s\n' "${AK1}" "${AK2}"                                            > "$tmpdir/generic.sh"
 
   # A placeholder that must NOT be caught (too short + placeholder word)
   printf 'secret = "example"\n' > "$tmpdir/placeholder.sh"
@@ -147,9 +158,16 @@ run_live_check() {
   cd "$PLUGIN_ROOT" || exit 1
 
   local findings=()
+  local SELF_REL="tests/l1-lint/no-secrets-in-source.sh"
+  local ALLOW_REL="tests/l1-lint/.no-secrets-allow"
 
   while IFS= read -r tracked_file; do
     [ -f "$tracked_file" ] || continue
+
+    # Exclude this script and the allowlist file (contain pattern seeds/exceptions)
+    case "$tracked_file" in
+      "$SELF_REL"|"$ALLOW_REL") continue ;;
+    esac
 
     # Exclude tests/fixtures/** and docs/**
     case "$tracked_file" in

--- a/tests/l1-lint/no-secrets-in-source.sh
+++ b/tests/l1-lint/no-secrets-in-source.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# L1 lint: scan tracked source for high-confidence secret patterns.
+#
+# Scans: git ls-files output, excluding tests/fixtures/** and docs/**
+#
+# Patterns (high-precision; false-positive-averse):
+#   1. AWS access key IDs          AKIA[0-9A-Z]{16}
+#   2. GitHub personal tokens      ghp_[A-Za-z0-9]{36}
+#   3. GitHub fine-grained PATs    github_pat_[A-Za-z0-9_]{22,}
+#   4. PEM private key headers     -----BEGIN [A-Z ]*PRIVATE KEY-----
+#   5. Generic secret assignments  key/secret/token/password/api_key = '...' or "..." (>=20 chars)
+#
+# Placeholders excluded from pattern 5: xxx, example, dummy, <...>, ${...}, 0000
+#
+# Allowlist: tests/l1-lint/.no-secrets-allow
+#   Format: path:line-pattern (one entry per line; # = comment)
+#   A finding is suppressed when its "file:line: matched-text" output contains
+#   both the path portion and the pattern portion of the allowlist entry.
+#
+# --self-test: seed temp files with one instance of each pattern class,
+#   assert all are caught, then confirm the live tree passes.
+#
+# Exit 0 on pass; exit 1 with file:line listing on fail.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$HERE/../.." && pwd)"
+ALLOWLIST="$HERE/.no-secrets-allow"
+
+# ---------------------------------------------------------------------------
+# Pattern definitions (POSIX ERE, macOS grep -E compatible — no \p or \d)
+# Note: grep receives these via -e to avoid leading-dash parsing issues.
+# ---------------------------------------------------------------------------
+
+P_AWS='AKIA[0-9A-Z]{16}'
+P_GHP='ghp_[A-Za-z0-9]{36}'
+P_PAT='github_pat_[A-Za-z0-9_]{22,}'
+P_PRIVKEY='-----BEGIN [A-Z ]*PRIVATE KEY-----'
+# Generic: key/secret/token/password/api_key followed by = or : and a quoted literal >= 20 chars
+P_GENERIC='(k(ey)?|secret|token|passw(or)?d|api_key)[[:space:]]*[:=][[:space:]]*['"'"'"][A-Za-z0-9+/_-]{20,}['"'"'"]'
+# Placeholder patterns — any match containing these is excluded from P_GENERIC hits
+P_PLACEHOLDER='(xxx|example|dummy|<[^>]*>|\$\{[^}]*\}|0000)'
+
+# grep_secret: run grep with all patterns via separate -e flags to avoid
+# issues when a pattern starts with '-' (e.g. the PEM header).
+grep_secret() {
+  grep -oE \
+    -e "$P_AWS" \
+    -e "$P_GHP" \
+    -e "$P_PAT" \
+    -e "$P_PRIVKEY" \
+    -e "$P_GENERIC" \
+    "$@" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Allowlist helper
+# ---------------------------------------------------------------------------
+
+is_allowlisted() {
+  local finding="$1"
+  [ -f "$ALLOWLIST" ] || return 1
+  while IFS= read -r entry; do
+    case "$entry" in '#'*|'') continue ;; esac
+    local path_part line_part
+    path_part="${entry%%:*}"
+    line_part="${entry#*:}"
+    if echo "$finding" | grep -qF "$path_part" && echo "$finding" | grep -qF "$line_part"; then
+      return 0
+    fi
+  done < "$ALLOWLIST"
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Self-test mode
+# ---------------------------------------------------------------------------
+
+run_self_test() {
+  local tmpdir
+  tmpdir=$(mktemp -d -t tmb-no-secrets-XXXX)
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  local fail=0
+
+  # Seed one file per pattern class
+  printf 'AWS_KEY=AKIAIOSFODNN7EXAMPLE\n'                    > "$tmpdir/aws.sh"
+  printf 'token=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg123\n' > "$tmpdir/ghp.sh"
+  printf 'pat=github_pat_ABCDEFGHIJKLMNOPQRSTUVWXYZ1\n'      > "$tmpdir/pat.sh"
+  printf '%s\n' '-----BEGIN RSA PRIVATE KEY-----'             > "$tmpdir/privkey.pem"
+  printf 'api_key = "abcdefghijklmnopqrstuvwxyz12345"\n'     > "$tmpdir/generic.sh"
+
+  # A placeholder that must NOT be caught (too short + placeholder word)
+  printf 'secret = "example"\n' > "$tmpdir/placeholder.sh"
+
+  check_caught() {
+    local file="$1" label="$2"
+    local result
+    result=$(grep_secret "$file")
+    if [ -z "$result" ]; then
+      printf 'FAIL self-test: pattern class [%s] not caught\n' "$label" >&2
+      fail=1
+    else
+      printf 'PASS self-test: pattern class [%s] caught\n' "$label"
+    fi
+  }
+
+  check_caught "$tmpdir/aws.sh"      "AWS access key"
+  check_caught "$tmpdir/ghp.sh"      "GitHub ghp_ token"
+  check_caught "$tmpdir/pat.sh"      "GitHub fine-grained PAT"
+  check_caught "$tmpdir/privkey.pem" "PEM private key header"
+  check_caught "$tmpdir/generic.sh"  "generic secret assignment"
+
+  # Placeholder must NOT produce a non-placeholder match
+  placeholder_hit=$(grep_secret "$tmpdir/placeholder.sh")
+  if [ -n "$placeholder_hit" ] && ! printf '%s' "$placeholder_hit" | grep -qE "$P_PLACEHOLDER"; then
+    printf 'FAIL self-test: placeholder line was incorrectly flagged\n' >&2
+    fail=1
+  else
+    printf 'PASS self-test: placeholder exclusion correct\n'
+  fi
+
+  if [ "$fail" -ne 0 ]; then
+    printf '\nno-secrets-in-source --self-test: FAIL\n' >&2
+    exit 1
+  fi
+
+  printf '\nno-secrets-in-source --self-test: PASS (5 pattern classes verified)\n'
+
+  # Also run the live-tree check as part of self-test
+  printf '\nRunning live-tree check...\n'
+  if run_live_check; then
+    printf 'no-secrets-in-source --self-test + live-tree: PASS\n'
+    exit 0
+  else
+    printf 'no-secrets-in-source --self-test: live-tree FAIL\n' >&2
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Live-tree scan
+# ---------------------------------------------------------------------------
+
+run_live_check() {
+  cd "$PLUGIN_ROOT" || exit 1
+
+  local findings=()
+
+  while IFS= read -r tracked_file; do
+    [ -f "$tracked_file" ] || continue
+
+    # Exclude tests/fixtures/** and docs/**
+    case "$tracked_file" in
+      tests/fixtures/*|tests/*/fixtures/*|docs/*) continue ;;
+    esac
+
+    local lineno=0
+    while IFS= read -r line || [ -n "$line" ]; do
+      lineno=$((lineno + 1))
+
+      # Quick pre-filter: skip lines with no candidate characters
+      case "$line" in
+        *AKIA*|*ghp_*|*github_pat_*|*'PRIVATE KEY'*|*secret*|*token*|*passw*|*api_key*|*key*) ;;
+        *) continue ;;
+      esac
+
+      hit=$(printf '%s' "$line" | grep_secret)
+      [ -n "$hit" ] || continue
+
+      # For each match, exclude placeholder-only hits
+      filtered_hit=""
+      while IFS= read -r h; do
+        [ -n "$h" ] || continue
+        if printf '%s' "$h" | grep -qE "$P_PLACEHOLDER"; then
+          continue
+        fi
+        filtered_hit="$h"
+        break
+      done <<< "$hit"
+      [ -n "$filtered_hit" ] || continue
+
+      local finding="${tracked_file}:${lineno}: ${filtered_hit}"
+
+      if is_allowlisted "$finding"; then
+        continue
+      fi
+
+      findings+=("$finding")
+    done < "$tracked_file"
+  done < <(git ls-files 2>/dev/null)
+
+  if [ "${#findings[@]}" -eq 0 ]; then
+    printf 'no-secrets-in-source: PASS\n'
+    return 0
+  fi
+
+  printf 'no-secrets-in-source: FAIL — %d finding(s):\n' "${#findings[@]}" >&2
+  for f in "${findings[@]}"; do
+    printf '  %s\n' "$f" >&2
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if [ "${1:-}" = "--self-test" ]; then
+  run_self_test
+else
+  run_live_check
+fi

--- a/tests/l3-integration/hooks/git-push-guard.test.sh
+++ b/tests/l3-integration/hooks/git-push-guard.test.sh
@@ -246,6 +246,56 @@ out=$(run_hook "git push origin main" "$db")
 assert_not_contains "$out" '"permissionDecision":"deny"' "non-SWE caller with all-signed should not be blocked"
 cleanup
 
+# ----- pr-reviewer role deny tests -------------------------------------
+
+# pr-reviewer run_hook helper: injects agent_type into the top-level payload.
+run_hook_as_pr_reviewer() {
+  local cmd="$1"
+  local db="${2:-/nonexistent.db}"
+  local agent_type="${3:-tmb:pr-reviewer}"
+  local payload
+  payload=$(jq -cn --arg c "$cmd" --arg a "$agent_type" '{agent_type:$a,tool_input:{command:$c}}')
+  (cd "$REPO_PATH" && echo "$payload" | TRAJECTORY_DB_PATH="$db" bash "$HOOK" 2>&1 || true)
+}
+
+test_case "pr-reviewer caller (tmb:pr-reviewer): git push BLOCKED with bro-owns-push message"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"
+sign_task   "$db" 1
+insert_task "$db" 2 "$SHA2"
+sign_task   "$db" 2
+out=$(run_hook_as_pr_reviewer "git push origin main" "$db" "tmb:pr-reviewer")
+assert_contains "$out" '"permissionDecision":"deny"' "pr-reviewer push must be blocked even with all-signed commits"
+assert_contains "$out" "verdict row"  "block message must reference the verdict row"
+assert_contains "$out" "bro"          "block message must state push decision belongs to bro"
+cleanup
+
+test_case "pr-reviewer caller (pr-reviewer): git push BLOCKED (bare agent_type variant)"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+out=$(run_hook_as_pr_reviewer "git push origin main" "/nonexistent.db" "pr-reviewer")
+assert_contains "$out" '"permissionDecision":"deny"' "bare pr-reviewer agent_type must also be blocked"
+cleanup
+
+test_case "pr-reviewer caller: git push --force still exits early (force delegated to git-guards before role check)"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+out=$(run_hook_as_pr_reviewer "git push --force origin main" "$db" "tmb:pr-reviewer")
+assert_not_contains "$out" '"permissionDecision":"deny"' "force push exits before role check (git-guards handles it)"
+cleanup
+
+test_case "bro caller (no agent_type): git push with all-signed NOT blocked by role check"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"
+sign_task   "$db" 1
+insert_task "$db" 2 "$SHA2"
+sign_task   "$db" 2
+out=$(run_hook "git push origin main" "$db")
+assert_not_contains "$out" '"permissionDecision":"deny"' "bro/Human with all-signed commits must not be blocked by role check"
+cleanup
+
 # ----- worktree-path push detection tests (audit item 14) ----------------
 #
 # Any push whose command or PWD involves .claude/worktrees/ must be blocked

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -72,6 +72,7 @@ run_step "L1 lint: RAG schema invariants"             bash "$HERE/l1-lint/rag-sc
 run_step "L1 lint: tool-description byte budget"      bash "$HERE/l1-lint/tool-description-budget.sh"
 run_step "L1 lint: dir toolchain allowlist"           bash "$HERE/l1-lint/dir-toolchain.sh"
 run_step "L1 lint: no raw SQL interpolation in hooks" bash "$HERE/l1-lint/no-raw-sql-interpolation.sh"
+run_step "L1 lint: no secrets in tracked source"    bash "$HERE/l1-lint/no-secrets-in-source.sh"
 run_step "L1 lint: main-source-guard + CODEOWNERS present" bash "$HERE/l1-lint/main-guard-files-present.sh"
 
 # ----- L1-adjacent: benchmark selftest (fast, deterministic) ------------


### PR DESCRIPTION
#426 enforcement remainder — the audit's two ungated prompt-held rules: git-push-guard denies pr-reviewer-context pushes outright (the push decision is bro's after the verdict row), and a no-secrets l1 lint scans tracked source for high-confidence secret patterns (self-excluding, runtime-concatenated self-test seeds — attempt 1 flagged its own tracked literals). 44/44 + lint PASS post-commit. Gate trail: task 24, pr-reviewer PASS (row 20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)