### PR TITLE
📝 docs(contributing): Phase D re-pins the rc channel to the stable tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,8 @@ L6 needs the `CLAUDE_CODE_OAUTH_TOKEN` repo secret; chain logs upload as a run a
 11. Promotion PR `dev → main` as a **merge commit**; merge.
 12. `git checkout main && git pull`, then `bash scripts/release.sh` — it tags `v<plugin.json version>` on `main` HEAD, pushes the tag, cuts the GitHub release from the matching CHANGELOG section, and runs the Docker install canary. Each step asks y/N and skips if already done (safe to re-run); it refuses off-`main`, on a dirty tree, or on a version/CHANGELOG mismatch.
 13. The stable catalog (`trustmybot/marketplace`) pins `ref: "main"` — promotion updates it automatically; no catalog edit.
-14. **Canary red = fix-forward immediately** — the release is already public. Diagnose before announcing; never delete the tag.
+14. **Re-pin the rc channel to the stable tag**: in `trustmybot/marketplace-rc`, set `plugins[].source.ref` to the new `vX.Y.Z` so rc-channel installs converge on the released build between rc cycles.
+15. **Canary red = fix-forward immediately** — the release is already public. Diagnose before announcing; never delete the tag.
 
 ## Writing code & tests
 


### PR DESCRIPTION
Codifies the post-promotion convention the Human caught after v0.8.1 (and that was also missed in the v0.8.0 cycle): once stable ships, `trustmybot/marketplace-rc` re-pins `plugins[].source.ref` to the new `vX.Y.Z` so rc-channel installs converge on the released build between rc cycles. Precedent: catalog commit 211e569 (v0.7.0 era). The pin itself is already executed (84bc390); this lands the step as Phase D #14, canary renumbered to #15.

No linked GH issue: release-process doc (local issue 15, closed on this task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)