### PR TITLE
🔒 fix(hooks): source fence is location-based — subagent identity never grants main-checkout source edits

### DIFF
--- a/scripts/hooks/no-source-edit-from-main.sh
+++ b/scripts/hooks/no-source-edit-from-main.sh
@@ -1,23 +1,20 @@
 #!/usr/bin/env bash
-# No-source-edit-from-main hook (#108).
+# No-source-edit-from-main hook (#108, updated #467).
 #
-# Blocks Edit/Write tool calls when bro mode is active and the target is a
-# source-code file outside an SWE worktree. Enforces the "bro never edits
-# source code directly" doctrine — every code change goes through SWE.
+# Blocks Edit/Write tool calls when the target is a source-code file outside
+# an SWE worktree in a TMB project. Policy is LOCATION-based: any agent
+# context (bro, general-purpose subagent, consultant, etc.) is denied — the
+# worktree location is the only credential.
 #
 # Block conditions (all must be true):
 #   1. Trajectory DB exists (this is a TMB project)
-#   2. Bro mode is active (transcript shows prior "Entering bro mode." with
-#      no later "exit bro mode" / "stop being bro")
-#   3. CWD is NOT inside .claude/worktrees/ (so this is bro, not SWE)
-#   4. Target file is NOT in the bro-allowlist (markdown, license, gitignore,
-#      git templates, plugin/agent/skill manifests, etc.)
+#   2. Target file is NOT inside .claude/worktrees/ (so this is not SWE)
+#   3. Target file is NOT in the docs/templates/config allowlist
 #
 # Allow conditions (any one allows):
 #   - DB missing (not a TMB project)
-#   - No bro mode (regular Claude Code session)
-#   - In worktree (SWE legitimately edits source there)
-#   - Target is in allowlist (docs / configs that are bro's job)
+#   - Target is inside .claude/worktrees/<slug>/... (SWE legitimately edits source there)
+#   - Target is in allowlist (docs / configs that are fine to edit from main)
 #
 # Bypass: TMB_ALLOW_SOURCE_EDIT=1 (emergency override for hotfixes).
 
@@ -46,32 +43,12 @@ fi
 
 [ -f "$DB_PATH" ] || exit 0
 
-TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null)
-if [ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ]; then
-  exit 0
-fi
-# Bro mode active when:
-#   - Assistant announced "Entering bro mode." (explicit), OR
-#   - The user addressed `@bro` (the explicit sigil) in the transcript.
-# The sigil is required, not a bare `bro` word: a bare-keyword scan over the
-# whole transcript matches this hook's own block message and every assistant
-# mention of bro, false-blocking plain sessions forever (#276). `@bro` still
-# catches headless `claude -p "@bro ..."` runs where the announcement is skipped.
-# Sticky-exit: a later "exit bro mode" / "stop being bro" deactivates.
-if grep -qiE 'exit bro mode|stop being bro' "$TRANSCRIPT" 2>/dev/null; then
-  exit 0
-fi
-if ! grep -q 'Entering bro mode.' "$TRANSCRIPT" 2>/dev/null \
-   && ! grep -qiE '@bro\b' "$TRANSCRIPT" 2>/dev/null; then
-  exit 0
-fi
-
 TARGET=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.notebook_path // ""' 2>/dev/null)
 [ -n "$TARGET" ] || exit 0
 
 # Worktree exemption: any write whose target path lives inside
 # `.claude/worktrees/<slug>/...` is a legitimate SWE edit in its task
-# worktree — allow regardless of bro/SWE distinction. This MUST be a
+# worktree — allow regardless of agent identity. This MUST be a
 # target-path check, not a $PWD check: CC subagents inherit the parent's
 # CWD, so $PWD is always the project root for every hook invocation
 # (the previous $PWD-based check never matched and silently blocked SWE).
