### PR TITLE
🔖 chore(release): bump to 0.8.0 — promote rc.1 to stable

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0",
   "description": "TMB plugin \u2014 bro orchestrates SWE + pr-reviewer in two gates (task gate, push gate) backed by a SQLite trajectory MCP server.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.8.0 — 2026-06-12
+
+Promotes `v0.8.0-rc.1` to stable. See the rc section below for the full milestone rollup. Release gate green on the rc tag: L0 + L1–L4 + L6 chain 13/13 in a single run. First release under the merge-commit promotion policy.
+
 ## v0.8.0-rc.1 — 2026-06-11
 
 The A- campaign release: every prompt surface (agents, skills, commands, CLAUDE.md) re-authored to the DETERMINISM grading bar, backed by composites, server features, and structural hardening across the full v0.8.0 milestone.

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "mcp/trajectory-server": {
       "name": "@trustmybot/trajectory-server",
-      "version": "0.8.0-rc.1",
+      "version": "0.8.0",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.0",

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Release-prep for v0.8.0: three manifests + bun.lock to 0.8.0, stable CHANGELOG section promoting rc.1 (gate green: run 27393137117, 13/13 single-run). Human approval recorded on local issue 10. Gate trail: task 52, pr-reviewer PASS (row 47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)