### PR TITLE
🐛 fix(hooks): brief-gate slug fallback; deny texts teach the real recoveries

### DIFF
--- a/scripts/hooks/auq-headless-deny.sh
+++ b/scripts/hooks/auq-headless-deny.sh
@@ -19,10 +19,10 @@ REASON='<<<TMB-HEADLESS-AUQ-DENIED>>>
 TMB_HEADLESS=1 is set — AskUserQuestion is unavailable in this run (CI / headless / scripted). Per `tmb_recovery` §A doctrine (mandatory):
 1. Load the `tmb_recovery` skill via `Skill(skill='"'"'tmb:tmb_recovery'"'"')`.
 2. Look up the calling skill'"'"'s documented default in `tmb_recovery skill body` §A "Per-skill defaults" (or in the calling skill'"'"'s own headless section).
-3. Emit BOTH writes — `audit_log(kind='"'"'event'"'"', event_type='"'"'headless_fallback'"'"', summary=...)` AND `discussion_append(kind='"'"'note'"'"', body=...)` — on bro'"'"'s behalf.
+3. Call `headless_fallback_record(event_type='"'"'headless_fallback'"'"', summary=..., chosen_value=...)` — one call records both the audit event and the discussion note.
 4. Continue the parent flow with the documented default value as if the Human had typed it.
 5. Skip retrying the AskUserQuestion call with different phrasing — the deny is the signal to fall back, not to rephrase.
-For file-writing creator skills (`tmb_skill-creator`, `/tmb:agent-create`), the documented default is `headless_creator_blocked` HALT instead of an autopick — still emit the audit_log event before halting.
+For file-writing creator skills (`tmb_skill-creator`, `/tmb:agent-create`), the documented default is `headless_creator_blocked` HALT instead of an autopick — still call headless_fallback_record before halting.
 <<<TMB-HEADLESS-AUQ-DENIED>>>'
 
 jq -nc --arg reason "$REASON" '{

--- a/scripts/hooks/git-push-guard.sh
+++ b/scripts/hooks/git-push-guard.sh
@@ -98,11 +98,11 @@ if [ "$WT_CWD" = "yes" ]; then
   exit 0
 fi
 
-# Block any git push from SWE context (swe.md "Never push" rule enforced structurally).
+# Block any git push from SWE context (enforced structurally by this gate).
 # Defense-in-depth fallback: catches non-worktree SWE pushes and cases where
 # CC #97 might strip the agent_type field from the payload.
 if [ "$AGENT_TYPE" = "swe" ]; then
-  jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":"BLOCKED: SWE must never push (swe.md). Bro handles the push gate at MR-open time. If this push was intended, the calling agent identity (.agent_type) is misconfigured."}}'
+  jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":"BLOCKED: SWE must never push. Bro handles the push gate after pr-reviewer passes. Commit in your worktree and call task_update_status(completed)."}}'
   exit 0
 fi
 

--- a/scripts/hooks/pr-reviewer-after-atomic-close.sh
+++ b/scripts/hooks/pr-reviewer-after-atomic-close.sh
@@ -76,7 +76,7 @@ Per tmb_planning Step 5 (verify + close, then pr-reviewer per tmb_review §B) + 
 
 SWE returning completed does not close the trajectory task — that is bro_atomic_close.
 
-Fix: call bro_atomic_close(agent='bro', task_id=${TASK_ID}, commit_sha=<sha>, file_summaries=[...], verification_summary='...') first, then retry this spawn."
+Fix: call bro_atomic_close(agent='bro', task_id=${TASK_ID}, commit_sha=<sha>, verification_summary='...') first, then retry this spawn."
 jq -nc --arg reason "$_DENY_REASON" '{
   hookSpecificOutput: {
     hookEventName: "PreToolUse",

--- a/scripts/hooks/swe-brief-gate.sh
+++ b/scripts/hooks/swe-brief-gate.sh
@@ -69,6 +69,31 @@ if [ -z "$TASK_ID" ]; then
   case "$TASK_ID" in ''|*[!0-9]*) TASK_ID="" ;; esac
 fi
 
+# Slug fallback: when transcript and tool_input provide no task_id, derive it
+# from the worktree root slug (same pattern as swe-boundary.sh).
+if [ -z "$TASK_ID" ]; then
+  WORKTREE_ROOT=""
+  case "$PWD" in
+    */.claude/worktrees/*)
+      WORKTREE_ROOT=$(echo "$PWD" | sed -E 's|(.*/.claude/worktrees/[^/]+).*|\1|')
+      ;;
+  esac
+  if [ -n "$WORKTREE_ROOT" ] && [ -n "$DB" ] && tmb_have_sqlite; then
+    WORKTREE_SLUG=$(echo "$WORKTREE_ROOT" | sed -E 's|.*/.claude/worktrees/([^/]+)$|\1|')
+    if [ -n "$WORKTREE_SLUG" ]; then
+      SAFE_SLUG=$(tmb_sql_quote "$WORKTREE_SLUG")
+      TASK_ID=$(tmb_sqlite_ro "$DB" "
+        SELECT id FROM tasks
+         WHERE branch_id LIKE '%/${SAFE_SLUG}'
+           AND status IN ('pending','running','completed')
+         ORDER BY id DESC
+         LIMIT 1;
+      " 2>/dev/null || true)
+      case "$TASK_ID" in ''|*[!0-9]*) TASK_ID="" ;; esac
+    fi
+  fi
+fi
+
 if [ -z "$TASK_ID" ]; then
   exit 0
 fi

