### PR TITLE
🐛 fix(hooks): deny gh/glab auth login + announce local-only when no remote configured (#548)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -112,6 +112,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/commit-msg-lint.sh",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/no-remote-auth-guard.sh",
+            "timeout": 5
           }
         ]
       },

--- a/scripts/hooks/no-remote-auth-guard.sh
+++ b/scripts/hooks/no-remote-auth-guard.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# PreToolUse hook — deny interactive auth login when no remote is configured.
+#
+# Blocks `gh auth login` and `glab auth login` (only the `login` subcommand)
+# when plugin_config.remotes contains no entry with a non-empty URL.
+# Fail-open on any error: missing DB, jq absent, sqlite3 absent → allow.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/hooks/lib/query-task.sh
+. "$SCRIPT_DIR/lib/query-task.sh"
+
+INPUT=$(cat)
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+
+[ -n "$CMD" ] || exit 0
+
+# Detect (gh|glab) auth login — the interactive subcommand that hangs without
+# TTY/network. Matches: gh auth login, glab auth login, with optional flags
+# between words. Does NOT match: auth status, auth token, auth logout, etc.
+MATCHED_TOOL=""
+if printf '%s' "$CMD" | grep -qE '(^|[[:space:];|&(])gh[[:space:]]+auth[[:space:]]+login([[:space:]]|$|;|&&|\|\|)'; then
+  MATCHED_TOOL="gh"
+elif printf '%s' "$CMD" | grep -qE '(^|[[:space:];|&(])glab[[:space:]]+auth[[:space:]]+login([[:space:]]|$|;|&&|\|\|)'; then
+  MATCHED_TOOL="glab"
+fi
+
+[ -n "$MATCHED_TOOL" ] || exit 0
+
+# Resolve DB — fail-open on any resolution failure.
+DB=$(tmb_db_path 2>/dev/null || true)
+[ -n "$DB" ] || exit 0
+tmb_have_sqlite || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+# Read remotes JSON from plugin_config.
+REMOTES_JSON=$(tmb_config_raw "remotes" "$DB" 2>/dev/null || true)
+
+# No remotes key at all → config says nothing → fail-open (allow).
+[ -n "$REMOTES_JSON" ] || exit 0
+
+# Check whether any entry has a non-empty url.
+HAS_REMOTE=$(printf '%s' "$REMOTES_JSON" | \
+  jq -r '[.[]|select(.url!=null and .url!="")]|length>0' 2>/dev/null || true)
+
+# jq errors → fail-open.
+[ -n "$HAS_REMOTE" ] || exit 0
+
+# A usable remote exists → allow.
+[ "$HAS_REMOTE" = "false" ] || exit 0
+
+REASON="BLOCKED: No remote is configured (remotes have no URL) — TMB is operating locally. Interactive '${MATCHED_TOOL} auth login' will hang here (no TTY/network); remote/push ops are skipped. Work locally."
+
+jq -nc --arg reason "$REASON" \
+  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":$reason}}'

--- a/scripts/hooks/substrate-preflight.sh
+++ b/scripts/hooks/substrate-preflight.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 # SessionStart hook — probes required host binaries and emits a loud
 # TMB-DEGRADED banner into additionalContext when any are missing.
+# Also emits a calm offline note when no remote has a usable URL.
 #
-# Healthy path (all 4 present): exits 0, emits nothing.
+# Healthy path (all 4 present, remote configured): exits 0, emits nothing.
 # Degraded path (any missing):  emits hookSpecificOutput.additionalContext
 #   beginning "TMB DEGRADED:" naming each missing binary and consequence.
+# No-remote path: emits a calm offline note (even when binaries are healthy).
+# Both degraded AND offline: includes both notes in one additionalContext.
 #
 # Self-contained: JSON is built with printf, NOT jq — jq may itself be missing.
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 MISSING_PARTS=""
 
@@ -28,9 +33,37 @@ _check sqlite3 "task/spawn gates cannot verify state"
 _check git     "branch guards and commit-message lint are inoperative"
 _check node    "MCP trajectory-server and scan tooling cannot start"
 
