### PR TITLE
🐛 fix(hooks,tests,prompts): consultant ceremony aligned to agent_resolve — L6 step 10 unblocked

### DIFF
--- a/scripts/hooks/prompt-intent-hints.sh
+++ b/scripts/hooks/prompt-intent-hints.sh
@@ -147,10 +147,10 @@ EOF
   fi
 
   if [ -n "$NAMED_ROLE" ]; then
-    CTX="[tmb consultant-spawn enforcement] The user's prompt names the \`${NAMED_ROLE}\` role. Invoke \`/tmb:agent-create ${NAMED_ROLE} <one-line restatement of the user question>\` — the command runs the full agent_list + Branch A/B/C ceremony AND spawns the consultant in the same call. Bare \`Agent(subagent_type='${NAMED_ROLE}')\` without the command bypasses the registry; do NOT take that shortcut."
+    CTX="[tmb consultant-spawn enforcement] The user's prompt names the \`${NAMED_ROLE}\` role. Invoke \`/tmb:agent-create ${NAMED_ROLE} <one-line restatement of the user question>\` — the command resolves the creation mode with agent_resolve, writes the agent file, registers it (the server audits the creation), and spawns the consultant in the same call. Bare \`Agent(subagent_type='${NAMED_ROLE}')\` without the command bypasses the registry; do NOT take that shortcut."
     emit_context "$CTX"
   elif [ -n "$DOMAIN" ]; then
-    CTX="[tmb consultant-spawn enforcement] The user's prompt looks like a \`${DOMAIN}\` judgment call. Invoke \`/tmb:agent-create <role> <one-line restatement>\` with the role that fits this domain (architect / cto / pm / legal-reviewer / a custom from-scratch role). The slash command handles the full ceremony — agent_list lookup, Branch A/B/C routing, audit, spawn — deterministically. Answering directly from general knowledge bypasses the consultant gate."
+    CTX="[tmb consultant-spawn enforcement] The user's prompt looks like a \`${DOMAIN}\` judgment call. Invoke \`/tmb:agent-create <role> <one-line restatement>\` with the role that fits this domain (architect / cto / pm / legal-reviewer / a custom from-scratch role). The slash command resolves the creation mode with agent_resolve, writes the agent file, registers it (the server audits the creation), and spawns the consultant. Answering directly from general knowledge bypasses the consultant gate."
     emit_context "$CTX"
   fi
 fi

--- a/skills/tmb_concerns-protocol/SKILL.md
+++ b/skills/tmb_concerns-protocol/SKILL.md
@@ -39,7 +39,7 @@ When no Human is in the loop (headless, or the prompt says not to ask): steps 1 
 
 Use when the concern is technical — architecture, security, performance, code quality — and you want an independent read.
 
-1. Identify the relevant consultant (`architect`, `cto`, etc.). If none exists in the project, ask the Human to create one with `/tmb:agent-create`.
+1. Identify the relevant consultant (`architect`, `cto`, etc.). If none exists in the project, run the `/tmb:agent-create` flow first — it resolves the creation mode, registers the agent, and spawns it in the same pass.
 2. Spawn the consultant with the specific question.
 3. Receive their analysis — decisions remain with the Human.
 4. Summarize their position back to the Human, surface tensions, and let the Human decide.

--- a/tests/l5-l6/rows/10-consultant/README.md
+++ b/tests/l5-l6/rows/10-consultant/README.md
@@ -1,6 +1,6 @@
 # 10-consultant
 
-**Scenario under test:** Human asks an architecture-trade-off question about the todo CLI's storage choice. The `consultant-spawn-required.sh` UserPromptSubmit hook (which is the deterministic enforcement surface after #198 part 2 retired the CLAUDE.md routing row) detects the architecture-trade-off pattern and injects a hint telling bro to invoke `/tmb:agent-create <role> <one-line restatement>`. Bro follows the hint, the slash command runs `agent_list` + Branch B (cto is template-scope), and spawns cto via `Agent`.
+**Scenario under test:** Human asks an architecture-trade-off question about the todo CLI's storage choice. The `consultant-spawn-required.sh` UserPromptSubmit hook (which is the deterministic enforcement surface after #198 part 2 retired the CLAUDE.md routing row) detects the architecture-trade-off pattern and injects a hint telling bro to invoke `/tmb:agent-create <role> <one-line restatement>`. Bro follows the hint, the slash command resolves the creation mode with `agent_resolve`, writes the agent file, registers it via `agent_register` (the server auto-audits `tmb_agent_created`), and spawns cto via `Agent`.
 
 The row deliberately uses a naturalistic prompt with no role name — bro must classify from context, the same way a real user phrases it. Naming `cto` in the prompt would short-circuit the hook + bro's classification and test the literal string match rather than the description-driven path.
 
@@ -13,7 +13,7 @@ The row deliberately uses a naturalistic prompt with no role name — bro must c
 | # | Speaker | Message |
 |---|---|---|
 | 1 | user | `@bro should we keep src/cli.py's storage in JSON or move to SQLite as the CLI scales?\n\nDon't ask questions.` |
-| → | bro | (consultant-spawn hook injects routing hint) → bro invokes `/tmb:agent-create cto` → command runs `agent_list`, sees cto is template-scope, runs Branch B (template-copy → `agent_register(scope='project-local')` → `audit_log(event_type='tmb_agent_created')` → spawn cto via `Agent`). Single turn. |
+| → | bro | (consultant-spawn hook injects routing hint) → bro invokes `/tmb:agent-create cto` → command calls `agent_resolve` (server returns creation mode), writes the agent file, calls `agent_register(scope='project-local')` (server auto-audits `tmb_agent_created`), spawns cto via `Agent`. Single turn. |
 
 ## Pass criteria
 
@@ -22,7 +22,7 @@ The row deliberately uses a naturalistic prompt with no role name — bro must c
 | `outcome.sql` | an `audit` row with `event_type='tmb_agent_created'` exists (load-bearing signal that the agent-creator ceremony ran). |
 | `outcome-coherence.json` | `audit WHERE event_type = 'tmb_agent_created'`: `>=1` |
 | `outcome-git.json` | `base_branch_unchanged: true` (read-only consult — no commits) |
-| `tools-required.json` | `agent_list`, `agent_register`, `Agent` |
+| `tools-required.json` | `agent_resolve`, `agent_register`, `Agent` |
 | `tools-forbidden.json` | `task_create_batch`, `validation_record` (consultants don't drive workflow state) |
 | `cost-budget.json` | Soft 200K / 600s |
 

--- a/tests/l5-l6/rows/10-consultant/tools-required.json
+++ b/tests/l5-l6/rows/10-consultant/tools-required.json
@@ -1,5 +1,5 @@
 [
-  "mcp__plugin_tmb_trajectory-server__agent_list",
+  "mcp__plugin_tmb_trajectory-server__agent_resolve",
   "mcp__plugin_tmb_trajectory-server__agent_register",
   "Agent"
 ]


### PR DESCRIPTION
PROMPT-TOUCHING (one concerns-protocol line, bro-authored under the recorded grant) + code. The rc gate's L6 step 10 (10-consultant) failed 3 scorers because three surfaces still carried the retired agent_list+Branch ceremony after #514: both consultant hint CTX strings now teach the agent_resolve flow (bypass warnings intact), the row's tools-required pins agent_resolve instead of agent_list (README narration aligned, prompt.txt byte-identical per the tests rule), and concerns-protocol step 1 has bro run the agent-create flow itself rather than deferring to the Human (the row forbids questions). Full hook runner 48/48. Gate trail: task 48, pr-reviewer PASS (row 43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)