### PR TITLE
✂️ chore(prompts): seven skills to the post-gate bar — composites adopted, enforced prose deleted, #289 wiring

### DIFF
--- a/skills/tmb_concerns-protocol/SKILL.md
+++ b/skills/tmb_concerns-protocol/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tmb_concerns-protocol
 description: How bro raises a concern when doubting the Human's plan — surface inline via discussion_append + ask, or spawn a consultant in analysis-only mode for technical disagreement. Always surface disagreement; always yield to the Human's call. Loaded when bro genuinely disagrees with a request.
-allowed-tools: Task, mcp__plugin_tmb_trajectory-server__discussion_append
+allowed-tools: Task, mcp__plugin_tmb_trajectory-server__discussion_append, mcp__plugin_tmb_trajectory-server__discussion_search
 ---
 
 # concerns-protocol
@@ -29,7 +29,7 @@ Two paths, pick by the type of doubt:
 
 Use when the concern is about HOW the work is being framed — scope, ordering, prerequisites, conventions.
 
-1. `discussion_append(agent='bro', kind='note', body='Concern: <one-line statement of the concern>. Recommendation: <what bro suggests instead>.')`
+1. Append a discussion note stating the concern and your recommendation — use the format: `Concern: <one-line statement>. Recommendation: <what bro suggests instead>.`
 2. Ask the Human directly in your next message: "Before I start, I want to flag <concern> — would you prefer <alternative>?"
 3. Wait for the Human's call. Hold on starting the work until they respond.
 
@@ -40,14 +40,13 @@ When no Human is in the loop (headless, or the prompt says not to ask): steps 1 
 Use when the concern is technical — architecture, security, performance, code quality — and you want an independent read.
 
 1. Identify the relevant consultant (`architect`, `cto`, etc.). If absent, invoke `/tmb:agent-create` first.
-2. Spawn the consultant with `consultant: analysis-only` marker and the specific question.
+2. Spawn the consultant with the specific question.
 3. Receive their analysis. Consultants are analysis-only — decisions remain with the Human (server-enforced).
 4. Summarize their position back to the Human, surface tensions, and let the Human decide.
 
 ## Protocol boundaries
 
 <!-- LOAD-BEARING-SAFETY: these are the four doctrine constraints that define bro's concerns role -->
-- **Surface disagreement, then yield.** "I think they're wrong, I'll just do it the right way" is a doctrine violation.
+- **State the concern once and yield.** One statement, one recommendation — then follow the Human's decision. "I'll just do it the right way" is a doctrine violation.
 - **Log genuine disagreement in the audit trail.** Silent compliance with a plan bro doubts makes bro useless as a sounding board.
-- **State the concern once and yield to the Human's call.** One statement of the concern, one recommendation, then follow the Human's decision.
 - **Lead with the concern.** Put it at the top of the response; keep the message focused.

--- a/skills/tmb_docs-conventions/SKILL.md
+++ b/skills/tmb_docs-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tmb_docs-conventions
-description: Discipline rules for editing prompt files (agents, skills, CLAUDE.md, workflow markdown) and the docs-update expectation. Link integrity: every internal markdown link must resolve to an existing file; broken links are a lint failure.
+description: Loaded when editing prompt files (agents, skills, CLAUDE.md, workflow markdown) or updating user-visible docs. Carries the editing judgment — what to delete, what to preserve, and where ripples land when a rename or restructure happens.
 ---
 
 # Docs Conventions — Editing Discipline