-[ -z "$MISSING_PARTS" ] && exit 0
+# Detect local-only mode: no remote with a non-empty url in plugin_config.
+OFFLINE_NOTE=""
+if command -v sqlite3 >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  # shellcheck source=scripts/hooks/lib/query-task.sh
+  . "$SCRIPT_DIR/lib/query-task.sh"
+  _DB=$(tmb_db_path 2>/dev/null || true)
+  if [ -n "$_DB" ]; then
+    _REMOTES_JSON=$(tmb_config_raw "remotes" "$_DB" 2>/dev/null || true)
+    if [ -n "$_REMOTES_JSON" ]; then
+      _HAS_REMOTE=$(printf '%s' "$_REMOTES_JSON" | \
+        jq -r '[.[]|select(.url!=null and .url!="")]|length>0' 2>/dev/null || true)
+      if [ "$_HAS_REMOTE" = "false" ]; then
+        OFFLINE_NOTE="TMB: operating locally — no remote configured; remote/push ops are skipped."
+      fi
+    fi
+  fi
+fi
 
-CONTEXT="TMB DEGRADED: ${MISSING_PARTS}. Install the missing tools to restore enforcement."
+[ -z "$MISSING_PARTS" ] && [ -z "$OFFLINE_NOTE" ] && exit 0
+
+CONTEXT=""
+if [ -n "$MISSING_PARTS" ]; then
+  CONTEXT="TMB DEGRADED: ${MISSING_PARTS}. Install the missing tools to restore enforcement."
+fi
+if [ -n "$OFFLINE_NOTE" ]; then
+  if [ -n "$CONTEXT" ]; then
+    CONTEXT="${CONTEXT} ${OFFLINE_NOTE}"
+  else
+    CONTEXT="$OFFLINE_NOTE"
+  fi
+fi
 
 # Escape for JSON string using bash substitutions only — no sed/awk required
 # (those tools may also be absent from PATH). Backslashes first, then quotes.

