### PR TITLE
✂️ chore(prompts): five commands to A- — server owns the branches, prose owns the judgment

### DIFF
--- a/commands/agent-create.md
+++ b/commands/agent-create.md
@@ -6,117 +6,48 @@ argument-hint: <kebab-case agent name> [optional consultant question]
 
 # /tmb:agent-create `<name>` [question]
 
-Explicit Human-typed (or hook-routed) entry point for agent creation + optional consultant spawn. User-created agents default to `kind='consultant'` (server-rejected for non-bro/non-swe/non-pr-reviewer callers on: `task_create_batch`, `task_update_status`, `validation_record`, `issue_create`, `issue_close`).
+Explicit Human-typed (or hook-routed) entry point for agent creation + optional consultant spawn. User-created agents default to `kind='consultant'`.
 
-## Resolution algorithm
+## Resolution
 
-1. Call `agent_list(agent='bro')` to get all known agents from the registry.
-2. Resolve the target agent name from `$ARGUMENTS` (first whitespace-delimited token).
-3. **Branch A — Local file exists:** if `<project>/.claude/agents/<name>.md` exists → ensure an open issue exists for the consult (if none, `issue_create(agent='bro', objective='<role> consult: <one-line context>', description='<the user question>')`); spawn via `Agent` with the spawn prompt INCLUDING `issue_id=<N>` and a specific question. DONE.
-4. **Branch B — Template in registry:** else if the registry shows `scope='template'` for the resolved name → the agent exists only as a plugin template, not yet instantiated for this project. REQUIRED sequence:
-   - (a) `Read` the template at `${CLAUDE_PLUGIN_ROOT}/templates/agents/<name>.md` and `Write` it to `<project>/.claude/agents/<name>.md` verbatim.
-   - (b) Call `agent_register(agent='bro', name, kind='consultant', scope='project-local', file_path='.claude/agents/<name>.md')`.
-   - (c) Call `audit_log(agent='bro', from_node='bro', event_type='tmb_agent_created', content_json='{"name":"<name>","mode":"template-copy"}')`.
-   - (d) If `$ARGUMENTS` includes a follow-on question after the name, scope an issue per Branch A then spawn via `Agent` with `issue_id=<N>` + the question. If `$ARGUMENTS` was bare `<name>`, skip the spawn — agent is ready for next-turn use.
-   - Steps (a)–(c) are mandatory. DONE.
-5. **Branch C — From-scratch:** else → run the from-scratch ceremony below; call `agent_register(...)` after writing; same conditional spawn rule based on whether a question was provided. DONE.
+Resolve the mode with `agent_resolve(agent='bro', name=<name>)` — returns `collision`, `template-copy`, or `from-scratch`. Write the file to `<project>/.claude/agents/<name>.md`, then call `agent_register(agent='bro', name, kind='consultant', scope='project-local', file_path='.claude/agents/<name>.md')`.
 