--- a/tests/l3-integration/hooks/auq-headless-deny.test.sh
+++ b/tests/l3-integration/hooks/auq-headless-deny.test.sh
@@ -37,6 +37,9 @@ input=$(make_input "AskUserQuestion")
 out=$(echo "$input" | TMB_HEADLESS=1 bash "$HOOK" 2>&1 || true)
 assert_contains "$out" '"permissionDecision":"deny"' "output has deny decision"
 assert_contains "$out" "tmb_recovery" "output references the recovery skill"
+assert_contains "$out" "headless_fallback_record" "output names headless_fallback_record as the recovery"
+assert_not_contains "$out" "audit_log" "output must not teach the old two-call recipe"
+assert_not_contains "$out" "discussion_append" "output must not teach the old two-call recipe"
 assert_contains "$out" "Skip retrying" "output includes no-retry instruction"
 
 # Test 4 — AUQ + TMB_HEADLESS=0 (set but falsy): exit 0, no stdout

--- a/tests/l3-integration/hooks/swe-brief-gate.test.sh
+++ b/tests/l3-integration/hooks/swe-brief-gate.test.sh
@@ -286,6 +286,40 @@ INPUT=$(jq -n --arg tr "$TR" '{
 out=$(run_hook "$INPUT")
 assert_not_contains "$out" '"permissionDecision":"deny"' "Edit must be allowed after task_brief"
 
+# ---- Slug fallback: no transcript, PWD inside worktree resolves task_id -----
+test_case "Slug fallback: no transcript, PWD inside worktree → gate evaluates (denies)"
+sqlite3 "$DB" "INSERT OR IGNORE INTO tasks VALUES (70, 1, 'fix/slug-task', 'pending', 'spec');" 2>/dev/null || true
+# PWD must look like a worktree root whose slug matches the branch_id suffix.
+FAKE_WT="$TMPDIR/.claude/worktrees/slug-task"
+INPUT=$(jq -n '{
+  agent_type: "swe",
+  tool_name: "mcp__tmb__trajectory-server__task_update_status",
+  tool_input: {}
+}')
+out=$(cd "$FAKE_WT" 2>/dev/null || mkdir -p "$FAKE_WT" && cd "$FAKE_WT" && echo "$INPUT" | bash "$HOOK" 2>&1 || true)
+assert_contains "$out" '"permissionDecision":"deny"' "slug fallback should resolve task and deny"
+assert_contains "$out" "task_brief" "deny reason must mention task_brief"
+
+test_case "Slug fallback: task_brief via slug writes sentinel"
+INPUT=$(jq -n '{
+  agent_type: "swe",
+  tool_name: "mcp__tmb__trajectory-server__task_brief",
+  tool_input: {}
+}')
+out=$(cd "$FAKE_WT" && echo "$INPUT" | bash "$HOOK" 2>&1 || true)
+assert_eq "" "$out" "task_brief via slug should be allowed"
+SENTINEL70=$(sqlite3 "$DB" "SELECT COUNT(*) FROM audit WHERE event_type='swe_brief_fetched' AND content_json LIKE '%\"task_id\":70%';" 2>/dev/null)
+assert_eq "1" "$SENTINEL70" "sentinel written for slug-resolved task"
+
+test_case "Slug fallback: after sentinel exists, tool allowed"
+INPUT=$(jq -n '{
+  agent_type: "swe",
+  tool_name: "mcp__tmb__trajectory-server__task_update_status",
+  tool_input: {}
+}')
+out=$(cd "$FAKE_WT" && echo "$INPUT" | bash "$HOOK" 2>&1 || true)
+assert_not_contains "$out" '"permissionDecision":"deny"' "tool allowed after slug-resolved sentinel"
+
 # ---- bro Edit never denied --------------------------------------------------
 test_case "bro caller: Edit never denied (gate must not affect bro)"
 sqlite3 "$DB" "INSERT INTO tasks VALUES (60, 1, 'feat/bro-edit', 'pending', 'spec');" 2>/dev/null || true


### PR DESCRIPTION
#506 items 1-4: swe-brief-gate gets the #501 slug fallback (unlocks deleting swe.md's last recipe line), auq-headless-deny now names headless_fallback_record as the one-call recovery, after-atomic-close drops the nonexistent file_summaries arg, push-guard's stale swe.md citation fixed. 48/48. Gate trail: task 35, pr-reviewer PASS (row 29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)