--- a/tests/l3-integration/hooks/no-remote-auth-guard.test.sh
+++ b/tests/l3-integration/hooks/no-remote-auth-guard.test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Tests for scripts/hooks/no-remote-auth-guard.sh.
+# Hook contract: PreToolUse/Bash hook denies `gh auth login` and
+# `glab auth login` when no remote has a non-empty URL; allows otherwise.
+# Fail-open when DB is absent or config unavailable.
+#
+# Cases:
+#   (a) gh auth login, no remote url → deny
+#   (b) glab auth login, no remote url → deny
+#   (c) gh auth login WITH a remote url → allow
+#   (d) gh auth status (not login) → allow
+#   (e) glab auth status → allow
+#   (f) ls → allow (no output)
+#   (g) gh pr list → allow
+#   (h) missing DB → allow (fail-open)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../lib/assert.sh"
+PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
+HOOK="$PLUGIN_ROOT/scripts/hooks/no-remote-auth-guard.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+DB="$TMPDIR/trajectory.db"
+
+# Fixture: remotes=[{name,provider,url:""}] — no usable url
+sqlite3 "$DB" "
+  CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT NOT NULL DEFAULT '');
+  INSERT INTO plugin_config (key, value_json) VALUES
+    ('remotes', '[{\"name\":\"origin\",\"provider\":\"github\",\"url\":\"\"}]');
+"
+
+# Fixture DB with a usable url
+DB_WITH_REMOTE="$TMPDIR/trajectory-with-remote.db"
+sqlite3 "$DB_WITH_REMOTE" "
+  CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT NOT NULL DEFAULT '');
+  INSERT INTO plugin_config (key, value_json) VALUES
+    ('remotes', '[{\"name\":\"origin\",\"provider\":\"github\",\"url\":\"https://github.com/org/repo.git\"}]');
+"
+
+input_bash() {
+  local cmd="$1"
+  jq -n --arg cmd "$cmd" '{
+    tool_name: "Bash",
+    tool_input: { command: $cmd }
+  }'
+}
+
+run_hook() {
+  local input="$1"
+  local db="${2:-$DB}"
+  echo "$input" | TRAJECTORY_DB_PATH="$db" bash "$HOOK" 2>/dev/null || true
+}
+
+# ============================================================================
+# Case (a) — gh auth login, no remote url → deny
+# ============================================================================
+test_case "(a) gh auth login with no remote url: deny"
+out=$(run_hook "$(input_bash 'gh auth login')")
+assert_contains "$out" '"permissionDecision":"deny"' "deny decision"
+
+test_case "(a) gh auth login: deny reason mentions BLOCKED"
+assert_contains "$out" "BLOCKED" "BLOCKED in reason"
+
+test_case "(a) gh auth login: deny reason names tool 'gh'"
+assert_contains "$out" "gh auth login" "tool name in reason"
+
+test_case "(a) gh auth login: output is valid JSON"
+if printf '%s' "$out" | jq . >/dev/null 2>&1; then
+  _pass
+else
+  _fail "output failed jq parse — got: $out"
+fi
+
+# ============================================================================
+# Case (b) — glab auth login, no remote url → deny
+# ============================================================================
+test_case "(b) glab auth login with no remote url: deny"
+out_b=$(run_hook "$(input_bash 'glab auth login')")
+assert_contains "$out_b" '"permissionDecision":"deny"' "deny decision"
+
+test_case "(b) glab auth login: deny reason mentions BLOCKED"
+assert_contains "$out_b" "BLOCKED" "BLOCKED in reason"
+
+test_case "(b) glab auth login: deny reason names tool 'glab'"
+assert_contains "$out_b" "glab auth login" "tool name in reason"
+
+# ============================================================================
+# Case (c) — gh auth login WITH a remote url → allow (silent)
+# ============================================================================
+test_case "(c) gh auth login with remote url present: allow (silent)"
+out_c=$(run_hook "$(input_bash 'gh auth login')" "$DB_WITH_REMOTE")
+assert_eq "" "$out_c" "no output when remote configured"
+
+# ============================================================================
+# Case (d) — gh auth status (not login) → allow
+# ============================================================================
+test_case "(d) gh auth status: allow (silent)"
+out_d=$(run_hook "$(input_bash 'gh auth status')")
+assert_eq "" "$out_d" "auth status not blocked"
+
+# ============================================================================
+# Case (e) — glab auth status → allow
+# ============================================================================
+test_case "(e) glab auth status: allow (silent)"
+out_e=$(run_hook "$(input_bash 'glab auth status')")
+assert_eq "" "$out_e" "glab auth status not blocked"
+
+# ============================================================================
+# Case (f) — ls → allow (no output at all)
+# ============================================================================
+test_case "(f) ls: allow with no output"
+out_f=$(run_hook "$(input_bash 'ls')")
+assert_eq "" "$out_f" "unrelated command silent"
+
+# ============================================================================
+# Case (g) — gh pr list → allow
+# ============================================================================
+test_case "(g) gh pr list: allow (silent)"
+out_g=$(run_hook "$(input_bash 'gh pr list')")
+assert_eq "" "$out_g" "non-auth gh command silent"
+
+# ============================================================================
+# Case (h) — missing DB → allow (fail-open)
+# ============================================================================
+test_case "(h) missing DB: fail-open (allow)"
+out_h=$(echo "$(input_bash 'gh auth login')" | TRAJECTORY_DB_PATH="$TMPDIR/no-such.db" bash "$HOOK" 2>/dev/null || true)
+assert_eq "" "$out_h" "missing DB → allow"
+
+# ============================================================================
+# Extra: gh auth token → allow (only login is blocked)
+# ============================================================================
+test_case "gh auth token: allow (not login)"
+out_tok=$(run_hook "$(input_bash 'gh auth token')")
+assert_eq "" "$out_tok" "auth token not blocked"
+
+# ============================================================================
+# Extra: glab auth login with remote url → allow
+# ============================================================================
+test_case "glab auth login with remote url present: allow (silent)"
+out_gl_r=$(run_hook "$(input_bash 'glab auth login')" "$DB_WITH_REMOTE")
+assert_eq "" "$out_gl_r" "glab allow when remote configured"
+
+# ============================================================================
+# Extra: remotes key absent (no row) → fail-open
+# ============================================================================
+test_case "remotes key absent: fail-open (allow)"
+DB_NO_REMOTES="$TMPDIR/trajectory-no-remotes.db"
+sqlite3 "$DB_NO_REMOTES" "
+  CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT NOT NULL DEFAULT '');
+"
+out_nr=$(echo "$(input_bash 'gh auth login')" | TRAJECTORY_DB_PATH="$DB_NO_REMOTES" bash "$HOOK" 2>/dev/null || true)
+assert_eq "" "$out_nr" "absent remotes key → allow"
+
+summarize