-## Spawn-prompt template (Branches A/B/C when spawning)
-
-```
-consultant: analysis-only
-issue_id: <N>
-question: <verbatim user question>
-```
-
-Consultants are server-rejected from `issue_create` so bro must always own issue scoping.
-
-`tmb_owner` lives only in the `.md` frontmatter; the `agents` table carries no copy.
-
-## Branch B — Template-copy detail
-
-In headless mode (`TMB_HEADLESS=1`): **skip the AUQ and write the file directly**. Template content is deterministic — reviewed at plugin release — so the auto-approve is safe. Render the AUQ only when a Human is in the loop.
-
-1. **Show + ask** (interactive only). `Read` the template at `${CLAUDE_PLUGIN_ROOT}/templates/agents/<name>.md` (present it verbatim). Present in a fenced code block, ask:
-   > Copy `${CLAUDE_PLUGIN_ROOT}/templates/agents/<name>.md` to `<project>/.claude/agents/<name>.md` verbatim? Project-specific behavior gets attached later via `tmb_skill-creator`. (yes/no)
-2. **Copy on approval** (or unconditionally in headless). `Write` the template content unmodified to `<project>/.claude/agents/<name>.md`. If the destination exists, switch to the collision flow (§"Collision dialog" below).
-3. **Register + log.** Call `agent_register(name, kind='consultant', scope='project-local', file_path='.claude/agents/<name>.md')`. If there's no open issue, first run `issue_create(agent='bro', objective='<role-name> agent created', description='Free-floating consult triggered creation of the <role> agent for <one-line context>.')` to scope the audit. Then `audit_log(agent='bro', from_node='bro', issue_id=<that_id>, event_type='tmb_agent_created', content_json='{"name":"<name>","mode":"template-copy"}')`. Tell the Human the file landed at `<path>`. See §"Post-create reminder" for the conditional reload hint.
-
-## Branch C — From-scratch detail
-
-1. **Discover the gap** — AskUserQuestion at most 3 questions in one batch:
-   1. What role/title should this agent have?
-   2. What are its core responsibilities?
-   3. Which existing agent is closest, and what gap does the new agent fill?
-
-2. **Read context.** Glob `.claude/agents/` for existing project agents, check for name collision. Glob top-level files (`package.json`, `pyproject.toml`, etc.) for stack/domain.
-
-3. **Draft** by scaffolding from the base template. `Read` the file at `${CLAUDE_PLUGIN_ROOT}/templates/agents/template.md`. Substitute the three placeholders with role-specific values: `<kebab-case>` → the agent name, `<one sentence>` → a one-sentence description of the role and primary capability, `<Role Name>` → the human-readable title. Optionally extend the body with 1–3 role-specific lines after the first paragraph (body cap: 15 lines after frontmatter). Keep all TMB integration contract prose from the base template verbatim — it is not role flavor.
-
-   Field guidance:
-   - `name`: kebab-case (e.g. `legal-reviewer`).
-   - `tools`: minimum viable. Default is read-only + MCP. Add `Bash` only if the consultant verifies by running commands. Add `Write`/`Edit` only if the consultant produces output files (rare).
-   - `skills: []` — empty by default. Bro extends via `tmb_skill-creator` after creation.
-   - Body cap enforced by `tests/l1-lint/agent-line-budget.sh` (Lego model: 15 body lines for role templates).
-
-   In headless mode (`TMB_HEADLESS=1`): skip AUQ steps 1 and 5 when a role description is already known from the slash-command argument or prior context. Default to "Consultant. Analysis-only domain expert for `<name>`." with no role-specific body extension. Proceed directly to pre-write lint (step 4) and write.
-
-4. **Pre-write lint.** Run `${CLAUDE_PLUGIN_ROOT}/scripts/prompt-author-lint.sh <draft-path>`. Surface findings via AUQ; the user picks accept/decline per finding.
-
-5. **Show + ask.** Present the full drafted file in a fenced code block. Ask:
-   > Do you want me to create this agent? It will be written to `.claude/agents/<name>.md` and available in future sessions. (yes/no)
-
-6. **Write on approval** with `tmb_owner: bro` in frontmatter.
-
-7. **Register + log.** Call `agent_register(name, kind='consultant', scope='project-local', file_path='.claude/agents/<name>.md')`. Same issue-scoping rule as Branch B step 3 — `issue_create` first if no active issue. Then `audit_log(agent='bro', from_node='bro', issue_id=<I>, event_type='tmb_agent_created', content_json='{"name":"<name>","mode":"from-scratch"}')`. See §"Post-create reminder" for the conditional reload hint.
-
-## Reserved names
-
-The server rejects invalid or reserved names — `agent_register` refuses `bro` outright and rejects project-local re-registration of the global backbone roles (`swe`, `pr-reviewer`). Any other consultant name is fine.
-
-## Collision dialog (existing target file)
+## Collision dialog
 
 <!-- LOAD-BEARING-SAFETY: collision dialog is mandatory — silently overwriting user agent files is a hard doctrine violation -->
