### PR TITLE
🔒 feat(hooks): Bash write-forms to prompt surfaces fenced — destination-coupled, read-safe

### DIFF
--- a/scripts/hooks/no-source-edit-from-main.sh
+++ b/scripts/hooks/no-source-edit-from-main.sh
@@ -1,22 +1,33 @@
 #!/usr/bin/env bash
-# No-source-edit-from-main hook (#108, updated #467).
+# No-source-edit-from-main hook (#108, updated #467, #502).
 #
-# Blocks Edit/Write tool calls when the target is a source-code file outside
-# an SWE worktree in a TMB project. Policy is LOCATION-based: any agent
-# context (bro, general-purpose subagent, consultant, etc.) is denied — the
-# worktree location is the only credential.
+# Two rules, both LOCATION-based — any agent context (bro, general-purpose
+# subagent, consultant, etc.) is denied; the worktree path is the only
+# credential for Edit/Write. For Bash, prompt-surface writes are denied
+# regardless of agent identity when outside a worktree.
 #
-# Block conditions (all must be true):
+# This is a tripwire for obvious write-forms, not a Bash sandbox. When in
+# doubt, the hook passes — precision beats recall here.
+#
+# Rule 1 — Edit/Write to source code from main checkout:
+#   Block conditions (all must be true):
 #   1. Trajectory DB exists (this is a TMB project)
 #   2. Target file is NOT inside .claude/worktrees/ (so this is not SWE)
 #   3. Target file is NOT in the docs/templates/config allowlist
-#
-# Allow conditions (any one allows):
+#   Allow conditions (any one allows):
 #   - DB missing (not a TMB project)
 #   - Target is inside .claude/worktrees/<slug>/... (SWE legitimately edits source there)
 #   - Target is in allowlist (docs / configs that are fine to edit from main)
 #
-# Bypass: TMB_ALLOW_SOURCE_EDIT=1 (emergency override for hotfixes).
+# Rule 2 — Bash write-form targeting a prompt surface from main checkout:
+#   Denied for every agent identity (bro, subagent, unknown) when outside a
+#   worktree. Write-forms: >, >>, tee, sed -i, perl -i, python open w/a, cp/mv/rsync.
+#   Prompt surfaces: agents/*.md, skills/*/SKILL.md, commands/*.md,
+#   templates/*.md, CLAUDE.md, CODEX.md, CURSOR.md, GEMINI.md.
+#   Reads (cat/grep/sed -n) are never tripped.
+#   Sanctioned route: spawn an SWE task (prompt_bearing=1 for prompt edits).
+#
+# Bypass: TMB_ALLOW_SOURCE_EDIT=1 (emergency override for hotfixes — rule 1 only).
 
 set -uo pipefail
 
@@ -24,11 +35,173 @@ INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
 
 case "$TOOL_NAME" in
-  Edit|Write|MultiEdit|NotebookEdit) ;;
+  Edit|Write|MultiEdit|NotebookEdit|Bash) ;;
   *) exit 0 ;;
 esac
 