--- a/tests/l3-integration/hooks/substrate-preflight.test.sh
+++ b/tests/l3-integration/hooks/substrate-preflight.test.sh
@@ -10,6 +10,8 @@
 #   5. Output is valid JSON when degraded
 #   6. Schema: hookSpecificOutput.hookEventName = "SessionStart"
 #   7. Self-contained: banner produced even when jq is the missing binary
+#   8. No-remote path: offline note emitted when remotes have no url
+#   9. No-remote path: offline note absent when a remote url exists
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -35,19 +37,49 @@ _make_stub_dir_with() {
 
 run_hook_with_path() {
   local path="$1"
-  echo '{}' | PATH="$path" /bin/bash "$HOOK" 2>/dev/null || true
+  local db="${2:-}"
+  if [ -n "$db" ]; then
+    echo '{}' | TRAJECTORY_DB_PATH="$db" PATH="$path" /bin/bash "$HOOK" 2>/dev/null || true
+  else
+    echo '{}' | PATH="$path" /bin/bash "$HOOK" 2>/dev/null || true
+  fi
 }
+
+run_hook() {
+  local db="${1:-}"
+  if [ -n "$db" ]; then
+    echo '{}' | TRAJECTORY_DB_PATH="$db" /bin/bash "$HOOK" 2>/dev/null || true
+  else
+    echo '{}' | /bin/bash "$HOOK" 2>/dev/null || true
+  fi
+}
+
+# Fixture DBs for no-remote tests
+_DB_DIR=$(mktemp -d -p "$STUB_DIR")
+DB_NO_REMOTE="$_DB_DIR/no-remote.db"
+sqlite3 "$DB_NO_REMOTE" "
+  CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT NOT NULL DEFAULT '');
+  INSERT INTO plugin_config (key, value_json) VALUES
+    ('remotes', '[{\"name\":\"origin\",\"provider\":\"github\",\"url\":\"\"}]');
+"
+
+DB_WITH_REMOTE="$_DB_DIR/with-remote.db"
+sqlite3 "$DB_WITH_REMOTE" "
+  CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT NOT NULL DEFAULT '');
+  INSERT INTO plugin_config (key, value_json) VALUES
+    ('remotes', '[{\"name\":\"origin\",\"provider\":\"github\",\"url\":\"https://github.com/org/repo.git\"}]');
+"
 
 # ============================================================================
 # Case 1 — Healthy host: all 4 present, silent exit 0
 # ============================================================================
 test_case "healthy host: exits 0 with no output"
-out=$(echo '{}' | /bin/bash "$HOOK" 2>/dev/null || true)
-assert_eq "" "$out" "no output when all binaries present"
+out=$(run_hook "$DB_WITH_REMOTE")
+assert_eq "" "$out" "no output when all binaries present and remote configured"
 
 test_case "healthy host: exit code is 0"
 exit_code=0
-echo '{}' | /bin/bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+echo '{}' | TRAJECTORY_DB_PATH="$DB_WITH_REMOTE" /bin/bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
 assert_eq "0" "$exit_code" "exit code"
 
 # ============================================================================
@@ -55,7 +87,7 @@ assert_eq "0" "$exit_code" "exit code"
 # ============================================================================
 test_case "jq missing: emits TMB DEGRADED"
 stub2=$(_make_stub_dir_with sqlite3 git node)
-out2=$(run_hook_with_path "$stub2")
+out2=$(run_hook_with_path "$stub2" "")
 assert_contains "$out2" "TMB DEGRADED" "DEGRADED banner present"
 
 test_case "jq missing: banner names jq"