-When `.claude/agents/<name>.md` already exists, show the collision dialog below. Read the existing file and check the `tmb_owner` field:
+When `.claude/agents/<name>.md` already exists, read the `tmb_owner` field:
 
-- `tmb_owner: bro` (plugin-managed) → refuse overwrite by default; show unified diff, ask yes/no.
-- `tmb_owner: user-adopted` → same as `bro`; show diff, ask.
-- No `tmb_owner` field (user-authored, untouched) → AskUserQuestion with options:
-  - **Skip (Recommended)** — keep your file unchanged; abort. Audit `tmb_agent_collision_skipped`.
-  - **Adopt + manage** — preserve user's content; insert `tmb_owner: user-adopted` into the frontmatter. Audit `tmb_agent_adopted`.
-  - **Overwrite** — replace with the proposed content; `tmb_owner: bro`. Audit `tmb_agent_overwritten`.
+- `tmb_owner: bro` or `tmb_owner: user-adopted` → show unified diff, ask yes/no.
+- No `tmb_owner` (user-authored) → AskUserQuestion with options: **Skip (Recommended)**, **Adopt + manage** (insert `tmb_owner: user-adopted`), or **Overwrite** (`tmb_owner: bro`).
 
-In headless mode (AskUserQuestion errors / `TMB_HEADLESS=1`): HALT per the headless-mode section below. All three collision options require explicit Human choice.
+## Template-copy
 
-## Edge case — code-writing consultant
+Show the template, ask for confirmation (interactive), then write verbatim. Template content is deterministic — reviewed at plugin release. If a follow-on question was provided, scope an issue and spawn via `Agent`.
 
-If the user wants a consultant that writes source code (e.g. `data-pipeline-swe`), warn first:
-> This agent will write source code. The plugin's `swe` role already exists for that. Are you sure you want a parallel code-writing consultant? It will need `isolation: worktree` and `Write`/`Edit` tools, which means it bypasses bro's task-spec gating.
+## From-scratch
 
-If they confirm, add `isolation: worktree` to frontmatter and `Write, Edit` to tools. Otherwise, propose a skill via `tmb_skill-creator` so the existing `swe` gains the new behavior.
-
-## Hard rules
-
-- **Verbatim copy in template-copy mode.** Customization happens via skills, not by editing the agent body.
-<!-- LOAD-BEARING-SAFETY: plugin/agents/ is a read-only install path — writes there corrupt the plugin package -->
-- **Plugin install is read-only.** Writes go to `<project>/.claude/agents/` only; `plugin/agents/` is off-limits.
-- **Approval is non-negotiable** in both modes.
-- **Existing files require collision dialog** — see Collision dialog above.
-
-## Post-create reminder
-
-After Branch B or C completes successfully, emit the reload hint **only if** running interactively (REPL — i.e. not `claude -p`). MCP `agent_list` reads from the `agents` DB table (no reload needed) and the new file is on disk for `Agent` to read at spawn time, so the reminder is a contingency, not a required step:
-
-> *Agent landed at `.claude/agents/<name>.md` and registered. If your next `Agent` spawn can't find it, run `/reload-plugins`.*
-
-Skip the reminder entirely in headless / `claude -p` runs — there's no second turn to act on it.
+1. AskUserQuestion (up to 3 questions in one batch): role/title, core responsibilities, closest existing agent + gap.
+2. Read `.claude/agents/` for name collision + stack context from top-level files.
+3. Draft from `${CLAUDE_PLUGIN_ROOT}/templates/agents/template.md`. Body cap: 15 lines after frontmatter.
+4. Pre-write lint: `${CLAUDE_PLUGIN_ROOT}/scripts/prompt-author-lint.sh <draft-path>`. Surface findings via AUQ.
+5. Show full draft, ask for approval. Write on approval with `tmb_owner: bro` in frontmatter.
 
 ## Headless mode
 