--- a/skills/tmb_planning/SKILL.md
+++ b/skills/tmb_planning/SKILL.md
@@ -16,32 +16,9 @@ Zoom-in: `world_model_get(path='src/api', depth=1)`. "Where does X live": `world
 
 When a remote is configured:
 
-```
-AskUserQuestion: "Which branch should I create the new feature branch from?"
-options: [pr_target (pull origin/<pr_target> first) | <current_branch> | 1–3 prominent local branches]
-```
+Ask the Human which branch to create the new feature branch from — offer the configured `pr_target`, the current branch, and 1–3 prominent local branches. On `pr_target`: `git fetch origin ${pr_target} && git checkout ${pr_target} && git pull --ff-only`. On a non-pr_target: switch; leave the branch as-is.
 
-On `pr_target`: `git fetch origin ${pr_target} && git checkout ${pr_target} && git pull --ff-only`. On a non-pr_target: switch; leave the branch as-is.
-
-Then derive + propose:
-
-```
-{ branch_id, confidence } = branch_id_propose(agent='bro', intent=<verbatim>, objective=<short>)
-```
-
-```
-AskUserQuestion: "Proceed with branch_id <X>?"
-options: [Yes, proceed | Suggest different branch_id]
-```
-
-On Yes:
-
-```
-issue_create(agent='bro', objective=<short>)
-discussion_append(issue_id, author='bro', kind='intent', body=<verbatim>)
-discussion_append(issue_id, author='bro', kind='note',   body='Beginning planning on ${branch_id}.')
-git branch "${branch_id}"
-```
+Then call `branch_id_propose(agent='bro', intent=<verbatim>, objective=<short>)` and confirm: "Proceed with branch_id X?" (yes / suggest different). On Yes: call `intent_start(agent='bro', intent_verbatim=<verbatim>, branch_id=<branch_id>)` to create the issue, log the intent, and record the planning note in one step, then create the git branch locally.
 
 ## 3. Author the spec
 
@@ -87,14 +64,13 @@ task_create_batch(agent='bro', issue_id=<I>, tasks=[{branch_id, spec_body, ...}]
 
 `waive_scope_gate` is valid for truly trivial work (`'trivial: <what>'`) or headless mode (`'headless mode, defaults applied; <one-line scope summary>'`).
 
-Then spawn SWE with `isolation='worktree'` — the server creates the worktree at `<workspace_root>/.claude/worktrees/<slug>` (where `workspace_root` is the directory holding `.claude/tmb/trajectory.db` and `slug` is `branch_id` minus its `<type>/` prefix). Pass that path so SWE lands in it:
+Then run the worktree hook per branch and spawn SWE with the task id and the printed worktree path:
 
 ```
-Task(subagent_type='swe', isolation='worktree',
-     prompt='task_id=<N> worktree=<workspace_root>/.claude/worktrees/<slug>')
+Task(subagent_type='swe', prompt='task_id=<N> worktree=<path printed by hook>')
 ```
 
-`isolation='worktree'` is the single creation path — the worktree is made for you on spawn. The batch response includes `parallel_groups` — tasks in the same group are safe to spawn in parallel.
+The batch response includes `parallel_groups` — tasks in the same group are safe to spawn in parallel.
 
 ## 5. Verify on SWE return + atomic close
 
@@ -106,13 +82,14 @@ After SWE returns `status=completed`:
 1. Changed files match `## Files`. No surprise files outside scope.
 2. `## Verification` commands pass — re-run verbatim inside the SWE worktree. Do this BEFORE V3 — the cleanup hook removes the worktree on close.
 3. Each `## Success Criteria` bullet visibly met by the diff.
+4. Run `world_model_get(path='<changed-dir>')` to confirm the change landed where expected.
 
 **V3** — all pass → `bro_atomic_close(agent='bro', task_id=<N>, commit_sha=<sha>, verification_summary='...', close_issue_if_last_task=true)`. The post-close hook re-scans automatically — the world model refreshes.
 
-Then spawn pr-reviewer for the push gate (see `tmb_review` §B). On PASS: `git push -u origin <branch>`. On FAIL: surface it, file the fix as a follow-up issue, and hold the push.
+Then spawn pr-reviewer for the push gate (see `tmb_review` §B). On FAIL: surface it, file the fix as a follow-up issue, and hold the push.
 
 **V3 — any check fails**: `bro_verification_fail_record(agent='bro', task_id=<N>, which_check='<V1|V2|V3>', details='<≤500 chars>')`. Leave the task open. Retry via `task_retry_batch` or escalate.
 
 ## Headless overrides (TMB_HEADLESS=1)
 
-No Human in the loop — skip AUQs, apply the documented defaults (see `tmb_recovery` §A per-skill defaults table), and record the fallback. After `branch_id_propose`, run step 2's "On Yes" block (issue_create + intent/note `discussion_append` + branch create) without the AUQs to get `<I>` and `<branch_id>`, then call `headless_intent_start(agent='bro', issue_id=<I>, branch_id=<branch_id>, intent_verbatim=<verbatim>, fallback_summary='<defaults applied>')`, then proceed to step 3.
+No Human in the loop — skip AUQs, apply the documented defaults (see `tmb_recovery` §A per-skill defaults table), and record the fallback. After `branch_id_propose`, call `headless_intent_start(agent='bro', issue_id=<I>, branch_id=<branch_id>, intent_verbatim=<verbatim>, fallback_summary='<defaults applied>')` — its dedup guard and shared helper handle the writes atomically — then proceed to step 3.

