### PR TITLE
🧪 fix(tests): prescan shape-setup skips real scan — kills ubuntu WAL/disk-IO race (#557)

### DIFF
--- a/tests/l3-integration/hooks/session-start-prescan.test.sh
+++ b/tests/l3-integration/hooks/session-start-prescan.test.sh
@@ -41,7 +41,7 @@ git -C "$FIXTURE_WS" commit -q -m "initial commit"
 
 # Helper: run the real hook from the fixture workspace with explicit DB.
 run_hook() {
-  (cd "$FIXTURE_WS" && env TRAJECTORY_DB_PATH="$DB" bash "$HOOK" 2>/dev/null) || true
+  (cd "$FIXTURE_WS" && env TRAJECTORY_DB_PATH="$DB" TMB_SKIP_AUTO_PRESCAN=1 bash "$HOOK" 2>/dev/null) || true
 }
 
 # reset_db: remove the DB and any WAL/SHM sidecars atomically, then recreate.


### PR DESCRIPTION
Fixes #557.

The L3 `session-start-prescan.test.sh` shape-test setup ran the real hook against a cold DB, spawning a real background scan that opened `trajectory.db` in WAL mode. That lingering process raced the test teardown, leaking `-wal`/`-shm` sidecars and triggering `disk I/O error (10)` on ubuntu — intermittently failing the release-gate (blocked #550's gate twice).

**Fix:** the `run_hook` helper now passes `TMB_SKIP_AUTO_PRESCAN=1`, so shape tests build the inventory without spawning a real scan. The dedicated scan-spawn path stays covered by the cold+invoker fake-invoker tests (which never open the DB). Hook source unchanged.

Verified: 25/25 + 5× repeat with zero sidecar leak; pr-reviewer PASS (row 67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)