### PR TITLE
🐛 fix(hooks): cleanup-worktree resolves HEAD-reset target per-repo; drop dead pr_target read (#559)

### DIFF
--- a/scripts/hooks/cleanup-worktree-on-task-close.sh
+++ b/scripts/hooks/cleanup-worktree-on-task-close.sh
@@ -24,6 +24,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/query-task.sh
 . "$SCRIPT_DIR/lib/query-task.sh"
+# shellcheck source=lib/resolve-repo.sh
+. "$SCRIPT_DIR/lib/resolve-repo.sh"
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
@@ -120,7 +122,11 @@ git -C "$REPO_ROOT" worktree prune >/dev/null 2>&1 || true
 # Bypass: TMB_KEEP_HEAD_ON_CLOSE=1 (rare — e.g. when the Human deliberately
 # wants to stay on the feature branch for follow-on inspection).
 if [ "${TMB_KEEP_HEAD_ON_CLOSE:-0}" != "1" ]; then
-  PR_TARGET=$(sqlite3 "$DB_PATH" "SELECT json_extract(value_json, '$') FROM plugin_config WHERE key='pr_target';" 2>/dev/null | sed -e 's/^"//' -e 's/"$//' || true)
+  _REPO_ROW=$(tmb_repo_resolve "$DB_PATH" "$REPO_ROOT")
+  PR_TARGET=$(printf '%s' "$_REPO_ROW" | cut -d'|' -f1)
+  if [ -z "$PR_TARGET" ]; then
+    PR_TARGET=$(sqlite3 "$DB_PATH" "SELECT json_extract(value_json, '$') FROM plugin_config WHERE key='pr_target';" 2>/dev/null | sed -e 's/^"//' -e 's/"$//' || true)
+  fi
   PR_TARGET="${PR_TARGET:-dev}"
   # Only checkout if (a) the target branch exists and (b) we're not already on it.
   CURRENT_HEAD=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)

--- a/scripts/hooks/swe-atomic-close.sh
+++ b/scripts/hooks/swe-atomic-close.sh
@@ -114,10 +114,6 @@ if [ -z "$DB" ] || ! command -v sqlite3 >/dev/null 2>&1; then
   exit 0
 fi
 
-# Read pr_target from config (default: main).
-PR_TARGET=$(tmb_config_get "pr_target" 2>/dev/null || true)
-PR_TARGET="${PR_TARGET:-main}"
-
 # Extract task_id from the subagent transcript (#369).
 # When two SWEs run in parallel, the most-recently-updated task heuristic
 # can auto-complete the WRONG task. The transcript contains the spawn prompt