--- a/skills/tmb_planning/SKILL.md
+++ b/skills/tmb_planning/SKILL.md
@@ -18,7 +18,7 @@ When a remote is configured:
 
 Ask the Human which branch to create the new feature branch from — offer the configured `pr_target`, the current branch, and 1–3 prominent local branches. On `pr_target`: `git fetch origin ${pr_target} && git checkout ${pr_target} && git pull --ff-only`. On a non-pr_target: switch; leave the branch as-is.
 
-Then call `branch_id_propose(agent='bro', intent=<verbatim>, objective=<short>)` and confirm: "Proceed with branch_id X?" (yes / suggest different). On Yes: call `intent_start(agent='bro', intent_verbatim=<verbatim>, branch_id=<branch_id>)` to create the issue, log the intent, and record the planning note in one step, then create the git branch locally.
+Then call `branch_id_propose(agent='bro', intent=<verbatim>, objective=<short>)` and confirm: "Proceed with branch_id X?" (yes / suggest different). On Yes: call `intent_start(agent='bro', objective=<short>, intent_verbatim=<verbatim>, branch_id=<branch_id>)` to create the issue, log the intent, and record the planning note in one step, then create the git branch locally.
 
 ## 3. Author the spec
 

--- a/skills/tmb_recovery/SKILL.md
+++ b/skills/tmb_recovery/SKILL.md
@@ -17,7 +17,7 @@ The bundled script `scripts/bro-sqlite-readonly.sh` is for §C (trajectory-serve
 ### Protocol
 
 1. **Look up the documented default** for that question (table below). If the calling skill has no documented default, that's a doctrine bug — log it and halt that specific skill (not bro overall).
-2. **Record the fallback** — call `headless_fallback_record(agent='bro', skill=<skill_name>, question=<question_short>, default=<chosen_default>)`. Its dedup guard and shared helper write both the audit event and the discussion note atomically; the deny hook names it on failure. For `issue_id`: use the parent issue when one exists; use `'-1'` for system-level events with no parent issue.
+2. **Record the fallback** — call `headless_fallback_record(agent='bro', skill=<skill_name>, question=<question_short>, chosen_default=<chosen_default>)`. Writes both the audit event and the discussion note atomically; the deny hook names it on failure. For `issue_id`: use the parent issue when one exists; use `'-1'` for system-level events with no parent issue.
 3. **Continue the skill's flow** with the default as if the Human typed it.
 
 ### Per-skill defaults

--- a/skills/tmb_recovery/SKILL.md
+++ b/skills/tmb_recovery/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tmb_recovery
 description: Bro's response when something fails — AskUserQuestion errors / TMB_HEADLESS=1 (use the documented per-skill default + audit), MCP tool returns is_error=true (halt + surface, don't silently proceed), or the trajectory-server is unreachable (degraded sqlite3 readonly fallback). Loaded reactively on the first failure of a session. Self-contained — defaults table + tool list inline.
-allowed-tools: Bash(skills/tmb_recovery/scripts/bro-sqlite-readonly.sh:*), mcp__plugin_tmb_trajectory-server__audit_log, mcp__plugin_tmb_trajectory-server__discussion_append
+allowed-tools: Bash(skills/tmb_recovery/scripts/bro-sqlite-readonly.sh:*), mcp__plugin_tmb_trajectory-server__headless_fallback_record, mcp__plugin_tmb_trajectory-server__audit_log, mcp__plugin_tmb_trajectory-server__discussion_append
 ---
 
 # Recovery — three failure modes, three responses
@@ -10,8 +10,6 @@ Bro keeps the user-visible flow moving on recoverable errors. Each failure class
 
 The bundled script `scripts/bro-sqlite-readonly.sh` is for §C (trajectory-server unreachable). Invoke it via Bash — use it as a black box, not by reading its source directly.
 
