### PR TITLE
🐛 fix(hooks): non-isolated SWE first-class — no-source-edit permits swe-role main edits + recovery message (#547)

### DIFF
--- a/scripts/hooks/no-source-edit-from-main.sh
+++ b/scripts/hooks/no-source-edit-from-main.sh
@@ -1,26 +1,22 @@
 #!/usr/bin/env bash
-# No-source-edit-from-main hook (#108, updated #467, #502).
-#
-# Two rules, both LOCATION-based — any agent context (bro, general-purpose
-# subagent, consultant, etc.) is denied; the worktree path is the only
-# credential for Edit/Write. For Bash, prompt-surface writes are denied
-# regardless of agent identity when outside a worktree.
-#
-# This is a tripwire for obvious write-forms, not a Bash sandbox. When in
-# doubt, the hook passes — precision beats recall here.
+# No-source-edit-from-main hook (#108, updated #467, #502, #547).
 #
 # Rule 1 — Edit/Write to source code from main checkout:
 #   Block conditions (all must be true):
 #   1. Trajectory DB exists (this is a TMB project)
-#   2. Target file is NOT inside .claude/worktrees/ (so this is not SWE)
+#   2. Target file is NOT inside .claude/worktrees/ (so this is not an isolated SWE)
 #   3. Target file is NOT in the docs/templates/config allowlist
+#   4. Normalized agent role is NOT 'swe' (non-isolated SWE first-class permit)
 #   Allow conditions (any one allows):
 #   - DB missing (not a TMB project)
 #   - Target is inside .claude/worktrees/<slug>/... (SWE legitimately edits source there)
 #   - Target is in allowlist (docs / configs that are fine to edit from main)
+#   - Normalized agent role == 'swe' (non-isolated SWE running in main checkout)
+#   Enforcement surfaces (scripts/hooks/, hooks/hooks.json) are ALWAYS denied from
+#   main, even for swe — they sit above the swe permit and are never re-opened.
 #
 # Rule 2 — Bash write-form targeting a prompt surface from main checkout:
-#   Denied for every agent identity (bro, subagent, unknown) when outside a
+#   Denied for every agent identity (bro, subagent, swe, unknown) when outside a
 #   worktree. Write-forms: >, >>, tee, sed -i, perl -i, python open w/a, cp/mv/rsync.
 #   Prompt surfaces: agents/*.md, skills/*/SKILL.md, commands/*.md,
 #   templates/*.md, CLAUDE.md, CODEX.md, CURSOR.md, GEMINI.md.
@@ -31,8 +27,13 @@
 
 set -uo pipefail
 
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/hooks/lib/normalize-role.sh
+. "$PLUGIN_ROOT/scripts/hooks/lib/normalize-role.sh"
+
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
+AGENT_TYPE=$(tmb_normalize_role "$(echo "$INPUT" | jq -r '.agent_type // .subagent_type // .tool_input.subagent_type // empty' 2>/dev/null || true)")
 
 case "$TOOL_NAME" in
   Edit|Write|MultiEdit|NotebookEdit|Bash) ;;
