### PR TITLE
🧪 fix(tests): sync db/schema test schema_version assertions to 12 (#569)

### DIFF
--- a/mcp/trajectory-server/dist/test/db.test.js
+++ b/mcp/trajectory-server/dist/test/db.test.js
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { tempDB } from './helpers.js';
 import { nowISO, TrajectoryDB } from '../db.js';
 describe('TrajectoryDB', () => {
-    it('opens an in-memory DB and verifies all 22 prod tables exist with schema_version=11 (world model in kuzu)', () => {
+    it('opens an in-memory DB and verifies all 22 prod tables exist with schema_version=12 (world model in kuzu)', () => {
         const db = tempDB();
         const expectedTables = [
             'issues',
@@ -41,7 +41,7 @@ describe('TrajectoryDB', () => {
         assert.deepEqual(actualNames, expectedSorted);
         const meta = db.get('SELECT schema_version FROM plugin_meta LIMIT 1');
         assert.ok(meta !== undefined, 'plugin_meta should have a row');
-        assert.equal(meta.schema_version, 11);
+        assert.equal(meta.schema_version, 12);
         db.close();
     });
     it('run inserts a row into skills, get retrieves it, all lists multiple rows', () => {

--- a/mcp/trajectory-server/dist/test/schema.test.js
+++ b/mcp/trajectory-server/dist/test/schema.test.js
@@ -40,11 +40,11 @@ describe('schema — current table set, default values, constraints', () => {
         assert.deepEqual(actualNames, [...expectedTables].sort());
         db.close();
     });
-    it('fresh DB has schema_version = 11 in plugin_meta', () => {
+    it('fresh DB has schema_version = 12 in plugin_meta', () => {
         const db = tempDB();
         const meta = db.get('SELECT schema_version, plugin_version FROM plugin_meta LIMIT 1');
         assert.ok(meta !== undefined, 'plugin_meta must have a seed row');
-        assert.equal(meta.schema_version, 11);
+        assert.equal(meta.schema_version, 12);
         assert.ok(typeof meta.plugin_version === 'string' && meta.plugin_version.length > 0, 'plugin_version must be a non-empty string');
         db.close();
     });

--- a/mcp/trajectory-server/src/test/db.test.ts
+++ b/mcp/trajectory-server/src/test/db.test.ts
@@ -7,7 +7,7 @@ import { tempDB } from './helpers.js';
 import { nowISO, TrajectoryDB } from '../db.js';
 
 describe('TrajectoryDB', () => {
-  it('opens an in-memory DB and verifies all 22 prod tables exist with schema_version=11 (world model in kuzu)', () => {
+  it('opens an in-memory DB and verifies all 22 prod tables exist with schema_version=12 (world model in kuzu)', () => {
     const db = tempDB();
 
     const expectedTables = [
@@ -50,7 +50,7 @@ describe('TrajectoryDB', () => {
       'SELECT schema_version FROM plugin_meta LIMIT 1',
     );
     assert.ok(meta !== undefined, 'plugin_meta should have a row');
-    assert.equal(meta.schema_version, 11);
+    assert.equal(meta.schema_version, 12);
 
     db.close();
   });

--- a/mcp/trajectory-server/src/test/schema.test.ts
+++ b/mcp/trajectory-server/src/test/schema.test.ts
@@ -47,14 +47,14 @@ describe('schema — current table set, default values, constraints', () => {
     db.close();
   });
 
-  it('fresh DB has schema_version = 11 in plugin_meta', () => {
+  it('fresh DB has schema_version = 12 in plugin_meta', () => {
     const db = tempDB();
 
     const meta = db.get<{ schema_version: number; plugin_version: string }>(
       'SELECT schema_version, plugin_version FROM plugin_meta LIMIT 1',
     );
     assert.ok(meta !== undefined, 'plugin_meta must have a seed row');
-    assert.equal(meta.schema_version, 11);
+    assert.equal(meta.schema_version, 12);
     assert.ok(
       typeof meta.plugin_version === 'string' && meta.plugin_version.length > 0,
       'plugin_version must be a non-empty string',


### PR DESCRIPTION
Fixes #569.

#542 bumped TARGET_SCHEMA_VERSION 11→12 but db.test.ts and schema.test.ts still asserted 11 (`12 !== 11`), reddening the local L0-L4 sweep on dev and blocking the v0.8.2 rc. Synced both assertions + description strings to 12; rebuilt dist. Test-only.

Verified: db.test + schema.test 22/22, dist-fresh PASS; pr-reviewer PASS (row 75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)