### PR TITLE
🐛 fix(hooks): swe-boundary resolves task_id by worktree slug when no transcript exists

### DIFF
--- a/scripts/hooks/swe-boundary.sh
+++ b/scripts/hooks/swe-boundary.sh
@@ -177,6 +177,22 @@ if [ "$IS_PROMPT_SURFACE" = "yes" ]; then
         | grep -oE 'task_id=[0-9]+' | head -1 | sed 's/task_id=//' || true)
       case "$TASK_ID" in ''|*[!0-9]*) TASK_ID="" ;; esac
     fi
+    # Slug fallback: when transcript provides no task_id but a worktree root is
+    # known, resolve the task by branch_id slug (same query as swe-scope-fence.sh).
+    if [ -z "$TASK_ID" ] && [ -n "$WORKTREE_ROOT" ]; then
+      WORKTREE_SLUG=$(echo "$WORKTREE_ROOT" | sed -E 's|.*/.claude/worktrees/([^/]+)$|\1|')
+      if [ -n "$WORKTREE_SLUG" ]; then
+        SAFE_SLUG=$(tmb_sql_quote "$WORKTREE_SLUG")
+        TASK_ID=$(tmb_sqlite_ro "$DB" "
+          SELECT id FROM tasks
+           WHERE branch_id LIKE '%/${SAFE_SLUG}'
+             AND status IN ('pending','running','completed')
+           ORDER BY id DESC
+           LIMIT 1;
+        " 2>/dev/null || true)
+        case "$TASK_ID" in ''|*[!0-9]*) TASK_ID="" ;; esac
+      fi
+    fi
     if [ -n "$TASK_ID" ]; then
       PROMPT_BEARING=$(tmb_sqlite_ro "$DB" "
         SELECT COALESCE(prompt_bearing, 0) FROM tasks WHERE id = ${TASK_ID} LIMIT 1;

--- a/tests/l3-integration/hooks/swe-boundary.test.sh
+++ b/tests/l3-integration/hooks/swe-boundary.test.sh
@@ -46,6 +46,10 @@ sqlite3 "$DB" "
   INSERT INTO tasks VALUES (11, 1, 'feat/prompt-task', 'pending', '', 1);
 "
 
+# Worktree for the prompt-bearing task (slug matches feat/prompt-task).
+WT_PROMPT="$WT_ROOT/prompt-task"
+mkdir -p "$WT_PROMPT"
+
 run_hook_swe() {
   local input="$1"
   (cd "$WORKTREE" && echo "$input" | bash "$HOOK" 2>&1 || true)
@@ -259,5 +263,32 @@ assert_not_contains "$out" '"permissionDecision":"deny"' "bro edit prompt-surfac
 test_case "(d) SWE edit templates/agents/architect.md: DENIED"
 out=$(cd "$NONWT_DIR" && echo "$(make_edit_with_transcript swe 'templates/agents/architect.md' 10)" | bash "$HOOK" 2>&1 || true)
 assert_contains "$out" '"permissionDecision":"deny"' "edit templates/ should be denied"
+
+# ===========================================================================
+# Rule (d) — slug fallback: task_id resolved from worktree slug, no transcript
+# ===========================================================================
+
+make_edit_no_transcript() {
+  local agent_type="$1" path="$2"
+  jq -n --arg a "$agent_type" --arg p "$path" '{
+    tool_name: "Edit",
+    agent_type: $a,
+    tool_input: {file_path: $p}
+  }'
+}
+
+test_case "(d/slug) prompt_bearing=1 task + worktree context + NO transcript: ALLOWED"
+out=$(cd "$WT_PROMPT" && echo "$(make_edit_no_transcript swe "$WT_PROMPT/agents/swe.md")" | bash "$HOOK" 2>&1 || true)
+assert_not_contains "$out" '"permissionDecision":"deny"' "prompt_bearing=1 via slug fallback should allow prompt-surface edit"
+
+test_case "(d/slug) prompt_bearing=0 task + worktree context + NO transcript: DENIED"
+out=$(cd "$WORKTREE" && echo "$(make_edit_no_transcript swe "$WORKTREE/agents/swe.md")" | bash "$HOOK" 2>&1 || true)
+assert_contains "$out" '"permissionDecision":"deny"' "prompt_bearing=0 via slug fallback should deny prompt-surface edit"
+
+test_case "(d/slug) no matching task for slug + NO transcript: DENIED"
+WT_UNKNOWN="$WT_ROOT/unknown-task"
+mkdir -p "$WT_UNKNOWN"
+out=$(cd "$WT_UNKNOWN" && echo "$(make_edit_no_transcript swe "$WT_UNKNOWN/agents/swe.md")" | bash "$HOOK" 2>&1 || true)
+assert_contains "$out" '"permissionDecision":"deny"' "no matching task slug should deny prompt-surface edit"
 
 summarize


### PR DESCRIPTION
Found live in the burn-down (task 29 blocked twice): without agent_transcript_path the prompt_bearing=1 authorization was unreachable, denying legitimately flagged prompt-surface edits. Adds the swe-scope-fence slug-lookup fallback (numeric-guarded, shared SQL helpers, fail-closed when no task matches); reviewer confirmed prompt_bearing=0/no-task stay denied and the fallback can't be steered cross-task (rule c confines edits to the physical worktree). 40/40 + 48/48. Gate trail: task 32, pr-reviewer PASS (row 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)