### PR TITLE
🔖 chore(release): bump to 0.8.1-rc.1 — changelog + version sync

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.8.0",
+  "version": "0.8.1-rc.1",
   "description": "TMB plugin \u2014 bro orchestrates SWE + pr-reviewer in two gates (task gate, push gate) backed by a SQLite trajectory MCP server.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.8.1-rc.1 — 2026-06-12
+
+Patch release carrying the #529 ensure-branch fix and the upload-artifact v7 upgrade.
+
+### Fixed
+
+- **`task_create_batch` ensures branch exists** — resolves repos via `repos.path`, creates the task's branch from `parent_branch_id` (fallback HEAD) if absent, and fires a `tmb_branch_autocreated` audit event; closes the headless one-way trap behind gate run #94's L6 step-5 failure (GH #529, PR #530).
+
+### Changed
+
+- **`actions/upload-artifact` v5→v7** — last Node 20 action off the release gate; all CI actions now Node 24-compatible (#528).
+
 ## v0.8.0 — 2026-06-12
 
 Promotes `v0.8.0-rc.1` to stable. See the rc section below for the full milestone rollup. Release gate green on the rc tag: L0 + L1–L4 + L6 chain 13/13 in a single run. First release under the merge-commit promotion policy.

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "mcp/trajectory-server": {
       "name": "@trustmybot/trajectory-server",
-      "version": "0.8.0",
+      "version": "0.8.1-rc.1",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.0",

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.8.0",
+  "version": "0.8.1-rc.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.8.0",
+  "version": "0.8.1-rc.1",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Mechanical rc bump for v0.8.1, mirroring 109e00d. Version sync to 0.8.1-rc.1 across plugin.json / package.json / mcp package.json / bun.lock + CHANGELOG section covering #528 (upload-artifact v7) and #529/#530 (ensure-branch fix).

The rc TAG itself is held until local L6 runs 13/13 green on dev with this merged — per the rc policy, local L6 licenses the tag; tag-triggered CI is re-confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)