@@ -66,7 +98,7 @@ assert_contains "$out2" "jq" "jq named in banner"
 # ============================================================================
 test_case "sqlite3 missing: emits TMB DEGRADED"
 stub3=$(_make_stub_dir_with jq git node)
-out3=$(run_hook_with_path "$stub3")
+out3=$(run_hook_with_path "$stub3" "")
 assert_contains "$out3" "TMB DEGRADED" "DEGRADED banner present"
 
 test_case "sqlite3 missing: banner names sqlite3"
@@ -77,7 +109,7 @@ assert_contains "$out3" "sqlite3" "sqlite3 named in banner"
 # ============================================================================
 test_case "multiple missing: both jq and git named"
 stub4=$(_make_stub_dir_with sqlite3 node)
-out4=$(run_hook_with_path "$stub4")
+out4=$(run_hook_with_path "$stub4" "")
 assert_contains "$out4" "jq" "jq named when multiple missing"
 assert_contains "$out4" "git" "git named when multiple missing"
 
@@ -115,5 +147,43 @@ if [ -n "$out2" ]; then
 else
   _fail "output was empty — hook depends on jq for its own output"
 fi
+
+# ============================================================================
+# Case 8 — no-remote path: offline note emitted when remotes have no url
+# ============================================================================
+test_case "no-remote: offline note emitted when remotes have no url"
+out8=$(run_hook "$DB_NO_REMOTE")
+assert_contains "$out8" "operating locally" "offline note in output"
+
+test_case "no-remote: offline note names remote/push ops skipped"
+assert_contains "$out8" "remote/push ops are skipped" "ops-skipped text present"
+
+test_case "no-remote: output is valid JSON"
+if printf '%s' "$out8" | jq . >/dev/null 2>&1; then
+  _pass
+else
+  _fail "no-remote output failed jq parse — got: $out8"
+fi
+
+test_case "no-remote: hookEventName is SessionStart"
+ev8=$(printf '%s' "$out8" | jq -r '.hookSpecificOutput.hookEventName' 2>/dev/null || echo "MISSING")
+assert_eq "SessionStart" "$ev8" "hookEventName"
+
+# ============================================================================
+# Case 9 — no-remote path: offline note absent when a remote url exists
+# ============================================================================
+test_case "with-remote: offline note absent when a url is configured"
+out9=$(run_hook "$DB_WITH_REMOTE")
+assert_eq "" "$out9" "no output when remote configured"
+
+# ============================================================================
+# Extra: both degraded AND no-remote → includes both notes
+# Use PATH=/usr/bin:/bin where node is absent but jq/sqlite3/git are present.
+# This gives us a degraded state while keeping system binaries for the hook.
+# ============================================================================
+test_case "degraded + no-remote: both DEGRADED and offline note in output"
+out_dr=$(echo '{}' | TRAJECTORY_DB_PATH="$DB_NO_REMOTE" PATH="/usr/bin:/bin" /bin/bash "$HOOK" 2>/dev/null || true)
+assert_contains "$out_dr" "TMB DEGRADED" "DEGRADED still present"
+assert_contains "$out_dr" "operating locally" "offline note also present"
 
 summarize


### PR DESCRIPTION
Fixes #548.

In the L7 bench, an interactive `gh auth login` hung a tool call in a no-remote / net-isolated container — the deterministic answer ("no remote → work locally") is already in `plugin_config.remotes`.

**Fix (mechanism, not prompt-nag):**
- New PreToolUse hook `no-remote-auth-guard.sh` denies `gh auth login` **and** `glab auth login` (TMB supports both GitHub and GitLab) when no configured remote has a URL. Matcher is anchored to a command boundary and gates only the `login` subcommand (not `auth status`/`token`/`logout`). Fail-open on missing DB/jq/sqlite3.
- `substrate-preflight.sh` surfaces a calm "operating locally — no remote configured" note at session start when no remote has a URL.

**Deliberately not blocked:** WebFetch (no git remote ≠ no internet) and native git (no `auth login`; remote ops fail-fast + offline-skipped by #546).

Verified: no-remote-auth-guard 16/16, substrate-preflight 20/20; pr-reviewer PASS (row 71). Follow-up (#564): add `)` to the trailing boundary class for subshell forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