-if [ "${TMB_ALLOW_SOURCE_EDIT:-0}" = "1" ]; then
+if [ "${TMB_ALLOW_SOURCE_EDIT:-0}" = "1" ] && [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
+
+# ---- Rule 2 (Bash): write-form targeting a prompt surface -------------------
+# Applies before the DB check — this rule does not require a TMB project.
+# Denied for every agent identity when the target is NOT inside a worktree.
+if [ "$TOOL_NAME" = "Bash" ]; then
+  CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
+
+  # Worktree exemption: if the command is operating inside a worktree, allow.
+  _main_bash_in_worktree() {
+    local cmd="$1"
+    case "$cmd" in
+      */.claude/worktrees/*|*.claude/worktrees/*) return 0 ;;
+    esac
+    return 1
+  }
+
+  # _is_prompt_surface_token <token>: returns 0 if the token is a prompt-surface path.
+  _is_prompt_surface_token() {
+    local tok="$1"
+    case "$tok" in
+      agents/*.md|*/agents/*.md) return 0 ;;
+      skills/*/SKILL.md|*/skills/*/SKILL.md) return 0 ;;
+      commands/*.md|*/commands/*.md) return 0 ;;
+      templates/*.md|*/templates/*.md) return 0 ;;
+      CLAUDE.md|*/CLAUDE.md) return 0 ;;
+      CODEX.md|*/CODEX.md) return 0 ;;
+      CURSOR.md|*/CURSOR.md) return 0 ;;
+      GEMINI.md|*/GEMINI.md) return 0 ;;
+    esac
+    return 1
+  }
+
+  # _main_bash_writes_prompt_surface: destination-coupled matching.
+  # The verb/redirect operator must be adjacent to the prompt-surface path token.
+  _main_bash_writes_prompt_surface() {
+    local cmd="$1"
+
+    # --- Redirect forms: > <dest> or >> <dest> ---
+    local after_redir=""
+    case "$cmd" in
+      *">>"*)
+        after_redir="${cmd##*>>}"
+        after_redir="${after_redir#"${after_redir%%[! ]*}"}"
+        local dest_tok="${after_redir%% *}"
+        _is_prompt_surface_token "$dest_tok" && return 0
+        ;;
+    esac
+    case "$cmd" in
+      *">"*)
+        local no_dbl
+        no_dbl=$(printf '%s' "$cmd" | sed 's/>>//g')
+        case "$no_dbl" in
+          *">"*)
+            after_redir="${no_dbl##*>}"
+            after_redir="${after_redir#"${after_redir%%[! ]*}"}"
+            local dest_tok2="${after_redir%% *}"
+            _is_prompt_surface_token "$dest_tok2" && return 0
+            ;;
+        esac
+        ;;
+    esac
+
+    # --- tee: match "tee <dest>" or "tee -a <dest>" ---
+    local tee_rest=""
+    case "$cmd" in
+      *" tee "*|*" tee	"*|"tee "*)
+        case "$cmd" in
+          *" tee "*) tee_rest="${cmd##* tee }" ;;
+          "tee "*) tee_rest="${cmd#tee }" ;;
+        esac
+        case "$tee_rest" in
+          "-a "*) tee_rest="${tee_rest#-a }" ;;
+        esac
+        local tee_dest="${tee_rest%% *}"
+        _is_prompt_surface_token "$tee_dest" && return 0
+        ;;
+    esac
+
+    # --- sed -i: file is the last token after sed -i ---
+    case "$cmd" in
+      *"sed -i"*|*"sed --in-place"*)
+        local after_sedi=""
+        case "$cmd" in
+          *"sed --in-place"*) after_sedi="${cmd##*sed --in-place}" ;;
+          *"sed -i"*) after_sedi="${cmd##*sed -i}" ;;
+        esac
+        local sedi_file="${after_sedi##* }"
+        _is_prompt_surface_token "$sedi_file" && return 0
+        ;;
+    esac
+
+    # --- perl -i: file is the last token after perl -i ---
+    case "$cmd" in
+      *"perl -i"*)
+        local after_perli="${cmd##*perl -i}"
+        local perli_file="${after_perli##* }"
+        _is_prompt_surface_token "$perli_file" && return 0
+        ;;
+    esac
+
+    # --- python/python3 open(<path>, 'w'|'a'): path inside open() ---
+    case "$cmd" in
+      *"python"*"open("*"'w'"*|*"python"*"open("*'"w"'*)
+        local open_arg="${cmd##*open(}"
+        local open_path="${open_arg%%,*}"
+        open_path="${open_path#\'}"
+        open_path="${open_path%\'}"
+        open_path="${open_path#\"}"
+        open_path="${open_path%\"}"
+        _is_prompt_surface_token "$open_path" && return 0
+        ;;
+    esac
+    case "$cmd" in
+      *"python"*"open("*"'a'"*|*"python"*"open("*'"a"'*)
+        local open_arg2="${cmd##*open(}"
+        local open_path2="${open_arg2%%,*}"
+        open_path2="${open_path2#\'}"
+        open_path2="${open_path2%\'}"
+        open_path2="${open_path2#\"}"
+        open_path2="${open_path2%\"}"
+        _is_prompt_surface_token "$open_path2" && return 0
+        ;;
+    esac
+
+    # --- cp/mv/rsync: destination is the LAST argument ---
+    case "$cmd" in
+      "cp "*|*" cp "*)
+        local cp_last="${cmd##* }"
+        _is_prompt_surface_token "$cp_last" && return 0
+        ;;
+    esac
+    case "$cmd" in
+      "mv "*|*" mv "*)
+        local mv_last="${cmd##* }"
+        _is_prompt_surface_token "$mv_last" && return 0
+        ;;
+    esac
+    case "$cmd" in
+      "rsync "*|*" rsync "*)
+        local rsync_last="${cmd##* }"
+        _is_prompt_surface_token "$rsync_last" && return 0
+        ;;
+    esac
+
+    return 1
+  }
+
+  if ! _main_bash_in_worktree "$CMD" \
+      && _main_bash_writes_prompt_surface "$CMD"; then
+    BASH_DENY_REASON="BLOCKED: Bash write-forms targeting prompt-surface files (agents/*.md, skills/*/SKILL.md, commands/*.md, templates/*.md, CLAUDE.md, CODEX/CURSOR/GEMINI.md) are denied from the main checkout for every agent identity. Sanctioned route: spawn an SWE task (prompt_bearing=1) for intentional prompt edits. Reads (cat/grep/sed -n) are always allowed."
+    jq -nc --arg reason "$BASH_DENY_REASON" '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: $reason
+      }
+    }'
+    exit 0
+  fi
+
   exit 0
 fi
 

--- a/scripts/hooks/swe-boundary.sh
+++ b/scripts/hooks/swe-boundary.sh
@@ -2,12 +2,23 @@
 # Hook: SWE boundary enforcement — structural gates keyed on deterministic
 # SWE-context signals.
 #
