### PR TITLE
🧪 fix(tests): prescan cleanup trap as a named function — shellcheck-clean

### DIFF
--- a/tests/l3-integration/hooks/session-start-prescan.test.sh
+++ b/tests/l3-integration/hooks/session-start-prescan.test.sh
@@ -12,17 +12,16 @@ HOOK="$PLUGIN_ROOT/scripts/hooks/session-start-prescan.sh"
 TMPDIR=$(mktemp -d)
 
 # Post-run sentinel: verify no WAL sidecars or stray node processes linger.
-trap '
-  # Kill any stray node processes referencing our fixture dir before cleanup.
+cleanup_sidecar_check() {
   pkill -f "$TMPDIR" 2>/dev/null || true
   wait 2>/dev/null || true
-  # Assert no WAL/SHM sidecars remain.
   leftover=$(find "$TMPDIR" \( -name "*.db-wal" -o -name "*.db-shm" \) 2>/dev/null || true)
   if [ -n "$leftover" ]; then
     printf "FAIL cleanup: WAL/SHM sidecars left behind:\n%s\n" "$leftover" >&2
   fi
   rm -rf "$TMPDIR"
-' EXIT
+}
+trap cleanup_sidecar_check EXIT
 
 DB="$TMPDIR/trajectory.db"
 


### PR DESCRIPTION
Gate attempt 4 failed shellcheck-hooks on SC2154 in the #521 cleanup trap (assignment invisible inside a trap string). Pure restructure into cleanup_sidecar_check() — byte-equivalent behavior (reviewer-verified, sentinel proven on a seeded sidecar), shellcheck PASS repo-wide, belt-and-braces L1 lints over the file class all green. Gate trail: task 51, pr-reviewer PASS (row 46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)