### PR TITLE
✂️ chore(prompts): seven skills to A- (includes the dev-red lint fix)

### DIFF
--- a/skills/tmb_concerns-protocol/SKILL.md
+++ b/skills/tmb_concerns-protocol/SKILL.md
@@ -39,14 +39,14 @@ When no Human is in the loop (headless, or the prompt says not to ask): steps 1 
 
 Use when the concern is technical — architecture, security, performance, code quality — and you want an independent read.
 
-1. Identify the relevant consultant (`architect`, `cto`, etc.). If absent, invoke `/tmb:agent-create` first.
+1. Identify the relevant consultant (`architect`, `cto`, etc.). If none exists in the project, ask the Human to create one with `/tmb:agent-create`.
 2. Spawn the consultant with the specific question.
-3. Receive their analysis. Consultants are analysis-only — decisions remain with the Human (server-enforced).
+3. Receive their analysis — decisions remain with the Human.
 4. Summarize their position back to the Human, surface tensions, and let the Human decide.
 
 ## Protocol boundaries
 
 <!-- LOAD-BEARING-SAFETY: these are the four doctrine constraints that define bro's concerns role -->
 - **State the concern once and yield.** One statement, one recommendation — then follow the Human's decision. "I'll just do it the right way" is a doctrine violation.
-- **Log genuine disagreement in the audit trail.** Silent compliance with a plan bro doubts makes bro useless as a sounding board.
+- **Log genuine disagreement as a discussion note.** Silent compliance with a plan bro doubts makes bro useless as a sounding board.
 - **Lead with the concern.** Put it at the top of the response; keep the message focused.