-# Four rules, all guarded by tmb_swe_context():
+# This is a tripwire for obvious write-forms, not a Bash sandbox. When in
+# doubt, the hook passes — precision beats recall here.
 #
-#   (a) Bash: git push from SWE context            → DENY
-#   (b) Bash: gh/glab MUTATING subcommands          → DENY (read-only gh allowed)
-#   (c) Edit/Write: target outside assigned worktree → DENY
-#   (d) Edit/Write: prompt-surface paths             → DENY (unless prompt_bearing=1)
+# Five rules, all guarded by tmb_swe_context():
+#
+#   (a) Bash: git push from SWE context                  → DENY
+#   (b) Bash: gh/glab MUTATING subcommands               → DENY (read-only gh allowed)
+#   (c) Edit/Write: target outside assigned worktree      → DENY
+#   (d) Edit/Write: prompt-surface paths                  → DENY (unless prompt_bearing=1)
+#   (e) Bash: write-form command targeting prompt surface → DENY (unless prompt_bearing=1)
+#
+# Write-forms matched by rule (e):
+#   >, >>, tee, sed -i, perl -i, python/python3 open(...,'w'|'a'), cp/mv/rsync
+#   with a prompt-surface destination (verb coupled to destination token).
+# Prompt surfaces: agents/*.md, skills/*/SKILL.md, commands/*.md,
+#   templates/*.md, CLAUDE.md, CODEX.md, CURSOR.md, GEMINI.md.
+# Read-only commands (cat, grep, sed -n, sed without -i) are never tripped.
 #
 # SWE-context signal (deterministic, defined once here):
 #   - For Bash tool calls: PWD is inside .claude/worktrees/* AND a tasks row with
@@ -58,6 +69,15 @@ tmb_swe_context() {
 
 SWE_CTX=$(tmb_swe_context)
 
+# Resolve the assigned worktree root once — used by rules (c), (d), and (e).
+# Primary signal: $PWD when it's inside a worktree.
+WORKTREE_ROOT=""
+case "$PWD" in
+  */.claude/worktrees/*)
+    WORKTREE_ROOT=$(echo "$PWD" | sed -E 's|(.*/.claude/worktrees/[^/]+).*|\1|')
+    ;;
+esac
+
 # ---- Rule (a): git push from SWE context ------------------------------------
 # Already handled by git-push-guard.sh (which checks both WT_CWD and agent_type).
 # This hook adds defense-in-depth by also checking the SWE_CTX signal for
@@ -99,6 +119,211 @@ if [ "$TOOL_NAME" = "Bash" ] && [ "$SWE_CTX" = "yes" ]; then
     jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":"BLOCKED: SWE may not run gh/glab mutating commands (create/close/edit/merge/delete/api POST|PATCH|PUT|DELETE). Read-only gh commands (view, list, status) are allowed. Mutations go through bro."}}'
     exit 0
   fi
