### PR TITLE
🧪 fix(l6): seeded resume matches live state for steps 10 and 13 (#536)

### DIFF
--- a/tests/l5-l6/l6-chain/seeds/after-08-architectural-change.sql
+++ b/tests/l5-l6/l6-chain/seeds/after-08-architectural-change.sql
@@ -9,6 +9,12 @@ INSERT INTO discussions (issue_id, author, kind, body, created_at)
 SELECT id, 'bro', 'question', 'Q: keep the interface in src/cli.py for now or move it under src/storage/?', datetime('now')
 FROM issues WHERE status IN ('open', 'closed') ORDER BY id DESC LIMIT 1;
 
+INSERT OR REPLACE INTO discussions_embeddings (discussion_id, embedding, model_id, embedded_at)
+VALUES (last_insert_rowid(), zeroblob(6144), 'stub-zero-v0', datetime('now'));
+
 INSERT INTO discussions (issue_id, author, kind, body, created_at)
 SELECT id, 'user', 'answer', 'A: keep it in src/cli.py for the interface and JSON impl; split out only when the SQLite impl lands.', datetime('now')
 FROM issues WHERE status IN ('open', 'closed') ORDER BY id DESC LIMIT 1;
+
+INSERT OR REPLACE INTO discussions_embeddings (discussion_id, embedding, model_id, embedded_at)
+VALUES (last_insert_rowid(), zeroblob(6144), 'stub-zero-v0', datetime('now'));

--- a/tests/l5-l6/lib/scorers.sh
+++ b/tests/l5-l6/lib/scorers.sh
@@ -77,12 +77,20 @@ l5_score_outcome() {
 }
 
 # l5_score_trajectory_required <project_dir> <flow> <scorer_dir> <run_id>
-# Reads scorer_dir/tools-required.json (a JSON array of tool/MCP names).
-# Asserts every listed tool was called at least once (superset semantics
+# Reads scorer_dir/tools-required.json (a JSON array). Each entry is either:
+#   - a plain string (tool name always required), or
+#   - an object {"tool":"name","skip_if_pre_state_sql":"SELECT 1 FROM ..."}
+#     where the SQL is evaluated against $project/.claude/tmb/_l6_pre_step.db
+#     when that file exists; if the query returns any row the requirement is
+#     waived (pre-state condition already satisfied — the tool is only needed
+#     when the pre-state lacks the resource). In L5 mode (no pre-step DB) the
+#     condition is ignored and the tool remains required.
+# Asserts every non-waived tool was called at least once (superset semantics
 # per LangSmith docs). Order-agnostic. Reads tool_use names from trajectory.jsonl.
 l5_score_trajectory_required() {
   local project="$1" flow="$2" scorer_dir="$3" run_id="$4"
   local db="$project/.claude/tmb/trajectory.db"
+  local pre_step_db="$project/.claude/tmb/_l6_pre_step.db"
   local jsonl="$project/trajectory.jsonl"
   local req_path="$scorer_dir/tools-required.json"
 
@@ -98,15 +106,37 @@ l5_score_trajectory_required() {
   local tools_called
   tools_called=$(jq -r 'select(.type=="assistant") | .message.content[]? | select(.type=="tool_use") | .name' "$jsonl" 2>/dev/null | sort -u)
 
-  local required missing=""
-  required=$(jq -r '.[]' "$req_path")
+  local entry_count missing=""
+  entry_count=$(jq -r 'length' "$req_path" 2>/dev/null || echo 0)
 
-  while IFS= read -r tool; do
+  local i
+  for i in $(seq 0 $((entry_count - 1))); do
+    local entry_type tool skip_sql
+    entry_type=$(jq -r ".[$i] | type" "$req_path" 2>/dev/null)
+
+    if [ "$entry_type" = "string" ]; then
+      tool=$(jq -r ".[$i]" "$req_path")
+      skip_sql=""
+    else
+      tool=$(jq -r ".[$i].tool" "$req_path" 2>/dev/null)
+      skip_sql=$(jq -r ".[$i].skip_if_pre_state_sql // empty" "$req_path" 2>/dev/null)
+    fi
+
     [ -z "$tool" ] && continue
+
+    if [ -n "$skip_sql" ] && [ -f "$pre_step_db" ]; then
+      local hit
+      hit=$(sqlite3 "$pre_step_db" "$skip_sql" 2>/dev/null | head -1)
+      if [ -n "$hit" ]; then
+        echo "  ⊘ trajectory_required: $tool waived (pre-state condition met)"
+        continue
+      fi
+    fi
+
     if ! echo "$tools_called" | grep -qFx "$tool"; then
       missing="${missing}; $tool"
     fi
-  done <<< "$required"
+  done
 
   if [ -z "$missing" ]; then
     echo "  ✓ trajectory_required: all required tools called"

--- a/tests/l5-l6/rows/10-consultant/tools-required.json
+++ b/tests/l5-l6/rows/10-consultant/tools-required.json
@@ -1,5 +1,8 @@
 [
   "mcp__plugin_tmb_trajectory-server__agent_resolve",
-  "mcp__plugin_tmb_trajectory-server__agent_register",
+  {
+    "tool": "mcp__plugin_tmb_trajectory-server__agent_register",
+    "skip_if_pre_state_sql": "SELECT 1 FROM agents WHERE name='cto' AND scope='project-local' LIMIT 1"
+  },
   "Agent"
 ]

--- a/tests/l5-l6/run-l6-chain.sh
+++ b/tests/l5-l6/run-l6-chain.sh
@@ -301,6 +301,7 @@ for idx in $(seq 0 $((STEP_COUNT - 1))); do
   fi
 
   l6c_snapshot_db "$PROJECT" "$STEP_DIR/pre-state.sql"
+  cp "$PROJECT/.claude/tmb/trajectory.db" "$PROJECT/.claude/tmb/_l6_pre_step.db" 2>/dev/null || true
   cp "$ROW_DIR/prompt.txt" "$STEP_DIR/user-input.txt"
 
   # If plugin_config.pr_target points at a branch that doesn't exist in


### PR DESCRIPTION
Closes #536. L6 --from resume diverged from live state: step-10 agent_register scorer false-failed (consultant pre-exists in seeded state), after-08 seed omitted the embeddings sidecar (step-13 fail). Fix: pre-state-conditioned scorer (skip_if_pre_state_sql, double-gated so live runs still require the call), after-08 seed embeddings rows, pre-step DB snapshot. No prompt.txt touched. pr-reviewer PASS (row #64). CI-affecting (L6) → release-gate workflow_dispatch must pass before merge. 🤖 Generated with [Claude Code](https://claude.com/claude-code)