### PR TITLE
🐛 fix(hooks): git-guards enforces glab mr create + anchored Rule 1 matcher (GitLab parity) (#564)

### DIFF
--- a/scripts/hooks/git-guards.sh
+++ b/scripts/hooks/git-guards.sh
@@ -18,10 +18,10 @@ CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty')
 # Early-exit: skip all DB work when the command contains no git/gh word.
 # This avoids ~3 sqlite3 opens on every ls/cat/echo call.
 _cmd_needs_git_guard() {
-  # Match 'git' or 'gh' as standalone words anywhere in the command.
+  # Match 'git', 'gh', or 'glab' as standalone words anywhere in the command.
   # Any non-word char may precede (handles `foo;git ...`, `echo y&&git ...`);
-  # word chars before (legit) or after (github) do not match.
-  printf '%s' "$1" | grep -qE '(^|[^[:alnum:]_./-])(git|gh)([[:space:]]|$)'
+  # word chars before (legit) or after (github/glabber) do not match.
+  printf '%s' "$1" | grep -qE '(^|[^[:alnum:]_./-])(git|gh|glab)([[:space:]]|$)'
 }
 _cmd_needs_git_guard "$CMD" || exit 0
 
@@ -192,18 +192,34 @@ branch_is_protected() {
 #
 # Exception: when PR_TARGET == "dev" (dual-tier model), `dev → main` is the
 # release-merge path and is allowed. The head MUST be `dev` (either
-# explicit `--head dev` or the current branch is `dev` and `--head` is
-# omitted). Any other head targeting main is blocked — feature branches do
-# not PR directly to main.
-case "$CMD" in
-  *"gh pr create"*)
+# explicit `--head dev` / --source-branch dev or the current branch is `dev`
+# and the flag is omitted). Any other head targeting main is blocked — feature
+# branches do not PR directly to main.
+#
+# Uses an anchored _rule1_match (mirroring _rule2_match's boundary class) so
+# the trigger phrase inside quoted argument text does NOT fire.
+_rule1_match() {
+  local cmd="$1"
+  # Return which forge tool's PR/MR-create command is present at a statement
+  # boundary (start of string, or after ; && || | with optional spaces).
+  # Exits 0 with "gh" or "glab" printed; exits 1 when neither matches.
+  if printf '%s' "$cmd" | grep -qE '(^|[[:space:]]*([;&]|[|][|]|[&][&])[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'; then
+    echo "gh"; return 0
+  fi
+  if printf '%s' "$cmd" | grep -qE '(^|[[:space:]]*([;&]|[|][|]|[&][&])[[:space:]]*)glab[[:space:]]+mr[[:space:]]+create([[:space:]]|$)'; then
+    echo "glab"; return 0
+  fi
+  return 1
+}
+
+_RULE1_FORGE=$(_rule1_match "$CMD" || true)
+if [ -n "$_RULE1_FORGE" ]; then
+  if [ "$_RULE1_FORGE" = "gh" ]; then
+    # --- gh pr create ---
     if echo "$CMD" | grep -qF -- "--base ${PR_TARGET}"; then
       :  # OK — feature → pr_target (the standard path)
     elif [ "$PR_TARGET" = "dev" ] && echo "$CMD" | grep -qF -- "--base main"; then
       # Dual-tier exception: dev → main release merge.
-      # `set -o pipefail` makes the assignment fail when grep finds no
-      # `--head` (which is the common case — gh defaults head to the
-      # current branch). The `|| true` keeps the pipeline succeeding.
       HEAD_BRANCH=$(echo "$CMD" | grep -oE -- '--head[= ][^[:space:]]+' | head -1 | sed -E 's/--head[= ]+//' | tr -d "'\"" || true)
       if [ -z "$HEAD_BRANCH" ]; then
         HEAD_BRANCH=$(git branch --show-current 2>/dev/null || true)
@@ -218,8 +234,38 @@ case "$CMD" in
         '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
       exit 0
     fi
-    ;;
-esac
+  else
+    # --- glab mr create ---
+    # Target flag: --target-branch <b> or -b <b> (or --target-branch=<b>)
+    TARGET_BRANCH=$(echo "$CMD" | grep -oE -- '--target-branch[= ][^[:space:]]+' | head -1 | sed -E 's/--target-branch[= ]+//' | tr -d "'\"" || true)
+    if [ -z "$TARGET_BRANCH" ]; then
+      TARGET_BRANCH=$(echo "$CMD" | grep -oE -- '-b[= ][^[:space:]]+' | head -1 | sed -E 's/-b[= ]+//' | tr -d "'\"" || true)
+    fi
+    # Head/source flag: --source-branch <b> or -s <b>
+    SOURCE_BRANCH=$(echo "$CMD" | grep -oE -- '--source-branch[= ][^[:space:]]+' | head -1 | sed -E 's/--source-branch[= ]+//' | tr -d "'\"" || true)
+    if [ -z "$SOURCE_BRANCH" ]; then
+      SOURCE_BRANCH=$(echo "$CMD" | grep -oE -- '-s[= ][^[:space:]]+' | head -1 | sed -E 's/-s[= ]+//' | tr -d "'\"" || true)
+    fi
+    if [ -z "$SOURCE_BRANCH" ]; then
+      SOURCE_BRANCH=$(git branch --show-current 2>/dev/null || true)
+    fi
+
+    if [ "$TARGET_BRANCH" = "$PR_TARGET" ]; then
+      :  # OK — feature → pr_target (the standard path)
+    elif [ "$PR_TARGET" = "dev" ] && [ "$TARGET_BRANCH" = "main" ]; then
+      # Dual-tier exception: dev → main release merge.
+      if [ "$SOURCE_BRANCH" != "dev" ]; then
+        jq -nc --arg r "BLOCKED: only 'dev → main' is permitted as a release merge. Feature branches must MR to ${PR_TARGET}: glab mr create --target-branch ${PR_TARGET} --source-branch <branch>. Got --source-branch=${SOURCE_BRANCH}." \
+          '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+        exit 0
+      fi
+    else
+      jq -nc --arg r "BLOCKED: MRs must target ${PR_TARGET} branch. Use: glab mr create --target-branch ${PR_TARGET} --source-branch <branch>. (Dev → main release merges are allowed when PR_TARGET=dev.)" \
+        '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+      exit 0
+    fi
+  fi
+fi
 
 # --- Rule 2: No direct commits/merges/rebases to protected_branches (worktree-aware) ---
 # Uses cmd_effective_branch so detached-HEAD worktrees resolve via DB lookup.

--- a/scripts/hooks/no-remote-auth-guard.sh
+++ b/scripts/hooks/no-remote-auth-guard.sh
@@ -18,9 +18,9 @@ CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null ||
 # TTY/network. Matches: gh auth login, glab auth login, with optional flags
 # between words. Does NOT match: auth status, auth token, auth logout, etc.
 MATCHED_TOOL=""
-if printf '%s' "$CMD" | grep -qE '(^|[[:space:];|&(])gh[[:space:]]+auth[[:space:]]+login([[:space:]]|$|;|&&|\|\|)'; then
+if printf '%s' "$CMD" | grep -qE '(^|[[:space:];|&(])gh[[:space:]]+auth[[:space:]]+login([[:space:]]|$|;|&&|\|\||\))'; then
   MATCHED_TOOL="gh"
-elif printf '%s' "$CMD" | grep -qE '(^|[[:space:];|&(])glab[[:space:]]+auth[[:space:]]+login([[:space:]]|$|;|&&|\|\|)'; then
+elif printf '%s' "$CMD" | grep -qE '(^|[[:space:];|&(])glab[[:space:]]+auth[[:space:]]+login([[:space:]]|$|;|&&|\|\||\))'; then
   MATCHED_TOOL="glab"
 fi
 

--- a/tests/l3-integration/hooks/git-guards.test.sh
+++ b/tests/l3-integration/hooks/git-guards.test.sh
@@ -416,4 +416,86 @@ done
 
 cleanup_repo
 
+# ---- glab mr create enforcement (GitLab parity) --------------------------------
+# Mirrors the gh pr create Rule 1 tests but exercises _rule1_match + glab path.
+# Uses a repo with pr_target=dev (dual-tier model) so we can also test the
+# dev→main release-merge exception.
+
+setup_glab_repo() {
+  local dir
+  dir=$(mktemp -d -t tmb-guards-glab-XXXX)
+  (
+    cd "$dir" || exit 1
+    git init -q -b dev
+    git config user.email t@t.t
+    git config user.name T
+    echo init > README.md
+    git add . && git commit -qm init
+
+    mkdir -p .claude/tmb
+    sqlite3 .claude/tmb/trajectory.db < "$PLUGIN_ROOT/mcp/trajectory-server/src/schema.sql" >/dev/null
+    sqlite3 .claude/tmb/trajectory.db "INSERT INTO repos (name, path) VALUES ('fixture', '$(git rev-parse --show-toplevel)');" >/dev/null
+    sqlite3 .claude/tmb/trajectory.db "
+      UPDATE plugin_config SET value_json = '\"dev\"'         WHERE key = 'pr_target';
+      UPDATE plugin_config SET value_json = '[\"main\",\"dev\"]' WHERE key = 'protected_branches';
+    " >/dev/null
+  )
+  REPO_PATH="$dir"
+}
+
+test_case "glab: glab mr list (read-only) is NOT blocked (early-exit passes glab)"
+out=$(run_hook '{"tool_input":{"command":"glab mr list"}}')
+assert_not_contains "$out" '"permissionDecision":"deny"' "glab mr list must not be blocked"
+
+test_case "glab: glab mr create --target-branch wrong → deny"
+setup_glab_repo
+out=$(run_hook_in_repo "glab mr create --target-branch wrong --source-branch feat/x --title 'x'")
+assert_contains "$out" '"permissionDecision":"deny"' "wrong target must block"
+assert_contains "$out" "BLOCKED" "deny reason must say BLOCKED"
+cleanup_repo
+
+test_case "glab: glab mr create --target-branch dev (== PR_TARGET) → allow"
+setup_glab_repo
+out=$(run_hook_in_repo "glab mr create --target-branch dev --source-branch feat/x --title 'x'")
+assert_not_contains "$out" '"permissionDecision":"deny"' "correct target must allow"
+cleanup_repo
+
+test_case "glab: glab mr create -b dev (short flag, == PR_TARGET) → allow"
+setup_glab_repo
+out=$(run_hook_in_repo "glab mr create -b dev -s feat/x --title 'x'")
+assert_not_contains "$out" '"permissionDecision":"deny"' "short -b correct target must allow"
+cleanup_repo
+
+test_case "glab: glab mr create -b main + --source-branch dev → allow (release exception)"
+setup_glab_repo
+out=$(run_hook_in_repo "glab mr create -b main --source-branch dev --title 'release'")
+assert_not_contains "$out" '"permissionDecision":"deny"' "dev→main with source=dev must allow"
+cleanup_repo
+
+test_case "glab: glab mr create -b main + --source-branch feat/x → deny (release exception non-dev source)"
+setup_glab_repo
+out=$(run_hook_in_repo "glab mr create -b main --source-branch feat/x --title 'x'")
+assert_contains "$out" '"permissionDecision":"deny"' "dev→main with non-dev source must block"
+cleanup_repo
+
+test_case "glab: glab mr create -b main + -s dev → allow (short -s source=dev release exception)"
+setup_glab_repo
+out=$(run_hook_in_repo "glab mr create -b main -s dev --title 'release'")
+assert_not_contains "$out" '"permissionDecision":"deny"' "short -s dev must allow release exception"
+cleanup_repo
+
+# ---- Rule 1 substring false-positive regression --------------------------------
+# A command that merely MENTIONS the PR/MR-create phrase inside quoted text
+# must NOT be blocked (anchored _rule1_match fix).
+
+setup_worktree_repo
+test_case "substring false-positive: echo quoting 'gh pr create --base x' is NOT blocked"
+out=$(run_hook_in_repo "echo \"run gh pr create --base dev from your feature branch\"")
+assert_not_contains "$out" '"permissionDecision":"deny"' "gh pr create inside quoted echo must not block"
+
+test_case "substring false-positive: echo quoting 'glab mr create --target-branch x' is NOT blocked"
+out=$(run_hook_in_repo "echo \"run glab mr create --target-branch dev from your feature branch\"")
+assert_not_contains "$out" '"permissionDecision":"deny"' "glab mr create inside quoted echo must not block"
+cleanup_repo
+
 summarize

--- a/tests/l3-integration/hooks/no-remote-auth-guard.test.sh
+++ b/tests/l3-integration/hooks/no-remote-auth-guard.test.sh
@@ -154,4 +154,21 @@ sqlite3 "$DB_NO_REMOTES" "
 out_nr=$(echo "$(input_bash 'gh auth login')" | TRAJECTORY_DB_PATH="$DB_NO_REMOTES" bash "$HOOK" 2>/dev/null || true)
 assert_eq "" "$out_nr" "absent remotes key → allow"
 
+# ============================================================================
+# Subshell-wrapped forms: (gh auth login) / (glab auth login) → deny
+# ============================================================================
+test_case "subshell (gh auth login): deny"
+out_sub_gh=$(run_hook "$(input_bash '(gh auth login)')")
+assert_contains "$out_sub_gh" '"permissionDecision":"deny"' "subshell gh auth login must deny"
+
+test_case "subshell (gh auth login): deny reason mentions BLOCKED"
+assert_contains "$out_sub_gh" "BLOCKED" "BLOCKED in reason for subshell gh"
+
+test_case "subshell (glab auth login): deny"
+out_sub_glab=$(run_hook "$(input_bash '(glab auth login)')")
+assert_contains "$out_sub_glab" '"permissionDecision":"deny"' "subshell glab auth login must deny"
+
+test_case "subshell (glab auth login): deny reason mentions BLOCKED"
+assert_contains "$out_sub_glab" "BLOCKED" "BLOCKED in reason for subshell glab"
+
 summarize


### PR DESCRIPTION
Fixes #564.

Per the standing principle that TMB hooks must treat **git, gh, and glab** consistently, `git-guards.sh` ignored GitLab entirely:

- Its early-exit only triggered on `git`/`gh` — a `glab` command exited before any rule ran.
- Rule 1 matched only the GitHub PR-create command (as a bare substring), with no GitLab MR-create equivalent — so GitLab-flow projects got **no MR-target enforcement**. The bare substring also false-fired when the phrase appeared in quoted argument text.

**Fix:**
- Early-exit trigger word set → `(git|gh|glab)`.
- Rule 1 now uses an anchored `_rule1_match` (byte-identical boundary class to `_rule2_match`) covering both forge commands; the GitHub branch is preserved verbatim, and a new GitLab branch enforces `--target-branch`/`-b` against `PR_TARGET` with the same dev→main release exception (head via `--source-branch`/`-s`).
- Anchoring kills the quoted-text false-positive.
- One-char trailing-boundary `)` added to `no-remote-auth-guard.sh` so subshell-wrapped auth-login forms can't evade (#548 advisory).

Verified: git-guards 93/93 (incl. GitLab enforcement, dev→main exception, false-positive regression), no-remote-auth-guard 20/20, git-push-guard 44/44; pr-reviewer PASS (row 72). Rule 2/3/4 untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
