### PR TITLE
🐛 fix(hooks): swe-atomic-close resolves worktree at workspace root — ends completion deadlock (#551)

### DIFF
--- a/scripts/hooks/lib/resolve-workspace.sh
+++ b/scripts/hooks/lib/resolve-workspace.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Library: workspace-root resolution for TMB hooks.
+# Sourced (not exec'd) by other hook scripts.
+# No set -e/-euo/-euo pipefail here — libs must not mutate caller shell options.
+
+# tmb_workspace_root <db_path>
+# Prints the workspace root: dirname of dirname of dirname of the DB path.
+# DB lives at <workspace_root>/.claude/<plugin>/trajectory.db, so three
+# dirname calls resolve back to the workspace root.
+#
+# Sentinel fallback: if the DB-derived workspace does not have the expected
+# .claude/worktrees/<slug> directory, the caller should fall back to the
+# active-workspace sentinel file at ${HOME}/.claude/${plugin}-active-workspace
+# (first line = workspace root). That fallback belongs to the caller because
+# it requires a slug to verify — this function only does the DB-path math.
+#
+# Single-repo installs: DB at <repo>/.claude/<plugin>/trajectory.db →
+# dirname×3 == repo root == workspace root. Unaffected.
+tmb_workspace_root() {
+  local db_path="${1:-}"
+  if [ -z "$db_path" ]; then
+    return 0
+  fi
+  dirname "$(dirname "$(dirname "$db_path")")" 2>/dev/null || true
+}

--- a/scripts/hooks/swe-atomic-close.sh
+++ b/scripts/hooks/swe-atomic-close.sh
@@ -28,6 +28,8 @@ PLUGIN_NAME=$(tmb_resolve_plugin_name)
 . "$SCRIPT_DIR/lib/query-task.sh" 2>/dev/null || true
 # shellcheck source=scripts/hooks/lib/normalize-role.sh
 . "$SCRIPT_DIR/lib/normalize-role.sh" 2>/dev/null || true
+# shellcheck source=scripts/hooks/lib/resolve-workspace.sh
+. "$SCRIPT_DIR/lib/resolve-workspace.sh" 2>/dev/null || true
 
 mkdir -p "${HOME}/.claude/${PLUGIN_NAME}/logs" 2>/dev/null || true
 
@@ -215,7 +217,30 @@ fi
 
 # Derive the worktree path: slug = everything after the last '/' in branch_id.
 SLUG="${BRANCH##*/}"
-WT_PATH="${REPO_ROOT}/.claude/worktrees/${SLUG}"
+# Resolve workspace root via shared lib (dirname×3 of DB).
+# In a workspace-above-repo layout (repo at <ws>/plugin, worktrees at
+# <ws>/.claude/worktrees) REPO_ROOT points into the inner repo while
+# worktrees live at the workspace root one level up.
+WS_ROOT=""
+if command -v tmb_workspace_root >/dev/null 2>&1 && [ -n "$DB" ]; then
+  WS_ROOT=$(tmb_workspace_root "$DB" || true)
+fi
+# Sentinel fallback: subagents that inherit cwd=~ and lack env vars.
+if [ -n "$WS_ROOT" ] && [ ! -d "${WS_ROOT}/.claude/worktrees/${SLUG}" ]; then
+  _SENTINEL="${HOME}/.claude/${PLUGIN_NAME}-active-workspace"
+  if [ -f "$_SENTINEL" ]; then
+    _WS_SENTINEL=$(head -1 "$_SENTINEL" 2>/dev/null || true)
+    if [ -n "$_WS_SENTINEL" ] && [ -d "${_WS_SENTINEL}/.claude/worktrees/${SLUG}" ]; then
+      WS_ROOT="$_WS_SENTINEL"
+    fi
+  fi
+fi
+# Fall back to REPO_ROOT if WS_ROOT is empty (preserves previous behavior).
+if [ -n "$WS_ROOT" ]; then
+  WT_PATH="${WS_ROOT}/.claude/worktrees/${SLUG}"
+else
+  WT_PATH="${REPO_ROOT}/.claude/worktrees/${SLUG}"
+fi
 
 # Read the SWE's worktree HEAD.
 WT_HEAD=$(git -C "$WT_PATH" rev-parse HEAD 2>/dev/null || true)

--- a/scripts/hooks/swe-verification-gate.sh
+++ b/scripts/hooks/swe-verification-gate.sh
@@ -27,6 +27,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$SCRIPT_DIR/lib/normalize-role.sh"
 # shellcheck source=scripts/lib/resolve-plugin-name.sh
 . "$SCRIPT_DIR/../lib/resolve-plugin-name.sh"
+# shellcheck source=scripts/hooks/lib/resolve-workspace.sh
+. "$SCRIPT_DIR/lib/resolve-workspace.sh"
 
 INPUT=$(cat)
 
@@ -115,15 +117,11 @@ fi
 # Extract the SLUG from branch_id (last path component) to locate worktree.
 SLUG="${BRANCH_ID##*/}"
 
-# Resolve workspace root the same way post-task-create-spawn-hint.sh does:
-# DB lives at <workspace_root>/.claude/<plugin>/trajectory.db, so dirname 3×.
+# Resolve workspace root via shared lib (dirname×3 of DB).
 # This handles workspace-above-repo layouts (repo at <ws>/plugin,
 # worktrees at <ws>/.claude/worktrees/<slug>) where a PWD walk-up from
 # inside the repo would land on the repo root instead of the workspace root.
-WS_ROOT=""
-if [ -n "$DB" ]; then
-  WS_ROOT="$(dirname "$(dirname "$(dirname "$DB")")")"
-fi
+WS_ROOT=$(tmb_workspace_root "$DB" || true)
 
 WT_PATH=""
 if [ -n "$WS_ROOT" ] && [ -d "${WS_ROOT}/.claude/worktrees/${SLUG}" ]; then

--- a/tests/l3-integration/hooks/swe-atomic-close.test.sh
+++ b/tests/l3-integration/hooks/swe-atomic-close.test.sh
@@ -827,4 +827,93 @@ test_case "slug fallback: transcript present → task 601 NOT touched (slug not 
 txfirst_status_601=$(sqlite3 "$TXFIRST_DB" "SELECT status FROM tasks WHERE id=601;")
 assert_eq "pending" "$txfirst_status_601" "task 601 untouched when transcript resolves task 600"
 
+# ========================================================
+# Workspace-above-repo layout: DB two levels above the repo.
+# Reproduces the completion deadlock: WT at <ws>/.claude/worktrees/<slug>,
+# repo at <ws>/inner-repo (REPO_ROOT != WS_ROOT).
+# ========================================================
+
+echo '--- Test: workspace-above-repo: worktree at WS_ROOT, not REPO_ROOT → auto-completed ---'
+
+WS_ROOT_DIR="$TMPDIR/ws-above"
+INNER_REPO="$WS_ROOT_DIR/inner-repo"
+WS_DB="$WS_ROOT_DIR/.claude/tmb/trajectory.db"
+WS_WT="$WS_ROOT_DIR/.claude/worktrees/ws-task"
+
+mkdir -p "$INNER_REPO"
+mkdir -p "$(dirname "$WS_DB")"
+
+git init -q -b dev "$INNER_REPO"
+git -C "$INNER_REPO" config user.email t@t.io
+git -C "$INNER_REPO" config user.name t
+echo base > "$INNER_REPO/base.txt"
+git -C "$INNER_REPO" add .
+git -C "$INNER_REPO" commit -qm "base"
+
+sqlite3 "$WS_DB" "
+  CREATE TABLE tasks (
+    id INTEGER PRIMARY KEY,
+    issue_id INTEGER NOT NULL DEFAULT 1,
+    branch_id TEXT NOT NULL,
+    parent_branch_id TEXT,
+    title TEXT NOT NULL DEFAULT '',
+    description TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'pending',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    spec_body TEXT NOT NULL DEFAULT '',
+    commit_sha TEXT,
+    repo TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    completed_at TEXT
+  );
+  CREATE TABLE repos (
+    name TEXT PRIMARY KEY,
+    path TEXT NOT NULL,
+    file_count INTEGER NOT NULL DEFAULT 0,
+    last_scanned_at TEXT NOT NULL DEFAULT ''
+  );
+  CREATE TABLE agent_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id INTEGER NOT NULL,
+    issue_id INTEGER,
+    agent_type TEXT NOT NULL DEFAULT 'swe',
+    tokens_in INTEGER NOT NULL DEFAULT 0,
+    tokens_out INTEGER NOT NULL DEFAULT 0,
+    tokens_total INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+    tool_uses INTEGER NOT NULL DEFAULT 0,
+    duration_ms INTEGER NOT NULL DEFAULT 0,
+    completed_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE plugin_config (
+    key TEXT PRIMARY KEY,
+    value_json TEXT NOT NULL DEFAULT '\"\"'
+  );
+  INSERT INTO tasks (id, branch_id, parent_branch_id, status, updated_at)
+    VALUES (700, 'fix/ws-task', 'dev', 'pending', datetime('now', '+1 second'));
+  INSERT INTO plugin_config (key, value_json) VALUES ('pr_target', '\"dev\"');
+"
+
+# Worktree lives at the WS root, not inside the inner repo.
+git -C "$INNER_REPO" branch fix/ws-task HEAD
+git -C "$INNER_REPO" worktree add -q "$WS_WT" fix/ws-task
+
+# SWE commits in the workspace-level worktree.
+(cd "$WS_WT" && echo "$RANDOM" >> ws-work.txt && git add ws-work.txt && git commit -qm "feat: ws work")
+WS_WT_HEAD=$(git -C "$WS_WT" rev-parse HEAD)
+
+ws_swe_input() {
+  jq -n '{agent_type: "tmb:swe", hook_event_name: "SubagentStop"}'
+}
+
+test_case "workspace-above-repo: worktree at WS_ROOT → pending task auto-completed (deadlock fix)"
+out=$(run_hook_in_dir "$INNER_REPO" "$(ws_swe_input)" "$WS_DB")
+assert_eq "" "$out" "no additionalContext on auto-close"
+ws_status=$(sqlite3 "$WS_DB" "SELECT status FROM tasks WHERE id=700;")
+assert_eq "completed" "$ws_status" "task 700 auto-closed via workspace-root worktree path"
+ws_sha=$(sqlite3 "$WS_DB" "SELECT commit_sha FROM tasks WHERE id=700;")
+assert_eq "$WS_WT_HEAD" "$ws_sha" "commit_sha written from WS_ROOT worktree HEAD"
+
 summarize


### PR DESCRIPTION
Fixes #551.

The SubagentStop hook `swe-atomic-close.sh` built the worktree path from `REPO_ROOT` (`<repo>/.claude/worktrees`), but in the workspace-above-repo layout worktrees live at the **workspace** root (`<ws>/.claude/worktrees`). Wrong path → empty `WT_HEAD` → the hook concluded SWE hadn't committed → never flipped the task → stuck `pending` → completion deadlock (the recurring friction throughout the v0.8.2 auto-solve).

**Fix:** extract a shared `scripts/hooks/lib/resolve-workspace.sh` (`tmb_workspace_root` = dirname×3 of the DB path, the same logic the verification gate already used inline), and use it in both `swe-atomic-close.sh` and `swe-verification-gate.sh`. `REPO_ROOT` is kept for git ref lookups; empty-`WS_ROOT` falls back to the prior path. Single-repo layout is unaffected (dirname×3 == repo root there).

L3: new workspace-above-repo case reproduces the deadlock and asserts pending→completed.

Verified: swe-atomic-close 57/57, swe-verification-gate 29/29; pr-reviewer PASS (row 70). worktree-create.sh left to #547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)