--- a/skills/tmb_docs-conventions/SKILL.md
+++ b/skills/tmb_docs-conventions/SKILL.md
@@ -5,11 +5,11 @@ description: Loaded when editing prompt files (agents, skills, CLAUDE.md, workfl
 
 # Docs Conventions — Editing Discipline
 
-Link integrity is enforced mechanically — every internal markdown link must resolve to a file that exists in the repo. This skill carries the editing judgment — what to delete, what to preserve verbatim, where the ripples go when a rename or restructure lands.
+Link integrity is gated at L1; this skill carries the editing judgment — what to delete, what to preserve verbatim, where the ripples go when a rename or restructure lands.
 
 ## Docs-update expectation
 
-When functionality changes, the same PR updates the user-visible docs that describe it. The PR-reviewer flags missing doc updates at the push gate. This is a judgment call (what counts as user-visible?) — not a regex check.
+When functionality changes, the same PR updates the user-visible docs that describe it. The PR-reviewer flags missing doc updates at the push gate. This is a judgment call (what counts as user-visible?).
 
 ## When docs and code disagree
 

--- a/skills/tmb_planning/SKILL.md
+++ b/skills/tmb_planning/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion, Task, mcp__plugin_tmb_tr
 
 ## 1. Verify the world model
 
-Before anything: `world_model_get(depth=2)`. Returns the project's directory tree with README-derived summaries — bro's working mental picture. If the response carries `warning: 'world-model-empty'`, run `scan_run(source='bro_auto_initial')` yourself to build it — it's deterministic and needs no Human — then re-read. This also satisfies the registry-cold gate on `task_create_batch`; reserve `waive_registry_gate` for the rare case scan genuinely cannot run. Without the world model bro is planning blind.
+Before anything: `world_model_get(depth=2)`. Returns the project's directory tree with README-derived summaries — bro's working mental picture. If the response carries `warning: 'world-model-empty'`, run `scan_run(source='bro_auto_initial')` yourself to build it — it's deterministic and needs no Human — then re-read. Without the world model bro is planning blind.
 
 Zoom-in: `world_model_get(path='src/api', depth=1)`. "Where does X live": `world_model_search(query='X', mode='hybrid')`.
 
@@ -16,7 +16,7 @@ Zoom-in: `world_model_get(path='src/api', depth=1)`. "Where does X live": `world
 
 When a remote is configured:
 
-Ask the Human which branch to create the new feature branch from — offer the configured `pr_target`, the current branch, and 1–3 prominent local branches. On `pr_target`: `git fetch origin ${pr_target} && git checkout ${pr_target} && git pull --ff-only`. On a non-pr_target: switch; leave the branch as-is.
+Ask the Human which branch to create the new feature branch from — offer the configured `pr_target`, the current branch, and 1–3 prominent local branches. On `pr_target`: check it out and bring it up to date with the remote. On any other choice: switch and leave the branch as-is.
 
 Then call `branch_id_propose(agent='bro', intent=<verbatim>, objective=<short>)` and confirm: "Proceed with branch_id X?" (yes / suggest different). On Yes: call `intent_start(agent='bro', objective=<short>, intent_verbatim=<verbatim>, branch_id=<branch_id>)` to create the issue, log the intent, and record the planning note in one step, then create the git branch locally.
 
@@ -58,17 +58,9 @@ Blast-radius (external side effects only): default config is the safe state (opt
 
 ## 4. Spawn SWE
 
-```
-task_create_batch(agent='bro', issue_id=<I>, tasks=[{branch_id, spec_body, ...}], emit_planning_complete=true, ...)
-```
+Create the tasks with `task_create_batch`, asking it to emit the planning-complete event in the same transaction. `waive_scope_gate` is valid for truly trivial work (`'trivial: <what>'`) or headless mode (`'headless mode, defaults applied; <one-line scope summary>'`).
 
-`waive_scope_gate` is valid for truly trivial work (`'trivial: <what>'`) or headless mode (`'headless mode, defaults applied; <one-line scope summary>'`).
-
-Then run the worktree hook per branch and spawn SWE with the task id and the printed worktree path:
-
-```
-Task(subagent_type='swe', prompt='task_id=<N> worktree=<path printed by hook>')
-```
+Then run the worktree hook per branch and spawn SWE per task — the post-create hint carries the exact spawn recipe.
 
 The batch response includes `parallel_groups` — tasks in the same group are safe to spawn in parallel.
 
@@ -78,7 +70,7 @@ After SWE returns `status=completed`:
 
 **V1** — pull: `task_get(task_id=<N>)` + `git diff <commit_sha>~1..<commit_sha>`.
 
-**V2** — three checks:
+**V2** — four checks:
 1. Changed files match `## Files`. No surprise files outside scope.
 2. `## Verification` commands pass — re-run verbatim inside the SWE worktree. Do this BEFORE V3 — the cleanup hook removes the worktree on close.
 3. Each `## Success Criteria` bullet visibly met by the diff.
@@ -86,10 +78,10 @@ After SWE returns `status=completed`:
 
 **V3** — all pass → `bro_atomic_close(agent='bro', task_id=<N>, commit_sha=<sha>, verification_summary='...', close_issue_if_last_task=true)`. The post-close hook re-scans automatically — the world model refreshes.
 
-Then spawn pr-reviewer for the push gate (see `tmb_review` §B). On FAIL: surface it, file the fix as a follow-up issue, and hold the push.
+Then spawn pr-reviewer for the push gate — the spawn-shape hook enforces the anchors. On FAIL: surface it, file the fix as a follow-up issue, and hold the push.
 
 **V3 — any check fails**: `bro_verification_fail_record(agent='bro', task_id=<N>, which_check='<V1|V2|V3>', details='<≤500 chars>')`. Leave the task open. Retry via `task_retry_batch` or escalate.
 
 ## Headless overrides (TMB_HEADLESS=1)
 
-No Human in the loop — skip AUQs, apply the documented defaults (see `tmb_recovery` §A per-skill defaults table), and record the fallback. After `branch_id_propose`, call `headless_intent_start(agent='bro', issue_id=<I>, branch_id=<branch_id>, intent_verbatim=<verbatim>, fallback_summary='<defaults applied>')` — its dedup guard and shared helper handle the writes atomically — then proceed to step 3.
+No Human in the loop — skip AUQs, apply the documented defaults (see `tmb_recovery` §A per-skill defaults table), and record the fallback. After `branch_id_propose`, call `headless_intent_start` — it writes the issue, intent, and note atomically and won't duplicate an intent that already exists — then proceed to step 3.

--- a/skills/tmb_recovery/SKILL.md
+++ b/skills/tmb_recovery/SKILL.md
@@ -17,7 +17,7 @@ The bundled script `scripts/bro-sqlite-readonly.sh` is for §C (trajectory-serve
 ### Protocol
 
 1. **Look up the documented default** for that question (table below). If the calling skill has no documented default, that's a doctrine bug — log it and halt that specific skill (not bro overall).
-2. **Record the fallback** — call `headless_fallback_record(agent='bro', skill=<skill_name>, question=<question_short>, chosen_default=<chosen_default>)`. Writes both the audit event and the discussion note atomically; the deny hook names it on failure. For `issue_id`: use the parent issue when one exists; use `'-1'` for system-level events with no parent issue.
+2. **Record the fallback** — call `headless_fallback_record` with the skill, the question, and the default you chose. It writes the audit event and the discussion note atomically, and the deny hook names it on failure.
 3. **Continue the skill's flow** with the default as if the Human typed it.
 
 ### Per-skill defaults
@@ -37,7 +37,7 @@ The bundled script `scripts/bro-sqlite-readonly.sh` is for §C (trajectory-serve
 
 `tmb_skill-creator` and `/tmb:agent-create` (from-scratch mode) HALT in headless mode rather than apply a default. Silent skill/agent generation in CI is the foot-gun this rule guards against:
 
-Call `audit_log` with `event_type='headless_creator_blocked'` and a summary naming the creator and the proposed name, then surface: "Cannot create skill/agent in headless mode — re-run interactively."
+Record an audit event noting which creator was blocked and the proposed name, then surface: "Cannot create skill/agent in headless mode — re-run interactively."
 
 ## B. MCP tool returns is_error=true
 
@@ -48,7 +48,7 @@ When any MCP call result has `is_error: true` or content includes `{"error": ...
 1. **Halt the current flow immediately.** Treat the failed call as the chain's last.
 2. **Pick one path** based on the error class:
    - **Surface verbatim** to the Human and ask how to proceed, OR
-   - **If recoverable AND you know the corrected call**, write `discussion_append(kind='note', body='Recovered from MCP error: <error_text>. Retrying with <corrected_call>.')` and retry.
+   - **If recoverable AND you know the corrected call**, append a note recording the error and the corrected retry, then retry.
 
 ### Error classification
 

--- a/skills/tmb_review/SKILL.md
+++ b/skills/tmb_review/SKILL.md
@@ -18,7 +18,7 @@ Load context via `task_brief(task_id)` — `spec_body`, `commit_sha`, and the ch
 
 The parent CC session's main checkout may be on ANY branch. Working-tree-dependent verification reads parent's current state, NOT the commit being reviewed.
 
-For working-tree-dependent verification use `pr_review_worktree(agent='pr-reviewer', commit_sha=<sha>, repo_path=<workspace_root>, command='<verification command>')` — `workspace_root` is the directory holding `.claude/tmb/trajectory.db` (same definition as `tmb_planning`); creates the worktree, runs the command, removes it atomically.
+For working-tree-dependent verification use `pr_review_worktree` with the workspace root — the directory holding `.claude/tmb/trajectory.db`; it creates the worktree, runs your command, and removes it atomically.
 
 Sha-based git ops (`git show <sha>`, `git diff <sha>~1..<sha>`, `git ls-tree <sha>`) work from any branch without a worktree — use those for diff inspection.
 
@@ -76,7 +76,7 @@ The verdict row is always authored by pr-reviewer itself — via MCP when availa
 ```
 task_id=42 commit_sha=abc123def branch_id=fix/foo repo=plugin attempt_n=<attempt #>
 
-Push-gate review. Per §A worktree discipline if running linters/build/tests against the working tree. Load context via task_brief(agent='pr-reviewer', task_id=42). Verify each Success Criterion against the diff. Write validation_attempts row per §A (path 1 if you have MCP, path 2 if you have only Bash). Verdict='fail' if any check fails.
+Push-gate review. Load the brief, verify each Success Criterion against the diff, and record your verdict — fail if any check fails.
 ```
 
 No-MCP fallback (Bash-only spawn, no `mcp__...` tools in tool list): use the documented fallback script pattern — `bro-sqlite-readonly.sh` in `tmb_recovery` §C.2 for read-only DB access.
@@ -89,7 +89,7 @@ Triggers:
 
 ### Reap commits → local feature branch
 
-`reap_and_review_prep(agent='bro', task_ids=[<N>, ...], repo_path=<workspace_root>)` — fetches each unsigned task's detached HEAD from its worktree into the main checkout, returns `{ reaped: [{task_id, branch_id, commit_sha, reaped, error?}] }`.
+`reap_and_review_prep` fetches each unsigned task's detached HEAD from its worktree into the main checkout and reports, per task, whether the reap landed or what failed.
 
 ### Spawn pr-reviewer per unsigned task (parallel)
 
@@ -114,27 +114,17 @@ Read pr-reviewer's first response line:
 
 ### Resolve the PR
 
-If `$ARGUMENTS` has a PR number, use it. Otherwise:
+If the Human named a PR number, use it. Otherwise:
 - GitHub: `gh pr view --json number`
 - GitLab: `glab mr list --source-branch <branch> --json`
 
-Empty result → render AUQ:
-```
-AskUserQuestion: "Which PR/MR number to monitor?"
-options: []  # Other free-text only
-```
+Empty result → ask the Human which PR/MR number to monitor (free-text answer).
 
 ### Fetch
 
-```
-pr_comments_get(agent='bro', pr_number=N)
-```
+Call `pr_comments_get` with the PR number.
 
-Carrier: look up the issue via `tasks.branch_id` for the current branch. If unresolved, render AUQ:
-```
-AskUserQuestion: "Which issue is this PR linked to?"
-options: []  # free-text issue ID
-```
+Carrier: look up the issue via `tasks.branch_id` for the current branch. If unresolved, ask the Human which issue the PR is linked to (free-text answer).
 
 ### Triage (judgment)
 
@@ -149,12 +139,7 @@ Group task-worthy comments by file or shared concept; one task per group. Flag t
 
 ### Dispatch
 
-Render AUQ:
-```
-AskUserQuestion: "Which review comments to address now? (subset OK)"
-multiSelect: true
-options: [<task title (with optional (arch-impact) suffix)> per ratified group]
-```
+Offer the ratified groups as a multi-select — one option per group, titled by the task it would become (suffix arch-impact ones) — and let the Human pick a subset.
 
 For each ratified group: `task_create_batch(...)`, spawn SWE, and if arch-impact, invoke `scan_run(source='bro_auto_post_change')` after SWE returns to refresh the world model.
 
@@ -185,7 +170,7 @@ Format: `- <Pattern name> / Symptom: ... / Root cause: ... / Rule: ... / Check: 
 ### Prompt authoring
 
 - **Negative directive in prompt**
-  Trigger: PR introduces a negation clause (start-of-line `Don't` / `Never` / `Do not`, or mid-sentence `MUST NOT` / `do not`) to a prompt or skill body. <!-- LOAD-BEARING-SAFETY: pattern description must name the negation forms for the lint check to be enforceable -->
+  Trigger: a PR adds a negation-phrased rule to a prompt or skill body — the prompt-author lint flags the exact forms.
   Action: Propose the positive alternative inline ("Use X" instead of "Don't use Y"). Or recommend promotion to a deterministic layer (hook / `requireRoles`) for structural enforcement. If load-bearing safety: require `<!-- LOAD-BEARING-SAFETY: <reason> -->` justification.
 
 (Add new findings here as they're caught.)

--- a/skills/tmb_skill-creator/SKILL.md
+++ b/skills/tmb_skill-creator/SKILL.md
@@ -8,8 +8,6 @@ allowed-tools: Read, Write, Edit, Glob, Bash, AskUserQuestion, mcp__plugin_tmb_t
 
 Add a new capability to a project's agents without editing their body. **Lego rule**: agent files are immutable identity; skills are additive capabilities. This skill is the only mechanism that extends a project agent — it appends to the agent's `skills:` array and leaves the body intact.
 
-Step 3 runs `${CLAUDE_PLUGIN_ROOT}/scripts/prompt-author-lint.sh` (regex scan for negations + noise citations) as a Bash step — bro doesn't read it directly. A bundled duplicate lives in `scripts/` for a future dedupe; the plugin-root script is canonical.
-
 ## When to invoke
 
 - Bro detects a project needs a new skill (e.g. Python-stack swe needs a Python-specific verification checklist that the default `tmb_swe-checklist` doesn't cover).
@@ -20,7 +18,7 @@ If the original ask depended on the new skill being in place, bro holds it until
 
 ## Step 1 — Discover the gap
 
-Ask three questions in one AskUserQuestion batch: (1) what to call the skill — propose 1–3 names from context, lowercase with hyphens; (2) which agents to attach it to — list from `.claude/agents/`; (3) when it activates — always or path-scoped. The server rejects invalid or reserved skill names (`tmb_` prefix is plugin-only).
+Ask three questions in one AskUserQuestion batch: (1) what to call the skill — propose 1–3 names from context, lowercase with hyphens; (2) which agents to attach it to — list from `.claude/agents/`; (3) when it activates — always or path-scoped.
 
 ## Step 2 — Draft
 
@@ -51,14 +49,14 @@ Present the full drafted file in a fenced code block. Ask:
 
 ## Step 5 — Write on approval
 
-1. Call `skill_register(agent='bro', name=<name>)` — the server validates and reserves the name (see **Hard rules** on collisions).
+1. Call `skill_register` — the server validates and reserves the name (see **Hard rules** on collisions).
 2. Write the skill file at `<project>/.claude/skills/<name>/SKILL.md`.
-3. For each agent in the attach list, **edit only the `skills:` array** to append the new name. Use `Edit` with a precise `old_string` that includes the existing `skills:` block + the closing `---` so the diff is unambiguous. **Scope the edit to the `skills:` line only — leave every other agent file line unchanged.**
+3. For each agent in the attach list, **edit only the `skills:` array** to append the new name.
 4. Verify by re-reading both the skill file and each agent's frontmatter.
 
 ## Step 6 — Log + report
 
-If there's no open issue (free-floating skill creation — common), create one with `issue_create` scoping the creation. Then log the event with `audit_log(event_type='tmb_skill_created', summary='Authored skill <name>; attached to <agents>.')` and tell the Human in one line: skill landed at `<path>`; attached to `<agents>`.
+If there's no open issue (free-floating skill creation — common), create one with `issue_create` scoping the creation. Then record an audit event noting the skill was created and which agents carry it, and tell the Human in one line: skill landed at `<path>`; attached to `<agents>`.
 
 ## Hard rules
 


### PR DESCRIPTION
PROMPT-SURFACE PR — HELD for your review. BRO-authored under your standing grant (same fence block as the agents PR). MERGING THIS TURNS DEV GREEN — it carries the no-audit-log-without-from-node fix.

The #506 re-grade queue: planning drops the registry-gate echo, the drifted Task(/Agent( spawn fence, the task_create_batch fence, and the git recipe, says 'four checks', naturalizes the §B ref; review inlines the workspace_root definition, de-recipes pr_review_worktree/reap_and_review_prep, converts the three pseudo-JSON AUQ blocks to sentences, retires $ARGUMENTS; recovery adopts the one-call composite description and drops the server-defaulted issue_id sentence; skill-creator de-recipes audit_log/skill_register and loses the meta-paragraph + echoes; concerns + docs-conventions get their clause trims. Reviewer cross-checked every composite mention against composites.ts — no drift. Gate trail: task 41, pr-reviewer PASS (row 35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)