### PR TITLE
🧪 fix(l6): step 12 chain_setup_command pre-creates the resume task's branch (#578)

### DIFF
--- a/tests/l5-l6/l6-chain/chain-manifest.json
+++ b/tests/l5-l6/l6-chain/chain-manifest.json
@@ -127,7 +127,8 @@
       "partial_test": false,
       "seed_before": "seeds/before-12-issue-resume.sql",
       "seed_after": null,
-      "halt_on_fail": true
+      "halt_on_fail": true,
+      "chain_setup_command": "base=$(git for-each-ref --format='%(refname:short)' refs/heads | while read -r br; do git ls-tree -r --name-only \"$br\" | grep -qx 'src/cli.py' && { echo \"$br\"; break; }; done); git branch feat/add-count-subcommand \"${base:-HEAD}\" 2>/dev/null || true"
     },
     {
       "step": 13,

--- a/tests/l5-l6/rows/12-issue-resume/README.md
+++ b/tests/l5-l6/rows/12-issue-resume/README.md
@@ -10,9 +10,9 @@ The bug class this catches: bro overplanning — re-creating an issue / re-runni
 
 ## Pre-state
 
-`onboarding-named` fixture + a pre-seeded resume issue and task on `feat/seed-cli` (id auto-increment for L6-chain compatibility):
-- `issues(objective='Add a CLI entry point (resume)', status='open')`
-- `tasks(branch_id='feat/seed-cli', status='pending')`
+`onboarding-named` fixture + a pre-seeded resume issue and task on `feat/add-count-subcommand` (id auto-increment for L6-chain compatibility):
+- `issues(objective='Add count subcommand to todo CLI', status='open')`
+- `tasks(branch_id='feat/add-count-subcommand', status='pending')`
 - `audit(event_type='planning_complete')` linked to the resume issue
 
 ## Turns
@@ -26,8 +26,8 @@ The bug class this catches: bro overplanning — re-creating an issue / re-runni
 
 | Scorer | Asserts |
 |---|---|
-| `outcome.sql` | resume issue exists exactly once (`objective='Add a CLI entry point (resume)'`); task on `feat/seed-cli` exists exactly once — bro did NOT replan |
-| `outcome-coherence.json` | resume issue count `=1`; task on `feat/seed-cli` count `=1` |
+| `outcome.sql` | resume issue exists exactly once (`objective='Add count subcommand to todo CLI'`); task on `feat/add-count-subcommand` exists exactly once — bro did NOT replan |
+| `outcome-coherence.json` | resume issue count `=1`; task on `feat/add-count-subcommand` count `=1` |
 | `outcome-git.json` | `base_branch_unchanged: true` |
 | `tools-required.json` | `Agent` (SWE dispatch). The "must read existing state" half is asserted by `outcome.sql` + `outcome-coherence.json` — if bro replanned, those would show 2/2. |
 | `tools-forbidden.json` | `issue_create`, `task_create_batch` — bro must NOT replan |


### PR DESCRIPTION
Fixes #578.

L6 chain step 12 (issue-resume) seeds the pending task via SQL but couldn't create its git branch (`setup-l5.sh` does for L5; the chain had no equivalent), so `require-feature-branch-active` trapped bro and the task stayed pending — a deterministic step-12 failure blocking the local v0.8.2 L6 gate. Added a `chain_setup_command` (mirroring step 6's branch-find) that pre-creates `feat/add-count-subcommand`, making the 'already-planned' state faithful (real planning always creates the branch). Also corrected stale `feat/seed-cli` refs in the row README.

Verified: JSON valid, command creates the branch in a fixture repo; pr-reviewer PASS (row 79). Test-fixture only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)