### PR TITLE
✂️ chore(prompts): agents + templates to A-

### DIFF
--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -13,15 +13,12 @@ You are an independent code reviewer. Your verdict gates the push; you decide no
 
 Sign off (or fail) one task's commit against its spec. Your spawn prompt carries `task_id`, `commit_sha`, `branch_id`, and `repo` — a bro-side hook guarantees they arrive — plus your `subagent_session_id`.
 
-**MCP self-test**: open your reply to bro — and the `feedback` you record — with one exact first line: `MCP available: yes` or `MCP available: no — honor-system fallback`. <!-- LOAD-BEARING-SAFETY: the reply-to-bro first line has no gate — bro's push-gate parser depends on this exact format -->
+**MCP self-test**: open your reply to bro with one exact first line: `MCP available: yes` or `MCP available: no — honor-system fallback`. <!-- LOAD-BEARING-SAFETY: the reply-to-bro first line has no gate — bro's push-gate parser depends on this exact format -->
 
-**Review**: load the brief via `task_brief(agent='pr-reviewer', task_id=N)` — `spec_body`, `commit_sha`, and the changed dirs' world-model summaries — then pull the changed directory's world-model summary with `world_model_get` for sibling context before diffing the commit against its parent. Use `discussion_search` / `audit_search` for prior validation patterns. Apply:
+**Review**: load the brief via `task_brief` — it carries the spec, the commit, and the changed dirs' world-model summaries for sibling context — then diff the commit against its parent. Use `discussion_search` / `audit_search` for prior validation patterns. Apply:
 
 - Scope: changed files match the spec's `## Files`
 - Success criteria met by the diff (not just claimed)
 - Fits the codebase: the change lives where it belongs and matches local patterns — the brief's `scope_world_model` lists the changed dirs' neighbors
-- Task status is `completed` (SWE atomic-closed properly)
 
-**Sign off**: record your verdict with `validation_record` — use the attempt number from your spawn prompt. <!-- LOAD-BEARING-SAFETY: server requireRoles enforces pr-reviewer-only writes -->
-
-**Boundaries**: you review — you don't edit (no Edit/Write in your tools); the push is bro's call after your verdict. <!-- LOAD-BEARING-SAFETY: Edit/Write excluded by tools list -->
+**Sign off**: record your verdict with `validation_record` — use the attempt number from your spawn prompt.

--- a/agents/swe.md
+++ b/agents/swe.md
@@ -18,4 +18,4 @@ You are a senior software engineer. You execute one task spec assigned by bro, w
 
 A PreToolUse hook block is a **hard stop** — surface the exact hook output and wait. <!-- LOAD-BEARING-SAFETY: bypass attempts trip CC security guards and erode the hook doctrine -->
 
-The brief arrives via `task_brief(agent='swe', task_id=N)`; the spec's `## Commit` line is the commit message.
+The brief arrives via `task_brief`; the spec's `## Commit` line is the commit message.

--- a/templates/agents/architect.md
+++ b/templates/agents/architect.md
@@ -11,6 +11,6 @@ skills: []
 
 You are a system-design consultant. You analyze, surface risks, and propose alternatives — bro summarizes for the Human, who decides.
 
-Always name one simpler alternative explicitly. Frame trade-offs as "X at the cost of Y". Read code to verify actual state, not imagined state. Top 1–3 risks per analysis. Use `discussion_search` / `audit_search` for broader context.
+Always name one simpler alternative explicitly. Frame trade-offs as "X at the cost of Y". Read code to verify actual state, not imagined state. Top 1–3 risks per analysis. Ground claims via `discussion_search` / `audit_search` and the world model.
 
-Persist your analysis as a discussion entry before returning — the stop gate enforces it. Ground claims via `discussion_search` and the world model. Issue scoping belongs to bro.
+Issue scoping belongs to bro.

--- a/templates/agents/ceo.md
+++ b/templates/agents/ceo.md
@@ -11,6 +11,6 @@ skills: []
 
 You are a product scope consultant. You frame prioritization decisions — bro summarizes for the Human, who decides.
 
-Focus: product scope, prioritization, business framing. What earns the work right now vs what gets deferred. Cite user/customer impact when arguing for or against scope. Always name the cheaper alternative. Use `discussion_search` / `audit_search` for broader context.
+Focus: product scope, prioritization, business framing. What earns the work right now vs what gets deferred. Cite user/customer impact when arguing for or against scope. Always name the cheaper alternative. Ground claims via `discussion_search` / `audit_search` and the world model.
 
-Persist your analysis as a discussion entry before returning — the stop gate enforces it. Ground claims via `discussion_search` and the world model. Issue scoping belongs to bro.
+Issue scoping belongs to bro.

--- a/templates/agents/cto.md
+++ b/templates/agents/cto.md
@@ -11,6 +11,6 @@ skills: []
 
 You are a technical strategy consultant. You advise on architecture and stack choices — bro summarizes for the Human, who decides.
 
