### PR TITLE
🧪 test(l5): re-key skill-register row on scope — created_by was a phantom column

### DIFF
--- a/tests/l5-l6/rows/misc-skill-register-on-creation/README.md
+++ b/tests/l5-l6/rows/misc-skill-register-on-creation/README.md
@@ -6,34 +6,34 @@
 
 ## Pre-state
 
-`onboarding-named` fixture. No project-local skills yet. The 8 schema-seeded `tmb_*` rows (added by MR !151) are present with `created_by='system'`.
+`onboarding-named` fixture. No project-local skills yet. The 8 schema-seeded `tmb_*` rows (added by MR !151) are present with `scope='global'`.
 
 ## Turns
 
 | # | Speaker | Message |
 |---|---|---|
-| 1 | user | `@bro create a project-local skill that documents our convention for tagging release commits with the Conventional Commits "release:" prefix. Don't ask questions.` |
+| 1 | user | `@bro create a project-local skill that documents our convention for tagging release commits with the Conventional Commits "release:" prefix. The Human pre-approves this skill — don't invoke AskUserQuestion.` |
 | → | bro | invokes `tmb_skill-creator` → drafts `.claude/skills/<name>/SKILL.md` → calls `skill_register` writing a row to the `skills` table. Single turn — terminates after the register call returns. |
 
 ## Pass criteria
 
 | Scorer | Asserts |
 |---|---|
-| `outcome.sql` | ≥1 row in `skills` with `created_by != 'system'` (bro-authored, not the schema-seeded ones) |
-| `outcome-coherence.json` | `skills WHERE created_by != 'system'`: `>=1` |
+| `outcome.sql` | ≥1 row in `skills` with `scope = 'project-local'` (bro-authored via tmb_skill-creator, not the schema-seeded global ones) |
+| `outcome-coherence.json` | `skills WHERE scope = 'project-local'`: `>=1` |
 | `outcome-git.json` | `base_branch_unchanged: true` |
 | `tools-required.json` | `skill_register` |
 | `tools-forbidden.json` | none |
 | `cost-budget.json` | Soft 200K / 600s |
 
-**Failure modes captured:** bro drafts the SKILL.md file but never calls `skill_register`; bro calls `skill_register` with `created_by='system'` (would shadow the seeded rows); bro invokes the wrong tool (e.g. writes to a different table).
+**Failure modes captured:** bro drafts the SKILL.md file but never calls `skill_register`; bro calls `skill_register` with `scope='global'` (would not be distinguished from the seeded rows); bro invokes the wrong tool (e.g. writes to a different table).
 
 ## Out of scope
 
 - Asserting the actual SKILL.md file exists on disk (filesystem check is brittle in the multi-runner harness).
 - The `agents[].skills[]` frontmatter wiring that `tmb_skill-creator` also performs.
-- Multi-turn ratification flow (the prompt forbids questions to keep it single-turn).
+- Multi-turn ratification flow (the prompt carries Human pre-approval to keep it single-turn).
 
 ## Verification status
 
-**Authored but not yet run end-to-end against `claude -p`.** Reasoning: the assertions are correctness-by-construction (any successful `skill_register` call produces the `created_by != 'system'` row; the schema seed is fixed). Run via `bash tests/l5-l6/run-l5.sh misc-skill-register-on-creation` when you want a live signal.
+**Authored but not yet run end-to-end against `claude -p`.** Reasoning: the assertions are correctness-by-construction (any successful `skill_register` call with default or explicit `scope='project-local'` produces the expected row; the schema seed is fixed at `scope='global'`). Run via `bash tests/l5-l6/run-l5.sh misc-skill-register-on-creation` when you want a live signal.

--- a/tests/l5-l6/rows/misc-skill-register-on-creation/outcome-coherence.json
+++ b/tests/l5-l6/rows/misc-skill-register-on-creation/outcome-coherence.json
@@ -1,5 +1,5 @@
 {
   "expected_writes": {
-    "skills WHERE created_by != 'system'": ">=1"
+    "skills WHERE scope = 'project-local'": ">=1"
   }
 }

--- a/tests/l5-l6/rows/misc-skill-register-on-creation/outcome.sql
+++ b/tests/l5-l6/rows/misc-skill-register-on-creation/outcome.sql
@@ -3,13 +3,11 @@
 -- new skill via `skill_register`. The assertion is that at least one
 -- new row landed in `skills` beyond the 8 schema-seeded `tmb_*` rows.
 --
--- created_by='bro' is the canonical mark for skills registered by bro
--- mid-session — the seeded rows carry `created_by='system'`. Filtering
--- on `created_by != 'system'` keeps the assertion robust to future
--- changes in the seed list.
+-- scope='project-local' is the canonical mark for skills registered by bro
+-- via tmb_skill-creator — the seeded tmb_* rows carry scope='global'.
 
 SELECT
   CASE WHEN COUNT(*) >= 1 THEN 1 ELSE 0 END AS pass,
-  'skills row created by bro (got ' || COUNT(*) || ', expected >=1) — #2853' AS description
+  'skills row with scope=project-local (got ' || COUNT(*) || ', expected >=1) — #2853' AS description
 FROM skills
-WHERE created_by != 'system';
+WHERE scope = 'project-local';

--- a/tests/l5-l6/rows/misc-skill-register-on-creation/prompt.txt
+++ b/tests/l5-l6/rows/misc-skill-register-on-creation/prompt.txt
@@ -1,1 +1,1 @@
-@bro create a project-local skill that documents our convention for tagging release commits with the Conventional Commits "release:" prefix. Don't ask questions.
+@bro create a project-local skill that documents our convention for tagging release commits with the Conventional Commits "release:" prefix. The Human pre-approves this skill — don't invoke AskUserQuestion.


### PR DESCRIPTION
#506 item 5: the row's regression net asserted skills.created_by which exists nowhere; re-keyed on scope='project-local' (fixture-proven 0→1 on register), pre-approval wording aligned with the sibling conflict rows. Gate trail: task 36, pr-reviewer PASS (row 30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)