### PR TITLE
⬆️ chore(ci): bump actions/upload-artifact v5→v7 (Node 24)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload L6 chain artifacts (on success or failure)
         if: ${{ always() && inputs.skip_l6 != true && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')) }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: l6-chain-runs-${{ github.run_id }}
           path: ~/.claude/tmb/l6-chain-runs/


### PR DESCRIPTION
Fixes the last remaining "Node.js 20 actions are deprecated" annotation on release-gate runs.

Unlike `checkout`/`setup-node`/`cache` (whose v5 majors are Node 24 builds), `actions/upload-artifact@v5` still declares `using: node20` — Node 24 landed in its v6.0.0; current is v7.0.1. GitHub runners force Node 24 by default on June 16, 2026. Our inputs (`name`, `path`, `if-no-files-found`, `retention-days`) are unchanged across v6/v7.

One line: `release-gate.yml:112` `@v5` → `@v7`.

Gate: full release-gate workflow_dispatch (L6 enabled, so the upload step actually executes on the new action) runs on this branch; merge only on green per never-merge-failing-CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)