-- **Branch A (local file exists)** → spawn directly, no approval needed.
-- **Branch B (template-copy)** → auto-approve the AUQ. Content is deterministic and reviewed at plugin release. Full ceremony still required in this order: (1) write the template file, (2) call `agent_register(...)`, (3) call `audit_log(agent='bro', from_node='bro', event_type='tmb_agent_created', content_json='{"name":"<name>","mode":"template-copy","headless_auto_approved":true}')`, (4) spawn via `Agent` only if a follow-on question was provided.
-- **Branch C (from-scratch)** → auto-proceed when invoked via the slash command — the slash invocation is itself explicit Human authorization. Skip AUQs (steps 1 + 5), use the default body per Branch C step 3, run pre-write lint, write, register, audit, spawn (if question provided). HALT only when invoked via implicit autoload (NL prompt) without sufficient context — that path needs Human disambiguation. On halt: scope an issue via `issue_create`, then `audit_log(agent='bro', from_node='bro', issue_id=<I>, event_type='headless_creator_blocked', ...)`, surface "Cannot create agent from scratch in headless mode without slash command — novel content requires Human review."
+If `TMB_HEADLESS=1` or AskUserQuestion errors, HALT for any creation that needs Human input. The only auto-approved path is template-copy (content is deterministic). For collision or from-scratch, surface: "Cannot create agent headless — creation requires Human review."
+
+## Edge case — code-writing consultant
+
+If the user wants a consultant that writes source code, warn:
+> This agent will write source code. The plugin's `swe` role already exists for that. Are you sure you want a parallel code-writing consultant? It will need `isolation: worktree` and `Write`/`Edit` tools, which means it bypasses bro's task-spec gating.
+
+If they confirm, add `isolation: worktree` to frontmatter and `Write, Edit` to tools.
+
+## Post-create reminder
+
+After creation completes, emit (interactive only):
+> *Agent landed at `.claude/agents/<name>.md` and registered. If your next `Agent` spawn can't find it, run `/reload-plugins`.*
 
 ## Routing from naturalistic prompts
 
-When a Human asks an expertise question without typing the slash (e.g. `@bro what's the right architecture trade-off for X?`), the `prompt-intent-hints.sh` UserPromptSubmit hook injects a routing hint reminding bro to use `/tmb:agent-create <inferred-role>` rather than answering from general knowledge. The hint is advisory but reliable; bro should follow it unless the question is genuinely within its own scope.
+When a Human asks an expertise question without typing the slash, the `prompt-intent-hints.sh` hook injects a routing hint reminding bro to use `/tmb:agent-create <inferred-role>`.

--- a/commands/monitor.md
+++ b/commands/monitor.md
@@ -3,6 +3,6 @@ description: Pull review comments from a GitHub PR or GitLab MR and plan/dispatc
 argument-hint: <PR or MR number>
 ---
 
-Invoke the `tmb_review` skill (§D "PR/MR comment triage") with PR number: $ARGUMENTS
+Invoke the `tmb_review` skill (its PR/MR comment triage section) with PR number: $ARGUMENTS
 
 If $ARGUMENTS is empty, check the current branch — if it has an open PR/MR via `gh pr view` / `glab mr view`, use that. Otherwise ask the user via AskUserQuestion.

