### PR TITLE
🧪 fix(l6): skip-guard scan_run in rows 04 + 33 — auto-prescan satisfies the world-model need (#580)

### DIFF
--- a/tests/l5-l6/rows/04-first-task-hits-gate/tools-required.json
+++ b/tests/l5-l6/rows/04-first-task-hits-gate/tools-required.json
@@ -1,4 +1,4 @@
 [
-  "mcp__plugin_tmb_trajectory-server__scan_run",
+  {"tool": "mcp__plugin_tmb_trajectory-server__scan_run", "skip_if_pre_state_sql": "SELECT 1 FROM audit WHERE event_type='deep_scan_completed' LIMIT 1"},
   "mcp__plugin_tmb_trajectory-server__task_create_batch"
 ]

--- a/tests/l5-l6/rows/33-multirepo-commit/tools-required.json
+++ b/tests/l5-l6/rows/33-multirepo-commit/tools-required.json
@@ -1,3 +1,3 @@
 [
-  "mcp__plugin_tmb_trajectory-server__scan_run"
+  {"tool": "mcp__plugin_tmb_trajectory-server__scan_run", "skip_if_pre_state_sql": "SELECT 1 FROM audit WHERE event_type='deep_scan_completed' LIMIT 1"}
 ]


### PR DESCRIPTION
Fixes #580.

The v0.8.2-rc.1 CI L6 chain flaked at step 4: `trajectory_required` demanded an explicit `scan_run` tool call, but the session-start auto-prescan emits `deep_scan_completed` without one (coherence confirmed the scan happened). LLM-variance flake — passed locally. Made `scan_run` skip-guarded in rows 04 (chained) + 33: waived when a `deep_scan_completed` audit exists (chain), still required in L5 isolation (cold world model). The scorer already supports the object form.

Verified: JSON valid, skip-guard object present, scorer honors it; pr-reviewer PASS (row 80). Test-fixture only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)