@@ -116,7 +93,7 @@ case "$TARGET" in
   *.github/*) exit 0 ;;
 esac
 
-REASON="BLOCKED: bro is a pure planner — every code change goes through SWE. Target '$TARGET' looks like source code; route via the code-touching ask chain (tmb_planning skill → task_create_batch → spawn SWE in a worktree). For emergency hotfix-style overrides, set TMB_ALLOW_SOURCE_EDIT=1."
+REASON="BLOCKED: source edits from the main checkout are denied for all agent contexts in a TMB project. Target '$TARGET' looks like source code; route via the code-touching ask chain (tmb_planning skill → task_create_batch → spawn SWE in a worktree). For emergency hotfix-style overrides, set TMB_ALLOW_SOURCE_EDIT=1."
 
 jq -nc --arg reason "$REASON" '{
   hookSpecificOutput: {

--- a/tests/l3-integration/hooks/no-source-edit-from-main.test.sh
+++ b/tests/l3-integration/hooks/no-source-edit-from-main.test.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Tests for scripts/hooks/no-source-edit-from-main.sh.
-# Hook contract: blocks Edit/Write tools when bro mode is active and the
-# target is source code outside an SWE worktree. Allows in worktrees, on
-# .md files, on configs/manifests, and when DB doesn't exist.
+# Hook contract: blocks Edit/Write tools when the target is source code outside
+# an SWE worktree in a TMB project. Policy is LOCATION-based — agent identity
+# (bro, general-purpose subagent, unknown) is irrelevant; the worktree path
+# is the only credential. Allows in worktrees, on .md files, on
+# configs/manifests, and when DB doesn't exist.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -16,6 +18,7 @@ DB="$TMPDIR/trajectory.db"
 TRANSCRIPT_BRO="$TMPDIR/bro.jsonl"
 TRANSCRIPT_PLAIN="$TMPDIR/plain.jsonl"
 TRANSCRIPT_EXITED="$TMPDIR/exited.jsonl"
+TRANSCRIPT_EMPTY="$TMPDIR/empty.jsonl"
 
 export TRAJECTORY_DB_PATH="$DB"
 
@@ -25,17 +28,17 @@ echo '{"role":"assistant","content":"Entering bro mode."}' > "$TRANSCRIPT_BRO"
 echo '{"role":"user","content":"hi"}' > "$TRANSCRIPT_PLAIN"
 echo '{"role":"assistant","content":"Entering bro mode."}' > "$TRANSCRIPT_EXITED"
 echo '{"role":"user","content":"exit bro mode"}' >> "$TRANSCRIPT_EXITED"
+touch "$TRANSCRIPT_EMPTY"
 
-# Real-world headless case: user said @bro but assistant skipped the
-# announcement (the h3/h4 prompt-discipline ceiling). Hook must still
-# detect bro mode.
-TRANSCRIPT_BRO_NO_ANNOUNCE="$TMPDIR/bro-no-announce.jsonl"
-echo '{"role":"user","content":"@bro tiny typo fix needed in src/foo.ts: change recieve to receive."}' > "$TRANSCRIPT_BRO_NO_ANNOUNCE"
-echo '{"role":"assistant","content":"On it."}' >> "$TRANSCRIPT_BRO_NO_ANNOUNCE"
+# Simulated general-purpose subagent: no bro announcement, no @bro sigil,
+# no role identity in the transcript — just a plain task prompt.
+TRANSCRIPT_SUBAGENT="$TMPDIR/subagent.jsonl"
+echo '{"role":"user","content":"Edit src/foo.ts to fix the bug."}' > "$TRANSCRIPT_SUBAGENT"
+echo '{"role":"assistant","content":"On it."}' >> "$TRANSCRIPT_SUBAGENT"
 
 # #276 regression: a plain session that merely mentions the word "bro" (no
 # @bro sigil, no announcement) — incl. this hook's own block message — must
-# NOT flip into bro-mode. Bare-keyword scanning was the substring over-match.
+# still be denied by the location-based policy (source edit in TMB project).
 TRANSCRIPT_BARE_BRO="$TMPDIR/bare-bro.jsonl"
 echo '{"role":"user","content":"thanks bro, can you edit src/foo.ts"}' > "$TRANSCRIPT_BARE_BRO"
 echo '{"role":"assistant","content":"Source edits go through bro + swe; this is bro-mode territory."}' >> "$TRANSCRIPT_BARE_BRO"
@@ -58,27 +61,43 @@ test_case "non-Edit tool: silent pass"
 out=$(run_hook "$(input 'Bash' 'whatever' "$TRANSCRIPT_BRO")")
 assert_eq "" "$out" "non-Edit tool ignored"
 
-test_case "no transcript: pass (can't determine bro state)"
-out=$(run_hook "$(input 'Edit' 'src/foo.ts' '')")
-assert_eq "" "$out" "no transcript = no block"
-
-test_case "plain transcript (no bro mode): pass"
-out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_PLAIN")")
-assert_eq "" "$out" "non-bro session = no block"
-
-test_case "#276: bare 'bro' word (no @sigil, no announce): pass — no substring over-match"
-out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_BARE_BRO")")
-assert_eq "" "$out" "casual 'bro' mention must not flip into bro-mode"
-
-test_case "bro mode but exited: pass"
-out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_EXITED")")
-assert_eq "" "$out" "exited bro mode = no block"
-
 test_case "TMB_ALLOW_SOURCE_EDIT bypass: pass"
 out=$(echo "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_BRO")" | env TMB_ALLOW_SOURCE_EDIT=1 bash "$HOOK" 2>&1 || true)
 assert_eq "" "$out" "env bypass works"
 
-# ---- allowlist paths (bro mode + DB present) ----
+# ---- location-based block: any agent context is denied ----
+
+test_case "bro mode + src/foo.ts: BLOCK"
+out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_BRO")")
+assert_contains "$out" '"permissionDecision":"deny"' "deny decision emitted"
+assert_contains "$out" 'source edits from the main checkout are denied for all agent contexts' "reason cites location policy"
+
+test_case "plain session (no bro) + src/foo.ts: BLOCK (location-based)"
+out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_PLAIN")")
+assert_contains "$out" '"permissionDecision":"deny"' "non-bro session still denied by location policy"
+
+test_case "exited bro mode + src/foo.ts: BLOCK (exit irrelevant under location policy)"
+out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_EXITED")")
+assert_contains "$out" '"permissionDecision":"deny"' "exited bro still denied — identity is not the gate"
+
+test_case "no transcript + src/foo.ts: BLOCK (identity irrelevant)"
+out=$(run_hook "$(input 'Edit' 'src/foo.ts' '')")
+assert_contains "$out" '"permissionDecision":"deny"' "no transcript = no identity check needed; location denies"
+
+test_case "general-purpose subagent context + src/foo.ts: BLOCK"
+out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_SUBAGENT")")
+assert_contains "$out" '"permissionDecision":"deny"' "subagent identity never grants main-checkout source edits"
+assert_contains "$out" 'source edits from the main checkout are denied for all agent contexts' "reason cites location policy"
+
+test_case "#276: bare 'bro' word + src/foo.ts: BLOCK (location policy, not substring match)"
+out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_BARE_BRO")")
+assert_contains "$out" '"permissionDecision":"deny"' "location policy blocks regardless of bare-word mention"
+
+test_case "unknown/absent agent identity + mcp/server.ts: BLOCK"
+out=$(run_hook "$(input 'Write' 'mcp/trajectory-server/src/index.ts' "$TRANSCRIPT_EMPTY")")
+assert_contains "$out" '"permissionDecision":"deny"' "absent identity never grants passage"
+
+# ---- allowlist paths (DB present, any context) ----
 
 test_case "bro mode + .md file: pass"
 out=$(run_hook "$(input 'Edit' 'docs/architecture/FILES.md' "$TRANSCRIPT_BRO")")
@@ -104,6 +123,10 @@ test_case "bro mode + skills/tmb_foo/SKILL.md: pass"
 out=$(run_hook "$(input 'Edit' 'skills/tmb_foo/SKILL.md' "$TRANSCRIPT_BRO")")
 assert_eq "" "$out" "skill prompts allowed"
 
+test_case "plain session + .md file: pass (allowlist applies to all contexts)"
+out=$(run_hook "$(input 'Edit' 'docs/architecture/FILES.md' "$TRANSCRIPT_PLAIN")")
+assert_eq "" "$out" "markdown allowed regardless of agent context"
+
 test_case "bro mode + hooks.json: BLOCK (enforcement surface)"
 out=$(run_hook "$(input 'Edit' 'hooks/hooks.json' "$TRANSCRIPT_BRO")")
 assert_contains "$out" '"permissionDecision":"deny"' "hooks.json denied from main checkout"
@@ -117,16 +140,7 @@ test_case "bro mode + .github/workflows/test.yml: pass"
 out=$(run_hook "$(input 'Edit' '.github/workflows/test.yml' "$TRANSCRIPT_BRO")")
 assert_eq "" "$out" "github workflows allowed"
 
-# ---- block paths ----
-
-test_case "bro mode + src/foo.ts: BLOCK"
-out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_BRO")")
-assert_contains "$out" '"permissionDecision":"deny"' "deny decision emitted"
-assert_contains "$out" 'bro is a pure planner' "reason cites doctrine"
-
-test_case "bro mode + Write to mcp/server.ts: BLOCK"
-out=$(run_hook "$(input 'Write' 'mcp/trajectory-server/src/index.ts' "$TRANSCRIPT_BRO")")
-assert_contains "$out" '"permissionDecision":"deny"' "deny decision emitted"
+# ---- enforcement-surface deny-first precedes allowlist ----
 
 test_case "bro mode + scripts/hooks/foo.sh: BLOCK (enforcement surface)"
 out=$(run_hook "$(input 'Edit' 'scripts/hooks/foo.sh' "$TRANSCRIPT_BRO")")
@@ -141,6 +155,8 @@ test_case "bro mode + nested hooks/hooks.json: BLOCK"
 out=$(run_hook "$(input 'Edit' 'some/path/hooks/hooks.json' "$TRANSCRIPT_BRO")")
 assert_contains "$out" '"permissionDecision":"deny"' "nested hooks.json denied from main checkout"
 
+# ---- worktree paths: SWE always allowed ----
+
 test_case "worktree + scripts/hooks/foo.sh: PASS (SWE in worktree edits hooks)"
 out=$(run_hook "$(input 'Edit' '.claude/worktrees/task-14/scripts/hooks/foo.sh' "$TRANSCRIPT_BRO")")
 assert_eq "" "$out" "SWE in worktree may edit hook files"
@@ -148,16 +164,6 @@ assert_eq "" "$out" "SWE in worktree may edit hook files"
 test_case "worktree + hooks/hooks.json: PASS (SWE in worktree edits manifest)"
 out=$(run_hook "$(input 'Edit' '.claude/worktrees/task-14/hooks/hooks.json' "$TRANSCRIPT_BRO")")
 assert_eq "" "$out" "SWE in worktree may edit hooks.json"
-
-test_case "bro mode + tests/lib/assert.sh: BLOCK"
-out=$(run_hook "$(input 'Edit' 'tests/lib/assert.sh' "$TRANSCRIPT_BRO")")
-assert_contains "$out" '"permissionDecision":"deny"' "deny decision emitted"
-
-test_case "REGRESSION: user said @bro but assistant skipped announce → still BLOCK"
-out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_BRO_NO_ANNOUNCE")")
-assert_contains "$out" '"permissionDecision":"deny"' "deny even without 'Entering bro mode.' marker"
-
-# ---- worktree path: SWE allowed ----
 
 test_case "REGRESSION: target inside .claude/worktrees/<slug>/ : PASS (SWE in worktree)"
 out=$(run_hook "$(input 'Edit' '.claude/worktrees/task-42/src/foo.ts' "$TRANSCRIPT_BRO")")
@@ -173,10 +179,20 @@ WORKTREE_DIR="$TMPDIR/.claude/worktrees/task-42"
 mkdir -p "$WORKTREE_DIR"
 cd "$WORKTREE_DIR"
 # CWD is a worktree, but TARGET is outside → must still block (the previous
-# $PWD-based check would have allowed; the new target-based check correctly blocks)
+# $PWD-based check would have allowed; the target-based check correctly blocks)
 out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_BRO")")
 cd "$PWD_ORIG"
 assert_contains "$out" '"permissionDecision":"deny"' "non-worktree target blocked even from worktree CWD"
+
+test_case "worktree target with no transcript: PASS (worktree exemption is location-only)"
+out=$(run_hook "$(input 'Edit' '.claude/worktrees/task-99/src/foo.ts' '')")
+assert_eq "" "$out" "worktree path exemption needs no transcript"
+
+# ---- other block paths ----
+
+test_case "bro mode + tests/lib/assert.sh: BLOCK"
+out=$(run_hook "$(input 'Edit' 'tests/lib/assert.sh' "$TRANSCRIPT_BRO")")
+assert_contains "$out" '"permissionDecision":"deny"' "deny decision emitted"
 
 # ---- DB-missing graceful path ----
 
@@ -184,3 +200,5 @@ test_case "no DB: pass even on source (not a TMB project)"
 rm -f "$DB"
 out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_BRO")")
 assert_eq "" "$out" "no DB = not a TMB project = allow"
+
+summarize


### PR DESCRIPTION
Fixes #467: the bro-mode transcript detection (the exemption general-purpose subagents rode through during the benchmark bypass) is removed — in a TMB project, source edits outside task worktrees deny for EVERY agent context; worktree/docs/non-TMB pass-throughs and the enforcement-surface deny-first are unchanged (adversarial pass-through matrix verified by the reviewer). 34/34 + full hook runner 48/48. Gate trail: task 30, pr-reviewer PASS (row 23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)