--- a/tests/l3-integration/hooks/cleanup-worktree-on-task-close.test.sh
+++ b/tests/l3-integration/hooks/cleanup-worktree-on-task-close.test.sh
@@ -176,4 +176,68 @@ out=$(bro_atomic_close_input 'mcp__plugin_tmb_trajectory-server__bro_atomic_clos
 assert_eq "" "$out" "non-bro agent must be silent no-op for bro_atomic_close"
 [ -d "$REPO/.claude/worktrees/atomic2" ] || { echo "FAIL: worktree removed for non-bro agent"; exit 1; }
 
+# ---- #559: per-repo HEAD-reset target resolution -----------------------------
+# Set up plugin_config + repos table in the main DB for these cases.
+_REPO_REALPATH=$(git -C "$REPO" rev-parse --show-toplevel)
+sqlite3 "$DB" "
+  CREATE TABLE IF NOT EXISTS plugin_config (key TEXT PRIMARY KEY, value_json TEXT, updated_at TEXT);
+  INSERT OR REPLACE INTO plugin_config (key, value_json, updated_at) VALUES ('pr_target', '\"dev\"', datetime('now'));
+  CREATE TABLE IF NOT EXISTS repos (
+    name              TEXT PRIMARY KEY,
+    path              TEXT NOT NULL,
+    file_count        INTEGER NOT NULL DEFAULT 0,
+    last_scanned_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    target_branch     TEXT,
+    branching_model   TEXT,
+    protected_branches TEXT
+  );
+"
+
+test_case "#559: registered repo with target_branch='main' → HEAD reset to main (not global dev)"
+# dev branch must exist so global fallback is plausible; main already exists.
+git -C "$REPO" branch -f dev HEAD 2>/dev/null || true
+# Create a scratch branch to put HEAD on (can't checkout the worktree branch).
+git -C "$REPO" branch -f scratch-50 HEAD
+git -C "$REPO" checkout -q scratch-50
+sqlite3 "$DB" "INSERT OR REPLACE INTO repos (name, path, target_branch) VALUES ('fixture', '${_REPO_REALPATH}', 'main');"
+git -C "$REPO" branch fix/per-repo-main HEAD
+git -C "$REPO" worktree add -q .claude/worktrees/per-repo-main fix/per-repo-main
+sqlite3 "$DB" "INSERT INTO tasks (id, branch_id, status) VALUES (50, 'fix/per-repo-main', 'completed');"
+out=$(echo "$(input 'mcp__plugin_tmb_trajectory-server__task_update_status' 'bro' 'closed' 50)" \
+  | bash "$HOOK" 2>&1 || true)
+assert_contains "$out" 'cleaned up worktree' "worktree removed"
+AFTER_HEAD=$(git -C "$REPO" rev-parse --abbrev-ref HEAD)
+[ "$AFTER_HEAD" = "main" ] || { echo "FAIL: HEAD is '$AFTER_HEAD', expected 'main'"; exit 1; }
+echo "  HEAD reset to main (per-repo target_branch honored)"
+
+test_case "#559: registered repo with NULL target_branch → falls back to global pr_target='dev'"
+sqlite3 "$DB" "INSERT OR REPLACE INTO repos (name, path, target_branch) VALUES ('fixture', '${_REPO_REALPATH}', NULL);"
+git -C "$REPO" branch fix/per-repo-null HEAD
+git -C "$REPO" worktree add -q .claude/worktrees/per-repo-null fix/per-repo-null
+sqlite3 "$DB" "INSERT INTO tasks (id, branch_id, status) VALUES (51, 'fix/per-repo-null', 'completed');"
+# Put HEAD on a scratch branch (not the worktree branch, not dev yet).
+git -C "$REPO" branch -f scratch-51 HEAD
+git -C "$REPO" checkout -q scratch-51
+out=$(echo "$(input 'mcp__plugin_tmb_trajectory-server__task_update_status' 'bro' 'closed' 51)" \
+  | bash "$HOOK" 2>&1 || true)
+assert_contains "$out" 'cleaned up worktree' "worktree removed"
+AFTER_HEAD=$(git -C "$REPO" rev-parse --abbrev-ref HEAD)
+[ "$AFTER_HEAD" = "dev" ] || { echo "FAIL: HEAD is '$AFTER_HEAD', expected 'dev'"; exit 1; }
+echo "  HEAD reset to dev (global pr_target fallback honored)"
+
+test_case "#559: TMB_KEEP_HEAD_ON_CLOSE=1 still skips the reset"
+sqlite3 "$DB" "INSERT OR REPLACE INTO repos (name, path, target_branch) VALUES ('fixture', '${_REPO_REALPATH}', 'main');"
+git -C "$REPO" branch fix/per-repo-bypass HEAD
+git -C "$REPO" worktree add -q .claude/worktrees/per-repo-bypass fix/per-repo-bypass
+sqlite3 "$DB" "INSERT INTO tasks (id, branch_id, status) VALUES (52, 'fix/per-repo-bypass', 'completed');"
+# Start on a scratch branch so the hook would otherwise move us to main.
+git -C "$REPO" branch -f scratch-52 HEAD
+git -C "$REPO" checkout -q scratch-52
+out=$(echo "$(input 'mcp__plugin_tmb_trajectory-server__task_update_status' 'bro' 'closed' 52)" \
+  | env TMB_KEEP_HEAD_ON_CLOSE=1 bash "$HOOK" 2>&1 || true)
+assert_contains "$out" 'cleaned up worktree' "worktree removed"
+AFTER_HEAD=$(git -C "$REPO" rev-parse --abbrev-ref HEAD)
+[ "$AFTER_HEAD" = "scratch-52" ] || { echo "FAIL: HEAD is '$AFTER_HEAD', expected 'scratch-52'"; exit 1; }
+echo "  HEAD unchanged when TMB_KEEP_HEAD_ON_CLOSE=1"
+
 summarize


### PR DESCRIPTION
Fixes #559. #550 follow-up.

After #550 shipped per-repo `target_branch`, two close-path hooks still read the **global** branching config:

- **`cleanup-worktree-on-task-close.sh`** reset the main checkout HEAD to global `pr_target` (hardcoded `dev` fallback). Now resolves per-repo: `target_branch` → global `pr_target` → `dev`. HEAD-reset is workspace hygiene so it still runs for unregistered repos via the fallback (no #549-style no-op).
- **`swe-atomic-close.sh`** read `pr_target` into an unused variable — dead code, removed.

L3 coverage: registered repo with `target_branch=main` (global `pr_target=dev`) → HEAD resets to `main`; null target → global fallback; `TMB_KEEP_HEAD_ON_CLOSE=1` still skips. The three converted guards are untouched.

Verified: cleanup 13/13, swe-atomic-close 54/54; pr-reviewer PASS (row 68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)