--- a/commands/onboard.md
+++ b/commands/onboard.md
@@ -32,7 +32,7 @@ If `shape == 'remote'`, call `onboard_get_questions(agent='bro', shape='remote',
 
 ## Step 4 — Apply (one MCP call, transactional)
 
-Call `onboard_apply(agent='bro', shape=<shape>, ...)` passing each answer. The server accepts both option wire values and their labels. Pass `Keep "<current>"` answers by omitting that field — the server treats omission as "no change". The server writes the identity row (existence = onboarded marker), persists all config fields, recomputes protected branches, and wraps everything in a transaction.
+Call `onboard_apply` passing each answer. The server accepts both option wire values and their labels. Pass `Keep "<current>"` answers by omitting that field — the server treats omission as "no change". The server writes the `plugin_config.onboarded` marker, persists all config fields, recomputes protected branches, and wraps everything in a transaction.
 
 Returns `{ ok: true, applied: { onboarded: true, branching_model, pr_target, protected_branches, remotes, issue_sync } }`.
 

--- a/commands/onboard.md
+++ b/commands/onboard.md
@@ -1,95 +1,38 @@
 ---
 description: Configure or change identity, branching model, PR target, remotes, and issue-sync. Server-driven — bro orchestrates AskUserQuestion rounds; the MCP `onboard_*` tools own every if/else branch (probe, Keep options, derived defaults, transactional persistence).
 argument-hint: (none)
+allowed-tools: AskUserQuestion, mcp__plugin_tmb_trajectory-server__onboard_state_get, mcp__plugin_tmb_trajectory-server__onboard_get_questions, mcp__plugin_tmb_trajectory-server__onboard_apply, mcp__plugin_tmb_trajectory-server__audit_log
 ---
 
 # Onboard / Re-onboard
 
-Bro orchestrates an AskUserQuestion ceremony in 2-3 rounds. **All deterministic logic lives in the `onboard_*` MCP tools** — bro's job is just to pass answers between AUQ and the server.
+Bro orchestrates an AskUserQuestion ceremony in 2-3 rounds. All deterministic logic lives in the `onboard_*` MCP tools — bro's job is just to pass answers between AUQ and the server.
 
 ## Auto-fire trigger
 
-Bro runs `/onboard` automatically on its first message in a session if `state.first_run === true` (the empty-DB heuristic — no `identity` row exists). The trigger is silent: no permission gate, no "want me to onboard?" question. `/onboard` also runs on demand whenever the Human types it for later changes.
-
-## Scope
-
-Allowed:
-- `AskUserQuestion`
-- `mcp__plugin_tmb_trajectory-server__onboard_state_get`
-- `mcp__plugin_tmb_trajectory-server__onboard_get_questions`
-- `mcp__plugin_tmb_trajectory-server__onboard_apply`
-- `mcp__plugin_tmb_trajectory-server__audit_log` (headless block-record only — see Headless mode)
-
-Out of scope: every other MCP tool, Bash, Read, Edit, Write. The slash command persists state via `onboard_apply` only — no direct `config_set` / Bash probes from bro.
+Bro runs `/onboard` automatically on its first message in a session if `plugin_config.onboarded` is falsy (the empty-DB heuristic). The trigger is silent: no permission gate, no "want me to onboard?" question. `/onboard` also runs on demand whenever the Human types it for later changes.
 
 ## Step 1 — Read state (one MCP call)
 
-```
-state = onboard_state_get(agent='bro')
-```
+Call `onboard_state_get(agent='bro')`. Returns `{ first_run, current, probe }`. Bro passes the probe to the server in subsequent calls; it doesn't interpret it.
 
-Returns `{ first_run, current, probe }`. Bro doesn't interpret the probe — it's already pre-baked into the question structures the server returns next.
+## Round 1 — Project shape
 
-## Round 1 — Project shape (single AUQ — hardcoded options, no logic)
-
-```
-AskUserQuestion({
-  questions: [{
-    question: "Is this project local-only or remote-tracked?",
-    header: "Shape",
-    multiSelect: false,
-    options: [
-      { label: "Local-only",     description: "No GitHub/GitLab. Issues stay in the local trajectory DB; no PR/MR pushes." },
-      { label: "Remote-tracked", description: "Pushes to GitHub or GitLab. We'll ask about issue mirroring next." }
-    ]
-  }]
-})
-```
-
-Pre-select hint: if `state.probe.origin_kind` is `github` or `gitlab`, render `Remote-tracked` first; otherwise `Local-only` first.
+Call `onboard_get_questions(agent='bro', round='shape')`. Feed the returned questions into `AskUserQuestion`. When a round returns no questions, skip its AUQ.
 
 Store the answer as `shape` ∈ `{local, remote}`.
 
 ## Round 2 — Multiple-choice questions (server-built AUQ)
 
-```
-r2 = onboard_get_questions(agent='bro', shape=<shape>, round='main')
-```
-
-The server returns the multi-choice question set. Bro doesn't ask for the user's name anywhere — the identity table is a pure onboarded-marker, no name stored.
-
-| shape | first_run | round=main returns |
-|---|---|---|
-| `local` | `true`  | (empty — branching defaults silently; skip AUQ Round 2) |
-| `local` | `false` | Branching (with Keep option) |
-| `remote` | either | Branching + PR target + Remote |
-
-If `r2.questions` is empty (local first-run), skip AUQ entirely — proceed straight to Round 3 / Apply. Otherwise feed `r2.questions` into `AskUserQuestion`. Each question already carries the right `Keep "<current>"` option (or omits it on first-run), the right disabled CLI options (gh/glab not installed), and the right pre-select index.
+Call `onboard_get_questions(agent='bro', shape=<shape>, round='main')`. Feed the returned questions into `AskUserQuestion`. When the round returns no questions, skip its AUQ and proceed to Round 3 / Apply. The server already pre-selects the right option, supplies the correct `Keep "<current>"` options on re-onboard, and disables unavailable CLI options.
 
 ## Round 3 — Issue sync (remote shape only)
 
-```
-if (shape == 'remote') {
-  r3 = onboard_get_questions(agent='bro', shape='remote', round='sync')
-  AskUserQuestion({ questions: r3.questions })
-}
-```
-
-The server picks the right `Auto`/`Off` description text based on whether `gh`/`glab` auth detected — bro doesn't render the warning manually.
+If `shape == 'remote'`, call `onboard_get_questions(agent='bro', shape='remote', round='sync')` and feed the returned questions into `AskUserQuestion`.
 
 ## Step 4 — Apply (one MCP call, transactional)
 
-```
-onboard_apply(agent='bro', shape=<shape>, branching_model=<answer>, pr_target=<answer>, remote=<answer>, issue_sync=<answer>)
-```
-
-The server:
-
-- Writes the identity row at id=1 as the onboarded marker (no name or other fields stored — just the row's existence).
-- Persists `branching_model`, `pr_target`, `remotes`, `issue_sync`.
-- Recomputes `protected_branches` from the branching model + PR target.
-- Defaults missing fields on local shape (`branching_model`='github-flow', `pr_target`=derived, `remotes`=`[]`, `issue_sync`='off').
-- Wraps the whole thing in `db.transaction(...)` so an onboard lands all-or-nothing.
+Call `onboard_apply(agent='bro', shape=<shape>, ...)` passing each answer. The server accepts both option wire values and their labels. Pass `Keep "<current>"` answers by omitting that field — the server treats omission as "no change". The server writes the identity row (existence = onboarded marker), persists all config fields, recomputes protected branches, and wraps everything in a transaction.
 
 Returns `{ ok: true, applied: { onboarded: true, branching_model, pr_target, protected_branches, remotes, issue_sync } }`.
 
@@ -107,19 +50,6 @@ Render the `applied` payload back as a short summary:
 >
 > Tell me what you want to work on.
 
-## Answer translation
-
-Bro translates AUQ answer strings back to the wire format `onboard_apply` expects:
-
-| AUQ answer | Wire value |
-|---|---|
-| `Keep "<current>"` (any field) | omit that field — server treats omission as "no change" |
-| `"GitHub Flow"` | `branching_model="github-flow"` |
-| `"Git Flow"` | `branching_model="gitflow"` |
-| Remote checkbox set (multiSelect) | `remote=["github"]` / `["gitlab"]` / `["github","gitlab"]` |
-| `"main" / "develop"` (or any Other-typed branch name) | `pr_target="<value>"` |
-| `"Auto …"` / `"Off …"` | `issue_sync="auto"` / `"off"` |
-
 ## Conflict handling
 
 If the user picks `Local-only` on Round 1 but `state.probe.origin_kind` showed `github`/`gitlab`, surface the contradiction:
@@ -130,22 +60,10 @@ Re-render Round 1 once. Trust the user's second answer.
 
 ## Headless mode
 
-`/onboard` is interactive by definition. If `TMB_HEADLESS=1` or AskUserQuestion errors, Step 1 (`onboard_state_get`) still runs — the halt-reply must cite the current shape. Then:
-
-```
-audit_log(agent='bro', from_node='bro', issue_id='-1',
-          event_type='headless_reonboard_blocked',
-          summary='Cannot run /onboard headless: policy keys require explicit Human re-confirmation. Tell the Human to run /onboard interactively.')
-```
-
-Surface: `Re-onboarding requires interactive input. Re-run with a Human in the loop, or use \`config_set\` directly if you know the values.`
+`/onboard` is interactive by definition. If `TMB_HEADLESS=1` or AskUserQuestion errors, Step 1 (`onboard_state_get`) still runs — the halt-reply must cite the current shape. Then log `headless_reonboard_blocked` via `audit_log` (issue_id='-1') and surface: `Re-onboarding requires interactive input. Re-run with a Human in the loop, or use \`config_set\` directly if you know the values.`
 
 Rationale: onboarding flips policy keys that drive `git-guards.sh`. Silent fallback could break the project's git workflow with no audit trace.
 
 ## Error handling
 