-Use `world_model_get` / `world_model_search` for project navigation; `discussion_search` / `audit_search` for prior decisions.
-
 ## A. AskUserQuestion error / TMB_HEADLESS=1
 
 `AskUserQuestion` is the only tool bro uses to consult the Human. When the call returns an error OR `TMB_HEADLESS=1` is set, there's no Human in the loop. **Bro halting here is a bug** — produce an audit trail with the documented default instead.
@@ -19,12 +17,7 @@ Use `world_model_get` / `world_model_search` for project navigation; `discussion
 ### Protocol
 
 1. **Look up the documented default** for that question (table below). If the calling skill has no documented default, that's a doctrine bug — log it and halt that specific skill (not bro overall).
-2. **Record both writes** — required, not optional:
-   ```
-   audit_log(agent='bro', from_node='bro', event_type='headless_fallback', summary='<skill_name>: <question_short> → <chosen_default>')
-   discussion_append(agent='bro', kind='note', body='Headless fallback: <skill> asked "<question>", no Human in loop, defaulted to <default>. Reason: <one-line>.')
-   ```
-   For `issue_id`: use the parent issue of the calling skill when one exists; otherwise use the system issue (`issue_id='-1'`, seeded for system-level events that have no parent issue). Use a real issue ID or `'-1'` — `audit` and `discussions` enforce a FK to `issues` and will reject invented placeholder strings.
+2. **Record the fallback** — call `headless_fallback_record(agent='bro', skill=<skill_name>, question=<question_short>, default=<chosen_default>)`. Its dedup guard and shared helper write both the audit event and the discussion note atomically; the deny hook names it on failure. For `issue_id`: use the parent issue when one exists; use `'-1'` for system-level events with no parent issue.
 3. **Continue the skill's flow** with the default as if the Human typed it.
 
 ### Per-skill defaults
@@ -44,12 +37,7 @@ Use `world_model_get` / `world_model_search` for project navigation; `discussion
 
 `tmb_skill-creator` and `/tmb:agent-create` (from-scratch mode) HALT in headless mode rather than apply a default. Silent skill/agent generation in CI is the foot-gun this rule guards against:
 
-```
-audit_log(agent='bro', from_node='bro', event_type='headless_creator_blocked',
-          summary='<creator>: cannot create <name> without Human approval in headless mode.')
-```
-
-Plus a clear surface message: "Cannot create skill/agent in headless mode. Re-run interactively, or write the file directly if you know what you want."
+Call `audit_log` with `event_type='headless_creator_blocked'` and a summary naming the creator and the proposed name, then surface: "Cannot create skill/agent in headless mode — re-run interactively."
 
 ## B. MCP tool returns is_error=true
 