@@ -266,7 +267,14 @@ case "$TARGET" in
   *.github/*) exit 0 ;;
 esac
 
-REASON="BLOCKED: source edits from the main checkout are denied for all agent contexts in a TMB project. Target '$TARGET' looks like source code; route via the code-touching ask chain (tmb_planning skill → task_create_batch → spawn SWE in a worktree). For emergency hotfix-style overrides, set TMB_ALLOW_SOURCE_EDIT=1."
+# Non-isolated SWE permit: a genuine SWE role editing source from the main
+# checkout (non-isolated mode) is allowed. This fires AFTER the worktree allow,
+# AFTER the enforcement-surface denies, and AFTER the docs/allowlist allows —
+# so enforcement surfaces (scripts/hooks/, hooks/hooks.json) remain
+# worktree-only even for swe, and bro/unknown/absent roles still fail closed.
+if [ "$AGENT_TYPE" = "swe" ]; then exit 0; fi
+
+REASON="BLOCKED: source edits from the main checkout are denied. Normal route: use tmb_planning → task_create_batch to spawn SWE in an isolated worktree. If the worktree-create step failed (e.g. WorktreeCreate input had no .branch field), SWE running with agent_type='swe' is auto-permitted to edit in-place (non-isolated mode). For a bro emergency hotfix, set TMB_ALLOW_SOURCE_EDIT=1 in the PROCESS environment at launch time — setting it in a shell rc file has no effect on an already-running session."
 
 jq -nc --arg reason "$REASON" '{
   hookSpecificOutput: {

--- a/scripts/hooks/worktree-create.sh
+++ b/scripts/hooks/worktree-create.sh
@@ -45,7 +45,7 @@ INPUT=$(cat)
 
 BRANCH_NAME=$(echo "$INPUT" | jq -r '.branch // ""' 2>/dev/null)
 if [ -z "$BRANCH_NAME" ]; then
-  printf 'tmb worktree-create: no branch in input — nothing to create\n' >&2
+  printf 'tmb worktree-create: WorktreeCreate input has no .branch field — cannot create an isolated worktree; SWE will run non-isolated in the main checkout (supported). If isolation is required, ensure the spawn passes the task'"'"'s branch.\n' >&2
   exit 1
 fi
 

--- a/tests/l3-integration/hooks/no-source-edit-from-main.test.sh
+++ b/tests/l3-integration/hooks/no-source-edit-from-main.test.sh
@@ -51,6 +51,14 @@ input() {
   }'
 }
 
+input_with_agent() {
+  jq -n --arg tn "$1" --arg fp "$2" --arg at "$3" '{
+    tool_name: $tn,
+    agent_type: $at,
+    tool_input: { file_path: $fp }
+  }'
+}
+
 run_hook() {
   echo "$1" | bash "$HOOK" 2>&1 || true
 }
@@ -70,7 +78,7 @@ assert_eq "" "$out" "env bypass works"
 test_case "bro mode + src/foo.ts: BLOCK"
 out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_BRO")")
 assert_contains "$out" '"permissionDecision":"deny"' "deny decision emitted"
-assert_contains "$out" 'source edits from the main checkout are denied for all agent contexts' "reason cites location policy"
+assert_contains "$out" 'source edits from the main checkout are denied' "reason cites location policy"
 
 test_case "plain session (no bro) + src/foo.ts: BLOCK (location-based)"
 out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_PLAIN")")
@@ -87,7 +95,7 @@ assert_contains "$out" '"permissionDecision":"deny"' "no transcript = no identit
 test_case "general-purpose subagent context + src/foo.ts: BLOCK"
 out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_SUBAGENT")")
 assert_contains "$out" '"permissionDecision":"deny"' "subagent identity never grants main-checkout source edits"
-assert_contains "$out" 'source edits from the main checkout are denied for all agent contexts' "reason cites location policy"
+assert_contains "$out" 'source edits from the main checkout are denied' "reason cites location policy"
 
 test_case "#276: bare 'bro' word + src/foo.ts: BLOCK (location policy, not substring match)"
 out=$(run_hook "$(input 'Edit' 'src/foo.ts' "$TRANSCRIPT_BARE_BRO")")
@@ -300,5 +308,43 @@ assert_eq "" "$out" "redirect to /tmp mentioning a prompt path should not be den
 test_case "Bash git commit -m message mentioning agents/swe.md: NOT denied"
 out=$(run_hook "$(bash_input 'git commit -m "touch agents/swe.md"')")
 assert_eq "" "$out" "commit message mentioning prompt path should not be denied"
+
+# ---- Non-isolated SWE first-class (agent_type=swe permit) ----
+# Restore DB (removed in the "no DB" test case above)
+sqlite3 "$DB" "CREATE TABLE meta (k TEXT);" 2>/dev/null || true
+
+test_case "agent_type=swe + src/foo.ts from main: ALLOWED (non-isolated SWE permit)"
+out=$(run_hook "$(input_with_agent 'Edit' 'src/foo.ts' 'swe')")
+assert_eq "" "$out" "swe role may edit source from main checkout"
+
+test_case "agent_type=swe + mcp/server.ts from main: ALLOWED"
+out=$(run_hook "$(input_with_agent 'Write' 'mcp/trajectory-server/src/index.ts' 'swe')")
+assert_eq "" "$out" "swe role may write .ts source from main checkout"
+
+test_case "agent_type=bro + src/foo.ts from main: DENIED (bro may not use swe permit)"
+out=$(run_hook "$(input_with_agent 'Edit' 'src/foo.ts' 'bro')")
+assert_contains "$out" '"permissionDecision":"deny"' "bro is denied even with explicit agent_type"
+
+test_case "no agent_type + src/foo.ts from main: DENIED (fail closed)"
+out=$(run_hook "$(input 'Edit' 'src/foo.ts' '')")
+assert_contains "$out" '"permissionDecision":"deny"' "absent agent_type fails closed"
+
+test_case "agent_type=swe + scripts/hooks/foo.sh from main: DENIED (enforcement surface)"
+out=$(run_hook "$(input_with_agent 'Edit' 'scripts/hooks/foo.sh' 'swe')")
+assert_contains "$out" '"permissionDecision":"deny"' "swe cannot edit enforcement surfaces from main"
+assert_contains "$out" 'enforcement surfaces' "deny message cites enforcement-surface doctrine"
+
+test_case "agent_type=swe + hooks/hooks.json from main: DENIED (enforcement surface)"
+out=$(run_hook "$(input_with_agent 'Edit' 'hooks/hooks.json' 'swe')")
+assert_contains "$out" '"permissionDecision":"deny"' "swe cannot edit hooks.json from main"
+
+test_case "REGRESSION: worktree path edit + agent_type=swe: ALLOWED"
+out=$(run_hook "$(input_with_agent 'Edit' '.claude/worktrees/task-99/src/foo.ts' 'swe')")
+assert_eq "" "$out" "worktree-path edit always allowed regardless of agent_type"
+
+test_case "deny message teaches recovery without mentioning shell rc files"
+out=$(run_hook "$(input_with_agent 'Edit' 'src/foo.ts' 'bro')")
+assert_not_contains "$out" 'bashrc' "deny message must not mention bashrc"
+assert_contains "$out" 'non-isolated' "deny message mentions non-isolated mode"
 
 summarize


### PR DESCRIPTION
Fixes #547.

The L7 dead-end: bro spawns SWE `isolation='worktree'`, the harness's WorktreeCreate omits the `branch` field → no worktree → SWE runs in the main checkout → its source Edit is blocked by no-source-edit-from-main.sh → bro chased `TMB_ALLOW_SOURCE_EDIT=1` via `.bashrc` (no effect mid-session).

**Fix (DETERMINISM: mechanism over prose — hooks only, no prompt change):**
- `no-source-edit-from-main.sh` permits Rule-1 source edits when the normalized agent role is `swe` — making non-isolated SWE first-class. Placed AFTER the enforcement-surface deny (scripts/hooks, hooks.json stay worktree-only even for swe) and AFTER the allowlist; bro / unknown / absent roles still **fail closed**.
- The final deny message now teaches the real recovery (worktree route, swe non-isolated auto-permit, `TMB_ALLOW_SOURCE_EDIT=1` in the **process env at launch** — not `.bashrc`).
- `worktree-create.sh` names the missing-`branch` contract gap in its stderr.

Verified: no-source-edit 67/67 (swe-allow, bro/absent-deny, enforcement-surface-deny-with-swe, worktree regression); pr-reviewer PASS (row 74) with a full safety trace (no new attack surface, fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)