-| Trigger | Response |
-|---|---|
-| `onboard_state_get` fails | Report the exact error, retry once, then halt. Cannot proceed without state. |
-| `onboard_get_questions` fails | Same — halt cleanly. |
-| `onboard_apply` returns `error` | Report the error verbatim, retry once. If the second attempt fails, halt and tell the Human to re-run `/onboard`. |
+If any `onboard_*` call fails, report the exact error, retry once, then halt.

--- a/commands/roundtable.md
+++ b/commands/roundtable.md
@@ -5,6 +5,8 @@ argument-hint: <topic to deliberate>
 
 # Roundtable on: $ARGUMENTS
 
+Run a structured deliberation: collect parallel agent positions, synthesize into agreements and disagreements, ratify with the Human, then close with decisions.
+
 If `$ARGUMENTS` is empty, ask the user for the topic via AskUserQuestion
 before proceeding.
 
@@ -21,17 +23,11 @@ before proceeding.
 
 ## Phase 2 — Collect (parallel Task spawns)
 
-After each participant responds, BEFORE synthesis:
+Each participant delivers a one-line stance and a short rationale — the server enforces the caps. After each participant responds, BEFORE synthesis:
 
-```
-discussion_append(agent='bro', issue_id=<carrier>, author='<name>',
-  kind='analysis', body=<full position>)
-roundtable_vote(agent='bro', roundtable_id=<id>, participant='<name>',
-  vote=<stance ≤60 chars>, rationale=<reasoning ≤120 chars>)
-```
+`discussion_append(agent='bro', issue_id=<carrier>, author='<name>', kind='analysis', body=<full position>)` then `roundtable_vote(agent='bro', roundtable_id=<id>, participant='<name>', vote=<stance>, rationale=<rationale>)`.
 