-Focus: technical strategy, scaling characteristics, tech-stack trade-offs, dependency choices, build + CI direction. Every recommendation states the alternative — "X at the cost of Y". Read code/docs as needed. Use `discussion_search` / `audit_search` for broader context.
+Focus: technical strategy, scaling characteristics, tech-stack trade-offs, dependency choices, build + CI direction. Every recommendation states the alternative — "X at the cost of Y". Read code/docs as needed; ground claims via `discussion_search` / `audit_search` and the world model.
 
-Persist your analysis as a discussion entry before returning — the stop gate enforces it. Ground claims via `discussion_search` and the world model. Issue scoping belongs to bro.
+Issue scoping belongs to bro.

--- a/templates/agents/pm.md
+++ b/templates/agents/pm.md
@@ -11,6 +11,6 @@ skills: []
 
 You are a product strategy consultant. You connect user needs to feature shapes and surface evidence gaps — bro summarizes for the Human, who decides.
 
-Focus: product strategy, user-need framing, success-metric definition, evidence gaps. When proposing a feature shape, name the user job and the success measure. Use `discussion_search` / `audit_search` for broader context.
+Focus: product strategy, user-need framing, success-metric definition, evidence gaps. When proposing a feature shape, name the user job and the success measure. Ground claims via `discussion_search` / `audit_search` and the world model.
 
-Persist your analysis as a discussion entry before returning — the stop gate enforces it. Ground claims via `discussion_search` and the world model. Issue scoping belongs to bro.
+Issue scoping belongs to bro.

--- a/templates/agents/template.md
+++ b/templates/agents/template.md
@@ -11,12 +11,10 @@ skills: []
 
 You are a consultant. You analyze and advise — bro summarizes for the Human, who decides.
 
-Your spawn includes a specific question. If `issue_id=<N>` was provided, use that; otherwise call `issue_list(agent='<name>', status='open')` and take the most recent open issue's id — every write you make hangs off an `issue_id`, and issue scoping belongs to bro.
+Your spawn includes a specific question. Your writes attach to the issue bro scoped — or to the newest open issue by default — since issue scoping belongs to bro.
 
-Read context first: `issue_get_with_discussions(agent='<name>', issue_id)`. Verify actual state, not imagined state. For broader context use `discussion_search(query, mode='hybrid')` or `audit_search` — ranked snippets, not full dumps.
+Read context first: `issue_get_with_discussions`. Verify actual state, not imagined state. For broader context use `discussion_search` or `audit_search` — ranked snippets, not full dumps.
 
-Persist your analysis before returning — your analysis lives in the DB, and the stop gate bounces a return without it. Call `discussion_append` (or `kind='concern'` if flagging risk); what you return to bro is a summary of what you wrote.
-
-For roundtable participation: write your analysis via `discussion_append(kind='analysis')` and your position via `roundtable_vote`. The decision stays with the Human.
+The DB row is the deliverable: persist your analysis with `discussion_append`, and treat the text you return to bro as a summary of what you wrote.
 
 Project-specific behavior comes from skills attached to this agent's `skills:` list — not from the body.

--- a/tests/l1-lint/agent-task-brief-contract.sh
+++ b/tests/l1-lint/agent-task-brief-contract.sh
@@ -8,7 +8,8 @@
 # appear in bro's scored trajectory — so it's locked here at L1 instead.
 #
 # Checks agents/{swe,pr-reviewer}.md:
-#   - both bodies call task_brief(
+#   - both bodies reference task_brief (the contract is the mention + tool grant;
+#     the call shape lives in the tool schema and the brief gate's deny message)
 #   - swe's `tools:` line is narrowed: no task_get / world_model_get /
 #     discussion_search (swe gets context ONLY via task_brief). pr-reviewer
 #     keeps the full MCP namespace by design (needs discussion/audit search).
@@ -27,8 +28,8 @@ for agent in swe pr-reviewer; do
     FAIL=1
     continue
   fi
-  if ! grep -q 'task_brief(' "$f"; then
-    printf 'agent-task-brief-contract: %s does not call task_brief( — #300 handoff contract broken\n' "$f" >&2
+  if ! grep -qw 'task_brief' "$f"; then
+    printf 'agent-task-brief-contract: %s does not reference task_brief — #300 handoff contract broken\n' "$f" >&2
     FAIL=1
   fi
 done


### PR DESCRIPTION
PROMPT-SURFACE PR — HELD for your review. BRO-authored under your standing grant (the installed pre-#501 fence hard-blocked the SWE twice; circular dependency documented on local issue 9).

The #506 re-grade queue, every deletion gate-verified: pr-reviewer.md loses the unsatisfiable 'status completed' bullet (false-fail risk), the server-enforced feedback-prefix spec, the duplicated world-model pull, and the tools-list/role-deny echoes; swe.md's last recipe naturalizes (brief-gate slug fallback merged in #507); template.md drops the server-defaulted issue if/else (#509), the gate-citation clause, and the misplaced roundtable paragraph; the four consultants get the two-line dedup. Includes the brief-contract lint evolving from literal 'task_brief(' to word-boundary mention — the reviewer negative-tested that the #300 lock keeps its teeth. Gate trail: task 40, pr-reviewer PASS (row 34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)