### PR TITLE
🧪 fix(l5): drop nonexistent audit.kind filter in rows 32 + 95 outcome.sql (#573)

### DIFF
--- a/tests/l5-l6/rows/32-team-config/outcome.sql
+++ b/tests/l5-l6/rows/32-team-config/outcome.sql
@@ -14,22 +14,18 @@
 SELECT
   CASE WHEN
        (SELECT COUNT(*) FROM audit
-         WHERE kind='event'
-           AND event_type IN ('config_changed', 'headless_reonboard_blocked'))
+         WHERE event_type IN ('config_changed', 'headless_reonboard_blocked'))
      + (SELECT COUNT(*) FROM audit
-         WHERE kind='event'
-           AND (summary LIKE '%/onboard%' OR content_json LIKE '%/onboard%'))
+         WHERE (summary LIKE '%/onboard%' OR content_json LIKE '%/onboard%'))
      + (SELECT COUNT(*) FROM discussions
          WHERE body LIKE '%/onboard%')
      >= 1 THEN 1 ELSE 0 END AS pass,
   'config-changed-or-headless-block-or-onboard-routing (got ' ||
     (
       (SELECT COUNT(*) FROM audit
-        WHERE kind='event'
-          AND event_type IN ('config_changed', 'headless_reonboard_blocked'))
+        WHERE event_type IN ('config_changed', 'headless_reonboard_blocked'))
     + (SELECT COUNT(*) FROM audit
-        WHERE kind='event'
-          AND (summary LIKE '%/onboard%' OR content_json LIKE '%/onboard%'))
+        WHERE (summary LIKE '%/onboard%' OR content_json LIKE '%/onboard%'))
     + (SELECT COUNT(*) FROM discussions
         WHERE body LIKE '%/onboard%')
     ) || ' total signals, expected ≥ 1)' AS description;

--- a/tests/l5-l6/rows/95-anonymous-cold-restart/outcome.sql
+++ b/tests/l5-l6/rows/95-anonymous-cold-restart/outcome.sql
@@ -19,4 +19,4 @@ FROM plugin_config;
 SELECT
   CASE WHEN COUNT(*) = 0 THEN 1 ELSE 0 END AS pass,
   'no-audit-events (got ' || COUNT(*) || ', expected 0)' AS description
-FROM audit WHERE kind='event';
+FROM audit;


### PR DESCRIPTION
Fixes #573.

Two L5 `outcome.sql` queried `audit WHERE kind='event'`, but `audit` has no `kind` column (it uses `event_type`; every row is an event) — they errored on a fresh schema. Dropped the bogus filter (95 → `FROM audit`; 32 → keep the `event_type IN(...)` / `/onboard` LIKE filters). Surfaced auditing L0-L6 for the v0.8.2 release. Not in the 13-step chain; row 19 already correct. Test-only.

Verified: both files execute against fresh v12 schema, semantics preserved; pr-reviewer PASS (row 77).

🤖 Generated with [Claude Code](https://claude.com/claude-code)