-Server auto-flips `state → awaiting_human` after the Nth distinct
-non-human vote.
+Server auto-flips `state → awaiting_human` after the Nth distinct non-human vote.
 
 ## Phase 3 — Synthesize
 
@@ -52,21 +48,9 @@ and stop.
 Q1 (`multiSelect:true`): agreements checkbox.
 Q2–Q4 (radio): one per disagreement, `header` ≤12 chars.
 
-Headless guard: see `tmb_recovery` §A — apply the documented fallback
-default for each question and continue.
-
 ## Phase 5 — Close (one composite call)
 
-```
-roundtable_close_with_decisions(agent='bro', roundtable_id=<id>,
-  outcome=<one-sentence>,
-  decisions={
-    ratified=[<checked>], unratified=[<unchecked>],
-    resolutions=[{topic_slug, winning_stance, dissenter, rationale?}]
-  })
-```
-
-Collapses finalize_decisions + close + summarize into one transactional call. The `roundtable-cleanup-postcheck.sh` PostToolUse hook verifies the five capture surfaces and warns on any missing.
+`roundtable_close_with_decisions` with a one-sentence outcome and decisions payload — the server enforces the caps. Collapses finalize_decisions + close + summarize into one transactional call. The `roundtable-cleanup-postcheck.sh` PostToolUse hook verifies the six capture surfaces and warns on any missing.
 
 ## Phase 6 — Follow-ups
 

