### PR TITLE
🔖 chore(release): bump to 0.8.1 — promote rc.1 to stable

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.8.1-rc.1",
+  "version": "0.8.1",
   "description": "TMB plugin \u2014 bro orchestrates SWE + pr-reviewer in two gates (task gate, push gate) backed by a SQLite trajectory MCP server.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.8.1 — 2026-06-12
+
+Promotes `v0.8.1-rc.1` to stable. See the rc section below for the change list. Local L6 chain 13/13 on the tagged tree (the licensing gate per the new phased release workflow); release-gate CI green on the rc tag as re-confirmation.
+
 ## v0.8.1-rc.1 — 2026-06-12
 
 Patch release carrying the #529 ensure-branch fix, the #537 embedding-await fix, and the upload-artifact v7 upgrade.

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "mcp/trajectory-server": {
       "name": "@trustmybot/trajectory-server",
-      "version": "0.8.1-rc.1",
+      "version": "0.8.1",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.0",

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.8.1-rc.1",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.8.1-rc.1",
+  "version": "0.8.1",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Phase D step 9: version sync to 0.8.1 + stable CHANGELOG section. Functional-identity vs v0.8.1-rc.1 holds: dev has zero commits since the rc tag; this PR is version mechanics only.

No linked issue: release mechanics (local issue 14 tracks the v0.8.1 cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)