+
+  # ---- Rule (e): Bash write-form targeting a prompt surface ------------------
+  # Tripwire for the obvious forms only — reads (cat/grep/sed -n) never fire.
+  # Deny lifts when the resolved task has prompt_bearing=1 (same resolution as
+  # rule (d), including the slug fallback).
+  #
+  # Destination-coupled matching: the verb/redirect operator must be adjacent to
+  # the prompt-surface path token. A prompt-surface path mentioned inside a quoted
+  # string argument (grep/echo) or as the SOURCE of cp/mv does not count.
+  #
+  # _is_prompt_surface_token <token>: returns 0 if the token is a prompt-surface path.
+  _is_prompt_surface_token() {
+    local tok="$1"
+    case "$tok" in
+      agents/*.md|*/agents/*.md) return 0 ;;
+      skills/*/SKILL.md|*/skills/*/SKILL.md) return 0 ;;
+      commands/*.md|*/commands/*.md) return 0 ;;
+      templates/*.md|*/templates/*.md) return 0 ;;
+      CLAUDE.md|*/CLAUDE.md) return 0 ;;
+      CODEX.md|*/CODEX.md) return 0 ;;
+      CURSOR.md|*/CURSOR.md) return 0 ;;
+      GEMINI.md|*/GEMINI.md) return 0 ;;
+    esac
+    return 1
+  }
+
+  _bash_writes_prompt_surface() {
+    local cmd="$1"
+
+    # --- Redirect forms: > <dest> or >> <dest> ---
+    # Extract the token immediately after > or >> (with optional leading spaces).
+    # We strip the redirect operator and look at what follows.
+    # Pattern: anything then ">>" or ">" then optional space then the dest token.
+    # We use a two-step approach: find the dest token after the last redirect.
+    local after_redir=""
+    case "$cmd" in
+      *">>"*)
+        # Extract what comes after >> (rightmost occurrence for pipelines).
+        after_redir="${cmd##*>>}"
+        # Strip leading whitespace.
+        after_redir="${after_redir#"${after_redir%%[! ]*}"}"
+        # Take first token (up to space or end).
+        local dest_tok="${after_redir%% *}"
+        _is_prompt_surface_token "$dest_tok" && return 0
+        ;;
+    esac
+    case "$cmd" in
+      *">"*)
+        # Only match single > (not >>). Strip >> occurrences first.
+        local no_dbl
+        no_dbl=$(printf '%s' "$cmd" | sed 's/>>//g')
+        case "$no_dbl" in
+          *">"*)
+            after_redir="${no_dbl##*>}"
+            after_redir="${after_redir#"${after_redir%%[! ]*}"}"
+            local dest_tok2="${after_redir%% *}"
+            _is_prompt_surface_token "$dest_tok2" && return 0
+            ;;
+        esac
+        ;;
+    esac
+
+    # --- tee: match "tee <dest>" or "tee -a <dest>" ---
+    # The destination is the last non-flag argument to tee.
+    # Extract the argument after 'tee' (or 'tee -a').
+    local tee_rest=""
+    case "$cmd" in
+      *" tee "*|*" tee	"*|"tee "*)
+        # Capture everything after the last occurrence of " tee " or "tee ".
+        case "$cmd" in
+          *" tee "*) tee_rest="${cmd##* tee }" ;;
+          "tee "*) tee_rest="${cmd#tee }" ;;
+        esac
+        # Skip -a flag if present.
+        case "$tee_rest" in
+          "-a "*) tee_rest="${tee_rest#-a }" ;;
+        esac
+        local tee_dest="${tee_rest%% *}"
+        _is_prompt_surface_token "$tee_dest" && return 0
+        ;;
+    esac
+
+    # --- sed -i: match "sed -i[suffix] ... <file>" ---
+    # The file is the last token. We check if the command has sed -i and a
+    # prompt-surface path token appears after sed -i (not before).
+    case "$cmd" in
+      *"sed -i"*|*"sed --in-place"*)
+        local after_sedi=""
+        case "$cmd" in
+          *"sed --in-place"*) after_sedi="${cmd##*sed --in-place}" ;;
+          *"sed -i"*) after_sedi="${cmd##*sed -i}" ;;
+        esac
+        # The last token in after_sedi is the file.
+        local sedi_file="${after_sedi##* }"
+        _is_prompt_surface_token "$sedi_file" && return 0
+        ;;
+    esac
+
+    # --- perl -i: match "perl -i[suffix] ... <file>" ---
+    case "$cmd" in
+      *"perl -i"*)
+        local after_perli="${cmd##*perl -i}"
+        local perli_file="${after_perli##* }"
+        _is_prompt_surface_token "$perli_file" && return 0
+        ;;
+    esac
+
+    # --- python/python3 open(<path>, 'w'|'a'): the path inside open() ---
+    case "$cmd" in
+      *"python"*"open("*"'w'"*|*"python"*"open("*'"w"'*)
+        local open_arg="${cmd##*open(}"
+        local open_path="${open_arg%%,*}"
+        # Strip surrounding quotes.
+        open_path="${open_path#\'}"
+        open_path="${open_path%\'}"
+        open_path="${open_path#\"}"
+        open_path="${open_path%\"}"
+        _is_prompt_surface_token "$open_path" && return 0
+        ;;
+    esac
+    case "$cmd" in
+      *"python"*"open("*"'a'"*|*"python"*"open("*'"a"'*)
+        local open_arg2="${cmd##*open(}"
+        local open_path2="${open_arg2%%,*}"
+        open_path2="${open_path2#\'}"
+        open_path2="${open_path2%\'}"
+        open_path2="${open_path2#\"}"
+        open_path2="${open_path2%\"}"
+        _is_prompt_surface_token "$open_path2" && return 0
+        ;;
+    esac
+
+    # --- cp/mv/rsync: destination is the LAST argument ---
+    # The prompt-surface path must be the last token (destination).
+    case "$cmd" in
+      "cp "*|*" cp "*)
+        local cp_last="${cmd##* }"
+        _is_prompt_surface_token "$cp_last" && return 0
+        ;;
+    esac
+    case "$cmd" in
+      "mv "*|*" mv "*)
+        local mv_last="${cmd##* }"
+        _is_prompt_surface_token "$mv_last" && return 0
+        ;;
+    esac
+    case "$cmd" in
+      "rsync "*|*" rsync "*)
+        local rsync_last="${cmd##* }"
+        _is_prompt_surface_token "$rsync_last" && return 0
+        ;;
+    esac
+
+    return 1
+  }
+
+  BASH_PROMPT_WRITE=""
+  if _bash_writes_prompt_surface "$CMD"; then
+    BASH_PROMPT_WRITE="yes"
+  fi
+
+  if [ "$BASH_PROMPT_WRITE" = "yes" ]; then
+    # Resolve prompt_bearing via transcript or slug fallback (mirrors rule (d)).
+    _PB_TASK_ID=""
+    _PB_TRANSCRIPT=$(echo "$INPUT" | jq -r '.agent_transcript_path // ""' 2>/dev/null || true)
+    if [ -n "$_PB_TRANSCRIPT" ] && [ -f "$_PB_TRANSCRIPT" ]; then
+      _PB_TASK_ID=$(jq -r '
+        .message.content // [] |
+        .[] | select(.type == "text") | .text // ""
+      ' "$_PB_TRANSCRIPT" 2>/dev/null \
+        | grep -oE 'task_id=[0-9]+' | head -1 | sed 's/task_id=//' || true)
+      case "$_PB_TASK_ID" in ''|*[!0-9]*) _PB_TASK_ID="" ;; esac
+    fi
+    if [ -z "$_PB_TASK_ID" ] && [ -n "$WORKTREE_ROOT" ]; then
+      _PB_SLUG=$(echo "$WORKTREE_ROOT" | sed -E 's|.*/.claude/worktrees/([^/]+)$|\1|')
+      if [ -n "$_PB_SLUG" ]; then
+        _PB_DB=$(tmb_db_path || true)
+        if [ -n "$_PB_DB" ] && tmb_have_sqlite; then
+          _SAFE_SLUG=$(tmb_sql_quote "$_PB_SLUG")
+          _PB_TASK_ID=$(tmb_sqlite_ro "$_PB_DB" "
+            SELECT id FROM tasks
+             WHERE branch_id LIKE '%/${_SAFE_SLUG}'
+               AND status IN ('pending','running','completed')
+             ORDER BY id DESC
+             LIMIT 1;
+          " 2>/dev/null || true)
+          case "$_PB_TASK_ID" in ''|*[!0-9]*) _PB_TASK_ID="" ;; esac
+        fi
+      fi
+    fi
+    _PB_ALLOWED=""
+    if [ -n "$_PB_TASK_ID" ]; then
+      _PB_DB=$(tmb_db_path || true)
+      if [ -n "$_PB_DB" ] && tmb_have_sqlite; then
+        _PB_VAL=$(tmb_sqlite_ro "$_PB_DB" "
+          SELECT COALESCE(prompt_bearing, 0) FROM tasks WHERE id = ${_PB_TASK_ID} LIMIT 1;
+        " 2>/dev/null || echo "0")
+        [ "${_PB_VAL:-0}" -eq 1 ] && _PB_ALLOWED="yes"
+      fi
+    fi
+    if [ "$_PB_ALLOWED" != "yes" ]; then
+      jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":"BLOCKED: SWE may not write prompt-surface files via Bash (>, >>, tee, sed -i, perl -i, python open w/a, cp/mv/rsync). Sanctioned routes: use a prompt_bearing=1 task for intentional prompt edits, or pr_review_worktree for reviewer experiments. Reads (cat/grep/sed -n) are always allowed."}}'
+      exit 0
+    fi
+  fi
 fi
 
 # ---- Rules (c) and (d): Edit/Write fence ------------------------------------
@@ -111,15 +336,6 @@ esac
 
 TARGET=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.notebook_path // ""' 2>/dev/null || true)
 [ -n "$TARGET" ] || exit 0
-
-# Resolve the assigned worktree root for this SWE instance.
-# Primary signal: $PWD when it's inside a worktree. Secondary: agent_transcript_path.
-WORKTREE_ROOT=""
-case "$PWD" in
-  */.claude/worktrees/*)
-    WORKTREE_ROOT=$(echo "$PWD" | sed -E 's|(.*/.claude/worktrees/[^/]+).*|\1|')
-    ;;
-esac
 
 # ---- Rule (c): target outside assigned worktree ----------------------------
 if [ -n "$WORKTREE_ROOT" ]; then