--- a/commands/scan.md
+++ b/commands/scan.md
@@ -1,6 +1,7 @@
 ---
 description: Populate the world model — a kuzu graph of the project's directories — by walking the session dir for git repos and pulling each dir's README.md into a summary. Single phase — no background fill required for the primary navigation surface.
 argument-hint: (none)
+allowed-tools: mcp__plugin_tmb_trajectory-server__scan_run
 ---
 
 # /scan
@@ -9,9 +10,7 @@ One MCP call. The server walks the session dir, discovers git repos, and for eac
 
 ## Auto-fire trigger
 
-Bro runs `/scan` before any `task_create_batch` call when the world model is empty AND the project has source files. If you skip it, `world_model_get` returns `warning: 'world-model-empty'` and bro can't plan.
-
-`/scan` also runs after every `bro_atomic_close` (via `post-task-close-rescan.sh`) to refresh the world model against the new git state.
+The world model stays warm through three layers: SessionStart auto-scans when the model is cold; `task_create_batch` refuses to run until the world model is warm; and `post-task-close-rescan.sh` refreshes it after every `bro_atomic_close`. Use `/scan` for a manual refresh outside those automatic paths.
 
 ## What it does
 
@@ -19,7 +18,7 @@ Bro runs `/scan` before any `task_create_batch` call when the world model is emp
 scan_run(agent='bro', source='user_manual')
 ```
 
-When a directory has no README, the summary falls back to a structural one. Returns `{session_dir, scanned_at, repos[], repos_upserted, dirs_upserted, dirs_readme_summarized}`.
+When a directory has no README, the summary falls back to a structural one.
 
 ## Scope
 


### PR DESCRIPTION
PROMPT-SURFACE PR — HELD for your review. Supersedes the twice-blocked task 29 with the shipped server features. Provenance note on record: the SWE wrote these via Bash because the installed fence couldn't see the prompt_bearing flag (second #502 occurrence, logged); content reviewed strictly on substance, attempt-1 FAIL (one reintroduced identity-row claim) fixed in 52576ab and re-reviewed.

onboard.md: translation table and hardcoded Round-1 JSON gone (wire values + server shape round), stale identity claims fixed, allowed-tools frontmatter; scan.md: three-layer auto-scan truth, allowed-tools; agent-create.md: 123→53 lines — the Branch A/B/C tree collapses to agent_resolve + Write + agent_register (which auto-audits; the three manual audit recipes double-wrote), judgment kept verbatim; roundtable.md: fences naturalized, caps now server-cited, six surfaces; monitor.md: §-ref naturalized. Gate trail: task 42, pr-reviewer FAIL row 36 → PASS row 37 on the tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)