@@ -57,7 +45,7 @@ When any MCP call result has `is_error: true` or content includes `{"error": ...
 
 ### Protocol
 
-1. **Halt the current flow immediately.** Don't chain subsequent calls as if the failed one succeeded.
+1. **Halt the current flow immediately.** Treat the failed call as the chain's last.
 2. **Pick one path** based on the error class:
    - **Surface verbatim** to the Human and ask how to proceed, OR
    - **If recoverable AND you know the corrected call**, write `discussion_append(kind='note', body='Recovered from MCP error: <error_text>. Retrying with <corrected_call>.')` and retry.
@@ -66,7 +54,7 @@ When any MCP call result has `is_error: true` or content includes `{"error": ...
 
 | Error shape | Meaning | Right response |
 |---|---|---|
-| `forbidden` | Bro called a tool scoped to another role. | Reconsider whether the action is bro's responsibility. Don't retry the same call signature. |
+| `forbidden` | Bro called a tool scoped to another role. | Reconsider whether the action is bro's responsibility. Change the call signature before retrying. |
 | `validation` | Input didn't match the schema (e.g. malformed branch_id). | Fix the input. Retry with the corrected payload. |
 | Constraint failure | DB integrity violation (foreign key, unique). | Surface to Human; usually means a stale or duplicate write attempt. |
 | `no matching deferred tools` | The MCP child process is dead. | Switch to degraded mode (§C). |

--- a/skills/tmb_review/SKILL.md
+++ b/skills/tmb_review/SKILL.md
@@ -18,7 +18,7 @@ Load context via `task_brief(task_id)` — `spec_body`, `commit_sha`, and the ch
 
 The parent CC session's main checkout may be on ANY branch. Working-tree-dependent verification reads parent's current state, NOT the commit being reviewed.
 
-For working-tree-dependent verification use `pr_review_worktree(agent='pr-reviewer', commit_sha=<sha>, repo_path=<workspace_root>, command='<verification command>')` — `workspace_root` is the directory holding `.claude/tmb/trajectory.db` (same definition as `tmb_planning`); creates the worktree, runs the command, removes it atomically. <!-- enforced by: pr_review_worktree composite (mech 2) -->
+For working-tree-dependent verification use `pr_review_worktree(agent='pr-reviewer', commit_sha=<sha>, repo_path=<workspace_root>, command='<verification command>')` — `workspace_root` is the directory holding `.claude/tmb/trajectory.db` (same definition as `tmb_planning`); creates the worktree, runs the command, removes it atomically.
 
 Sha-based git ops (`git show <sha>`, `git diff <sha>~1..<sha>`, `git ls-tree <sha>`) work from any branch without a worktree — use those for diff inspection.
 
@@ -45,6 +45,8 @@ Gaps → Design-Compliance findings (severity is separate).
 
 Naming, error-handling style, logging, test structure match the surrounding codebase? Deviations need explicit spec authorization; otherwise flag. Cross-check against the **Living patterns** below.
 
+For context, pull the changed directory's world-model summary (`world_model_get(path='<changed-dir>')`) to see sibling patterns before judging.
+
 ### Phase 4 — Performance (only when the spec mentions it)
 
 O(n²) where O(n) suffices? N+1 patterns? Hot-path allocations?
@@ -56,28 +58,19 @@ Public-API change reflected in user docs / type defs? Breaking change flagged in
 
 ### Writing the validation_attempts row — YOU write it yourself
 
-After producing a verdict, YOU (the pr-reviewer subagent) write the `validation_attempts` row directly. Two paths depending on your tool list:
+After producing a verdict, YOU (the pr-reviewer subagent) write the `validation_attempts` row directly — use the spawn prompt's `attempt_n`. Two paths depending on your tool list:
 
-**Path 1 — MCP available** (your tool list includes `mcp__plugin_tmb_trajectory-server__validation_record`):
-```
-validation_record(agent='pr-reviewer', task_id=N, attempt_n=1, verdict='pass'|'fail', feedback='MCP available: yes\n<your verdict text>', subagent_session_id='<your-session-id>')
-```
+**Path 1 — MCP available** (your tool list includes `mcp__plugin_tmb_trajectory-server__validation_record`): call `validation_record(agent='pr-reviewer', ...)` — the schema enforces the required shape; start your feedback with `'MCP available: yes'`.
 
-**Path 2 — MCP unavailable** (only Read + Bash in your tool list): `${CLAUDE_PLUGIN_ROOT}/skills/tmb_review/scripts/validation-record-fallback.sh <task_id> <attempt_n> <pass|fail> '<verdict text>' '<session-id>'`
+**Path 2 — MCP unavailable** (only Read + Bash in your tool list): use the fallback script at `${CLAUDE_PLUGIN_ROOT}/skills/tmb_review/scripts/validation-record-fallback.sh` — run it with `--help` for the argument shape.
 
-The `feedback` column CHECK constraint: must start with `'MCP available: yes'` OR `'MCP available: no — honor-system fallback'`. <!-- enforced by: requireRoles (mech 6) — server rejects bro identity; schema CHECK rejects wrong prefix -->
-
-<!-- LOAD-BEARING-SAFETY: never delegate writing this row to bro. Bro impersonating pr-reviewer is a content-integrity violation — server's validation_record MCP tool returns forbidden for bro identity, AND the auto-mode classifier blocks raw sqlite3 INSERT from bro as impersonation. The honor-system fallback is for YOU to write directly via Bash sqlite3. -->
-
-`scripts/hooks/git-push-guard.sh` only lets pushes through when this row exists. <!-- enforced by: git-push-guard.sh PreToolUse hook (mech 3) -->
+<!-- LOAD-BEARING-SAFETY: never delegate writing this row to bro. Bro impersonating pr-reviewer is a content-integrity violation — the server's validation_record tool returns forbidden for bro identity, and the auto-mode classifier blocks raw DB writes from bro as impersonation. The honor-system fallback is for YOU to write directly via the fallback script. -->
 
 If you spot a recurring pattern at the push gate, append a bullet to **Living patterns** below using the format documented there.
 
 ## B. Spawning pr-reviewer (bro-side discipline)
 
 The verdict row is always authored by pr-reviewer itself — via MCP when available, via the fallback script otherwise (§A). <!-- LOAD-BEARING-SAFETY: pr-reviewer must write validation_attempts directly; delegating to bro is impersonation and is blocked by the auto-mode classifier -->
-
-The spawn prompt shape is enforced by `pr-reviewer-spawn-prompt-shape.sh`. <!-- LOAD-BEARING-SAFETY: enforced by pr-reviewer-spawn-prompt-shape.sh PreToolUse hook (mech 3) -->
 
 **Clean spawn prompt example:**
 ```
@@ -86,7 +79,7 @@ task_id=42 commit_sha=abc123def branch_id=fix/foo repo=plugin attempt_n=<attempt
 Push-gate review. Per §A worktree discipline if running linters/build/tests against the working tree. Load context via task_brief(agent='pr-reviewer', task_id=42). Verify each Success Criterion against the diff. Write validation_attempts row per §A (path 1 if you have MCP, path 2 if you have only Bash). Verdict='fail' if any check fails.
 ```
 
-No-MCP fallback (Bash-only spawn, no `mcp__...` tools in tool list): load spec via `sqlite3 "${TRAJECTORY_DB_PATH}" "SELECT spec_body FROM tasks WHERE id=42"` — keep this as the documented fallback only.
+No-MCP fallback (Bash-only spawn, no `mcp__...` tools in tool list): use the documented fallback script pattern — `bro-sqlite-readonly.sh` in `tmb_recovery` §C.2 for read-only DB access.
 
 ## C. Push-gate orchestration (bro, loaded reactively)
 
@@ -96,7 +89,7 @@ Triggers:
 
 ### Reap commits → local feature branch
 
-`reap_and_review_prep(agent='bro', task_ids=[<N>, ...], repo_path=<workspace_root>)` — fetches each unsigned task's detached HEAD from its worktree into the main checkout, returns `{ reaped: [{task_id, branch_id, commit_sha, reaped, error?}] }`. <!-- enforced by: reap_and_review_prep composite (mech 2) -->
+`reap_and_review_prep(agent='bro', task_ids=[<N>, ...], repo_path=<workspace_root>)` — fetches each unsigned task's detached HEAD from its worktree into the main checkout, returns `{ reaped: [{task_id, branch_id, commit_sha, reaped, error?}] }`.
 
 ### Spawn pr-reviewer per unsigned task (parallel)
 
@@ -104,7 +97,7 @@ Use `subagent_type='pr-reviewer'` (no-namespace form resolves project-local over
 
 Read pr-reviewer's first response line:
 - `MCP available: yes` — the reviewer wrote `validation_record` itself.
-- `MCP available: no — honor-system fallback` — the reviewer wrote the row through the fallback script (§A Path 2), which prepends the required feedback prefix itself. Either way the row must exist before you push; `git-push-guard.sh` blocks the push when it's missing.
+- `MCP available: no — honor-system fallback` — the reviewer wrote the row through the fallback script (§A Path 2), which prepends the required feedback prefix itself. Either way the row must exist before you push.
 
 ### Outcomes
 
@@ -117,7 +110,7 @@ Read pr-reviewer's first response line:
 
 ## D. PR/MR comment triage (bro, loaded by /monitor)
 
-`pr_comments_get` does the deterministic fetch + since-marker bookkeeping; comment rows are auto-persisted as discussion notes by `post-pr-comments-persist.sh` PostToolUse hook. This section is the judgment around what's task-worthy. <!-- enforced by: post-pr-comments-persist.sh PostToolUse hook (mech 4) -->
+`pr_comments_get` does the deterministic fetch + since-marker bookkeeping; comment rows are auto-persisted as discussion notes by `post-pr-comments-persist.sh` PostToolUse hook. This section is the judgment around what's task-worthy.
 
 ### Resolve the PR
 
@@ -164,8 +157,6 @@ options: [<task title (with optional (arch-impact) suffix)> per ratified group]
 ```
 
 For each ratified group: `task_create_batch(...)`, spawn SWE, and if arch-impact, invoke `scan_run(source='bro_auto_post_change')` after SWE returns to refresh the world model.
-
-Use `world_model_get` / `world_model_search` for project navigation; `discussion_search` / `audit_search` for prior decisions.
 
 ## Code-quality criteria (qualitative reference)
 

--- a/skills/tmb_skill-creator/SKILL.md
+++ b/skills/tmb_skill-creator/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: tmb_skill-creator
 description: Generate a new project-local skill at .claude/skills/<name>/SKILL.md and attach it to existing agents. Loads when the user asks to capture a repeatable behavior — e.g. "create a skill that codifies <our convention>", "teach swe to also <run mypy / use black / etc.>", "make a skill for <reviewing PRs / writing changelogs / etc.>", "we need a checklist when <X happens>". Extends the consuming agent's `skills:` frontmatter array only; agent body stays intact. Always Human-approved.
-allowed-tools: Read, Write, Edit, Glob, AskUserQuestion, mcp__plugin_tmb_trajectory-server__audit_log
+allowed-tools: Read, Write, Edit, Glob, Bash, AskUserQuestion, mcp__plugin_tmb_trajectory-server__skill_register, mcp__plugin_tmb_trajectory-server__audit_log, mcp__plugin_tmb_trajectory-server__issue_create
 ---
 
 # Skill Creator
 
 Add a new capability to a project's agents without editing their body. **Lego rule**: agent files are immutable identity; skills are additive capabilities. This skill is the only mechanism that extends a project agent — it appends to the agent's `skills:` array and leaves the body intact.
 
-The bundled `scripts/prompt-author-lint.sh` (regex scan for negations + noise citations) runs as a Bash step in Step 3 — bro doesn't read it directly.
+Step 3 runs `${CLAUDE_PLUGIN_ROOT}/scripts/prompt-author-lint.sh` (regex scan for negations + noise citations) as a Bash step — bro doesn't read it directly. A bundled duplicate lives in `scripts/` for a future dedupe; the plugin-root script is canonical.
 
 ## When to invoke
 
@@ -20,17 +20,7 @@ If the original ask depended on the new skill being in place, bro holds it until
 
 ## Step 1 — Discover the gap
 
-```
-AskUserQuestion: 3 questions in one batch
-  Q1 "What should this skill be called? (lowercase, hyphens)"
-     options: [<bro proposes 1-3 names from context>]   // free-text Other
-  Q2 "Which agents should load this skill?" (multiSelect)
-     options: [<bro lists existing project agents from .claude/agents/>]
-  Q3 "When should this skill activate?"
-     options: [Always — load every spawn | Path-scoped (paths: in frontmatter)]
-```
-
-The server rejects invalid or reserved skill names (the `tmb_` prefix is plugin-only).
+Ask three questions in one AskUserQuestion batch: (1) what to call the skill — propose 1–3 names from context, lowercase with hyphens; (2) which agents to attach it to — list from `.claude/agents/`; (3) when it activates — always or path-scoped. The server rejects invalid or reserved skill names (`tmb_` prefix is plugin-only).
 
 ## Step 2 — Draft
 
@@ -45,7 +35,7 @@ allowed-tools: <optional, comma-separated — restricts tools the skill can invo
 
 # <Title — Human-Readable>
 
-[Body — concrete rules, checks, or patterns the agent should apply when this skill is loaded. Keep it focused; if this skill grows over 80 lines, propose splitting or trimming.]
+[Body — concrete rules, checks, or patterns the agent should apply when this skill is loaded. Keep it focused.]
 ```
 
 **Skill structure**: keep flat (single SKILL.md). Anthropic-style splits (SKILL.md + reference.md + forms.md + scripts/) sound clean but tax bro in headless mode — every extra file is another Read when bro can't ask the Human. Inline lookup tables and AUQ shapes; bundle scripts only when truly executable.
@@ -61,21 +51,14 @@ Present the full drafted file in a fenced code block. Ask:
 
 ## Step 5 — Write on approval
 
-1. Write the skill file. If `<project>/.claude/skills/<name>/` exists, refuse — name collision means the Human resolves (pick a different name or manually delete the existing one).
-2. For each agent in the attach list, **edit only the `skills:` array** to append the new name. Use `Edit` with a precise `old_string` that includes the existing `skills:` block + the closing `---` so the diff is unambiguous. **Scope the edit to the `skills:` line only — leave every other agent file line unchanged.**
-3. Verify by re-reading both the skill file and each agent's frontmatter.
+1. Call `skill_register(agent='bro', name=<name>)` — the server validates and reserves the name (see **Hard rules** on collisions).
+2. Write the skill file at `<project>/.claude/skills/<name>/SKILL.md`.
+3. For each agent in the attach list, **edit only the `skills:` array** to append the new name. Use `Edit` with a precise `old_string` that includes the existing `skills:` block + the closing `---` so the diff is unambiguous. **Scope the edit to the `skills:` line only — leave every other agent file line unchanged.**
+4. Verify by re-reading both the skill file and each agent's frontmatter.
 
 ## Step 6 — Log + report
 
-If there's no open issue (free-floating skill creation — common), first run `issue_create(agent='bro', objective='Skill <name> created', description='Free-floating creation of skill <name> attached to <agents>.')` to scope the audit. Then:
-
-```
-audit_log(agent='bro', from_node='bro', issue_id=<I>, event_type='tmb_skill_created',
-          summary='Authored skill <name>; attached to <agents>.',
-          content_json='{"name":"<name>","agents":[...],"paths":[...] | null}')
-```
-
-Tell the Human in one line: skill landed at `<path>`; attached to `<agents>`.
+If there's no open issue (free-floating skill creation — common), create one with `issue_create` scoping the creation. Then log the event with `audit_log(event_type='tmb_skill_created', summary='Authored skill <name>; attached to <agents>.')` and tell the Human in one line: skill landed at `<path>`; attached to `<agents>`.
 
 ## Hard rules
 
@@ -91,7 +74,7 @@ Tell the Human in one line: skill landed at `<path>`; attached to `<agents>`.
 Skill creation is interactive by definition. On `AskUserQuestion` error or `TMB_HEADLESS=1`:
 
 1. Halt immediately. Leave all files unwritten.
-2. `issue_create(agent='bro', objective='Skill creation blocked (headless)', description='Free-floating skill <proposed_name> creation attempted in headless mode; HALTed per doctrine.')` to scope, then `audit_log(agent='bro', from_node='bro', issue_id=<that_id>, event_type='headless_creator_blocked', summary='tmb_skill-creator blocked: cannot create skill <proposed_name> without Human approval.')`
+2. Create a scoping issue via `issue_create`, then log `event_type='headless_creator_blocked'` naming the proposed skill.
 3. Surface: "Cannot create skill in headless mode — file writes require Human approval. Re-run interactively."
 
 A skill is a behavior change to the agent ecosystem. CI-time generation requires Human review before any file is written.

--- a/skills/tmb_swe-checklist/SKILL.md
+++ b/skills/tmb_swe-checklist/SKILL.md
@@ -9,8 +9,7 @@ Before `task_update_status(completed)`, confirm these by reading the diff. Mecha
 
 - **Spec fidelity.** Every bullet under `## Files`, `## Success Criteria`, and every error/edge case named in `## Description` has a concrete change in the diff. Quote the bullet, point to the diff line.
 - **Scope discipline.** Nothing changed outside `## Files` except trivial imports. No "while I was there" cleanups. No new TODOs.
-- **Verification verbatim.** Ran the `## Verification` commands literally, not paraphrased. Pasted output proves they passed.
-- **Worktree isolation.** Edits and commits all live inside the assigned worktree path; the main checkout is untouched.
+- **Verification output.** Paste the verification output in your close report.
 
 Escalate (not guess) when:
 


### PR DESCRIPTION
PROMPT-SURFACE PR — per the auto-merge policy this stays open for Human review.

#468 audit applied to all seven skills: tmb_planning adopts intent_start (correct arg shape incl. objective) and the spawn-hint-era worktree flow, drops the spec-shape list and pass-before-push echoes, gains #289 pre-task search + post-task read-back; tmb_review drops the CHECK/push-gate restatements, verbatim SQL, and (mech N) annotations, gains the Phase-3 world-model line; tmb_recovery adopts headless_fallback_record (chosen_default, false dedup claim removed) and positive phrasing; swe-checklist drops its two now-gated bullets; concerns-protocol/docs-conventions de-duplicated; skill-creator regains the skill_register step with matching allowed-tools. Replaces the v1 branch (reviewer-caught arg shapes). Gate trail: task 31, pr-reviewer PASS (row 25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)