--- a/tests/l3-integration/hooks/no-source-edit-from-main.test.sh
+++ b/tests/l3-integration/hooks/no-source-edit-from-main.test.sh
@@ -201,4 +201,104 @@ rm -f "$DB"
 out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_BRO")")
 assert_eq "" "$out" "no DB = not a TMB project = allow"
 
+# ---- Rule 2: Bash write-forms targeting prompt surfaces (main checkout) ----
+
+bash_input() {
+  jq -n --arg cmd "$1" '{
+    tool_name: "Bash",
+    tool_input: { command: $cmd }
+  }'
+}
+
+test_case "Bash non-write: silent pass"
+out=$(run_hook "$(bash_input 'cat agents/swe.md')")
+assert_eq "" "$out" "cat is read-only, should pass"
+
+test_case "Bash redirect > to agents/swe.md: DENIED (bro context)"
+out=$(run_hook "$(bash_input 'echo "content" > agents/swe.md')")
+assert_contains "$out" '"permissionDecision":"deny"' "redirect > to agents/*.md denied from main checkout"
+assert_contains "$out" "prompt-surface" "deny reason mentions prompt-surface"
+
+test_case "Bash redirect >> to CLAUDE.md: DENIED"
+out=$(run_hook "$(bash_input 'echo "extra" >> CLAUDE.md')")
+assert_contains "$out" '"permissionDecision":"deny"' "redirect >> to CLAUDE.md denied"
+
+test_case "Bash tee to commands/scan.md: DENIED"
+out=$(run_hook "$(bash_input 'cat /tmp/x | tee commands/scan.md')")
+assert_contains "$out" '"permissionDecision":"deny"' "tee to commands/*.md denied"
+
+test_case "Bash sed -i on skills/tmb_planning/SKILL.md: DENIED"
+out=$(run_hook "$(bash_input "sed -i 's/old/new/' skills/tmb_planning/SKILL.md")")
+assert_contains "$out" '"permissionDecision":"deny"' "sed -i on SKILL.md denied"
+
+test_case "Bash perl -i on agents/bro.md: DENIED"
+out=$(run_hook "$(bash_input "perl -i -pe 's/x/y/' agents/bro.md")")
+assert_contains "$out" '"permissionDecision":"deny"' "perl -i on agents/*.md denied"
+
+test_case "Bash python3 open w to agents/swe.md: DENIED"
+out=$(run_hook "$(bash_input "python3 -c \"open('agents/swe.md','w').write('x')\"")")
+assert_contains "$out" '"permissionDecision":"deny"' "python3 open w to agents/*.md denied"
+
+test_case "Bash python open a to GEMINI.md: DENIED"
+out=$(run_hook "$(bash_input "python -c \"open('GEMINI.md','a').write('x')\"")")
+assert_contains "$out" '"permissionDecision":"deny"' "python open a to GEMINI.md denied"
+
+test_case "Bash cp to templates/agents/foo.md: DENIED"
+out=$(run_hook "$(bash_input 'cp /tmp/foo.md templates/agents/foo.md')")
+assert_contains "$out" '"permissionDecision":"deny"' "cp to templates/*.md denied"
+
+test_case "Bash mv to commands/foo.md: DENIED"
+out=$(run_hook "$(bash_input 'mv /tmp/foo.md commands/foo.md')")
+assert_contains "$out" '"permissionDecision":"deny"' "mv to commands/*.md denied"
+
+test_case "Bash rsync to agents/foo.md: DENIED"
+out=$(run_hook "$(bash_input 'rsync -av /tmp/agent.md agents/foo.md')")
+assert_contains "$out" '"permissionDecision":"deny"' "rsync to agents/*.md denied"
+
+test_case "Bash redirect > to non-prompt file: pass"
+out=$(run_hook "$(bash_input 'echo "hello" > src/index.ts')")
+assert_eq "" "$out" "redirect to non-prompt file passes"
+
+test_case "Bash sed -n (read-only) on agents/swe.md: pass"
+out=$(run_hook "$(bash_input "sed -n '1,5p' agents/swe.md")")
+assert_eq "" "$out" "sed -n is read-only, should pass"
+
+test_case "Bash grep on agents/swe.md: pass"
+out=$(run_hook "$(bash_input 'grep "pattern" agents/swe.md')")
+assert_eq "" "$out" "grep is read-only, should pass"
+
+test_case "Bash write in a worktree path: pass (worktree exemption)"
+out=$(run_hook "$(bash_input 'echo "x" > .claude/worktrees/task-99/agents/swe.md')")
+assert_eq "" "$out" "worktree-targeted write passes"
+
+test_case "Bash redirect > to CODEX.md: DENIED"
+out=$(run_hook "$(bash_input 'echo "x" > CODEX.md')")
+assert_contains "$out" '"permissionDecision":"deny"' "redirect to CODEX.md denied"
+
+test_case "Bash redirect > to CURSOR.md: DENIED"
+out=$(run_hook "$(bash_input 'echo "x" > CURSOR.md')")
+assert_contains "$out" '"permissionDecision":"deny"' "redirect to CURSOR.md denied"
+
+test_case "Bash deny applies regardless of agent identity (no agent_type field)"
+out=$(run_hook "$(bash_input 'echo "x" > agents/swe.md')")
+assert_contains "$out" '"permissionDecision":"deny"' "deny fires even with no agent identity"
+
+# ---- Rule 2 false-positive regressions (destination-coupling) ----
+
+test_case "Bash grep containing > char: NOT denied (not a redirect)"
+out=$(run_hook "$(bash_input 'grep ">" agents/swe.md')")
+assert_eq "" "$out" "grep with > in pattern should not be denied"
+
+test_case "Bash awk comparison > on .md file: NOT denied (comparison, not redirect)"
+out=$(run_hook "$(bash_input "awk '\$1 > 5' agents/swe.md")")
+assert_eq "" "$out" "awk comparison operator should not be denied"
+
+test_case "Bash echo with prompt path in string redirected to /tmp: NOT denied"
+out=$(run_hook "$(bash_input 'echo "see agents/swe.md for details" > /tmp/notes.txt')")
+assert_eq "" "$out" "redirect to /tmp mentioning a prompt path should not be denied"
+
+test_case "Bash git commit -m message mentioning agents/swe.md: NOT denied"
+out=$(run_hook "$(bash_input 'git commit -m "touch agents/swe.md"')")
+assert_eq "" "$out" "commit message mentioning prompt path should not be denied"
+
 summarize

--- a/tests/l3-integration/hooks/swe-boundary.test.sh
+++ b/tests/l3-integration/hooks/swe-boundary.test.sh
@@ -291,4 +291,113 @@ mkdir -p "$WT_UNKNOWN"
 out=$(cd "$WT_UNKNOWN" && echo "$(make_edit_no_transcript swe "$WT_UNKNOWN/agents/swe.md")" | bash "$HOOK" 2>&1 || true)
 assert_contains "$out" '"permissionDecision":"deny"' "no matching task slug should deny prompt-surface edit"
 
+# ===========================================================================
+# Rule (e): Bash write-forms targeting prompt surfaces
+# ===========================================================================
+
+make_bash_with_transcript() {
+  local agent_type="$1" cmd="$2" task_id="$3"
+  local tr
+  tr=$(make_transcript "$task_id")
+  jq -n --arg a "$agent_type" --arg c "$cmd" --arg tr "$tr" '{
+    tool_name: "Bash",
+    agent_type: $a,
+    agent_transcript_path: $tr,
+    tool_input: {command: $c}
+  }'
+}
+
+test_case "(e) SWE redirect > to agents/swe.md: DENIED"
+out=$(run_hook_swe "$(make_bash_with_transcript swe 'echo "content" > agents/swe.md' 10)")
+assert_contains "$out" '"permissionDecision":"deny"' "redirect > to agents/*.md should be denied"
+assert_contains "$out" "prompt-surface" "deny reason should mention prompt-surface"
+
+test_case "(e) SWE redirect >> to CLAUDE.md: DENIED"
+out=$(run_hook_swe "$(make_bash_with_transcript swe 'echo "extra" >> CLAUDE.md' 10)")
+assert_contains "$out" '"permissionDecision":"deny"' "redirect >> to CLAUDE.md should be denied"
+
+test_case "(e) SWE tee to commands/scan.md: DENIED"
+out=$(run_hook_swe "$(make_bash_with_transcript swe 'cat template | tee commands/scan.md' 10)")
+assert_contains "$out" '"permissionDecision":"deny"' "tee to commands/*.md should be denied"
+
+test_case "(e) SWE sed -i on skills/tmb_planning/SKILL.md: DENIED"
+out=$(run_hook_swe "$(make_bash_with_transcript swe "sed -i 's/old/new/' skills/tmb_planning/SKILL.md" 10)")
+assert_contains "$out" '"permissionDecision":"deny"' "sed -i on SKILL.md should be denied"
+
+test_case "(e) SWE perl -i on agents/bro.md: DENIED"
+out=$(run_hook_swe "$(make_bash_with_transcript swe "perl -i -pe 's/old/new/' agents/bro.md" 10)")
+assert_contains "$out" '"permissionDecision":"deny"' "perl -i on agents/*.md should be denied"
+
+test_case "(e) SWE python3 open w to agents/swe.md: DENIED"
+out=$(run_hook_swe "$(make_bash_with_transcript swe "python3 -c \"open('agents/swe.md','w').write('x')\"" 10)")
+assert_contains "$out" '"permissionDecision":"deny"' "python3 open w to agents/*.md should be denied"
+
+test_case "(e) SWE python open a to GEMINI.md: DENIED"
+out=$(run_hook_swe "$(make_bash_with_transcript swe "python -c \"open('GEMINI.md','a').write('x')\"" 10)")
+assert_contains "$out" '"permissionDecision":"deny"' "python open a to GEMINI.md should be denied"
+
+test_case "(e) SWE cp src to templates/agents/foo.md: DENIED"
+out=$(run_hook_swe "$(make_bash_with_transcript swe 'cp /tmp/foo.md templates/agents/foo.md' 10)")
+assert_contains "$out" '"permissionDecision":"deny"' "cp to templates/*.md should be denied"
+
+test_case "(e) SWE mv src to commands/foo.md: DENIED"
+out=$(run_hook_swe "$(make_bash_with_transcript swe 'mv /tmp/foo.md commands/foo.md' 10)")
+assert_contains "$out" '"permissionDecision":"deny"' "mv to commands/*.md should be denied"
+
+test_case "(e) SWE rsync src to agents/: DENIED"
+out=$(run_hook_swe "$(make_bash_with_transcript swe 'rsync -av /tmp/agent.md agents/agent.md' 10)")
+assert_contains "$out" '"permissionDecision":"deny"' "rsync to agents/*.md should be denied"
+
+test_case "(e) SWE cat agents/swe.md: NOT denied (read-only)"
+out=$(run_hook_swe "$(make_bash_with_transcript swe 'cat agents/swe.md' 10)")
+assert_not_contains "$out" '"permissionDecision":"deny"' "cat is read-only, should not be denied"
+
+test_case "(e) SWE grep in agents/swe.md: NOT denied (read-only)"
+out=$(run_hook_swe "$(make_bash_with_transcript swe 'grep "pattern" agents/swe.md' 10)")
+assert_not_contains "$out" '"permissionDecision":"deny"' "grep is read-only, should not be denied"
+
+test_case "(e) SWE sed -n on agents/swe.md: NOT denied (read-only)"
+out=$(run_hook_swe "$(make_bash_with_transcript swe "sed -n '1,5p' agents/swe.md" 10)")
+assert_not_contains "$out" '"permissionDecision":"deny"' "sed -n is read-only, should not be denied"
+
+test_case "(e) SWE redirect > to non-prompt file: NOT denied"
+out=$(run_hook_swe "$(make_bash_with_transcript swe 'echo "content" > src/index.ts' 10)")
+assert_not_contains "$out" '"permissionDecision":"deny"' "redirect to non-prompt file should not be denied by rule (e)"
+
+test_case "(e) SWE redirect > to agents/swe.md with prompt_bearing=1: ALLOWED"
+out=$(run_hook_swe "$(make_bash_with_transcript swe 'echo "content" > agents/swe.md' 11)")
+assert_not_contains "$out" '"permissionDecision":"deny"' "prompt_bearing=1 task should allow Bash write to prompt surface"
+
+test_case "(e) SWE sed -i on CLAUDE.md via slug fallback (prompt_bearing=1): ALLOWED"
+out=$(cd "$WT_PROMPT" && echo "$(make_bash_input swe "sed -i 's/old/new/' CLAUDE.md")" | bash "$HOOK" 2>&1 || true)
+assert_not_contains "$out" '"permissionDecision":"deny"' "slug fallback prompt_bearing=1 should allow sed -i on CLAUDE.md"
+
+test_case "(e) SWE redirect > to agents/swe.md via slug fallback (prompt_bearing=0): DENIED"
+out=$(cd "$WORKTREE" && echo "$(make_bash_input swe 'echo x > agents/swe.md')" | bash "$HOOK" 2>&1 || true)
+assert_contains "$out" '"permissionDecision":"deny"' "slug fallback prompt_bearing=0 should deny Bash write to prompt surface"
+
+test_case "(e) bro redirect > to agents/swe.md: NOT denied (bro is not SWE)"
+out=$(run_hook_bro "$(make_bash_input bro 'echo "content" > agents/swe.md')")
+assert_not_contains "$out" '"permissionDecision":"deny"' "bro Bash write to prompt surface not denied by swe-boundary"
+
+# ===========================================================================
+# Rule (e) — false-positive regressions (destination-coupling)
+# ===========================================================================
+
+test_case "(e/fp) grep containing > char: NOT denied (not a redirect)"
+out=$(run_hook_swe "$(make_bash_with_transcript swe 'grep ">" agents/swe.md' 10)")
+assert_not_contains "$out" '"permissionDecision":"deny"' "grep with > in pattern should not be denied"
+
+test_case "(e/fp) awk comparison > on .md file: NOT denied (comparison, not redirect)"
+out=$(run_hook_swe "$(make_bash_with_transcript swe "awk '\$1 > 5' agents/swe.md" 10)")
+assert_not_contains "$out" '"permissionDecision":"deny"' "awk comparison operator should not be denied"
+
+test_case "(e/fp) echo with prompt path in string redirected to /tmp: NOT denied"
+out=$(run_hook_swe "$(make_bash_with_transcript swe 'echo "see agents/swe.md for details" > /tmp/notes.txt' 10)")
+assert_not_contains "$out" '"permissionDecision":"deny"' "redirect to /tmp mentioning a prompt path should not be denied"
+
+test_case "(e/fp) git commit -m message mentioning agents/swe.md: NOT denied"
+out=$(run_hook_swe "$(make_bash_with_transcript swe 'git commit -m "touch agents/swe.md"' 10)")
+assert_not_contains "$out" '"permissionDecision":"deny"' "commit message mentioning prompt path should not be denied"
+
 summarize


### PR DESCRIPTION
Fixes #502 (three logged bypass occurrences): write verbs couple to their prompt-surface DESTINATION — redirect target token, dest-verb last token, open() arg — so the reviewer's false-positive probes (grep \">\" CLAUDE.md, awk comparisons, /tmp writes mentioning prompt paths, commit-message mentions) pass while all nine write-forms still deny in both worktree and main-checkout contexts; prompt_bearing=1 lifts via transcript or slug. Attempt 1 FAIL row 40 → PASS row 41 with the probes as regressions. Reviewer noted two non-blocking hardening ideas (quoted redirect targets, matcher dedup into lib) for a future pass. 63/63 + 57/57 + 48/48. Gate trail: task 46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)