### PR TITLE
🔖 chore(release): bump to v0.8.2-rc.2 (L6 fixture determinism re-cut)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.8.2-rc.1",
+  "version": "0.8.2-rc.2",
   "description": "TMB plugin \u2014 bro orchestrates SWE + pr-reviewer in two gates (task gate, push gate) backed by a SQLite trajectory MCP server.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.8.2-rc.2 — 2026-06-13
+
+Re-cut of `rc.1` with L6-chain test-fixture determinism fixes only — functionally identical shipped runtime. `rc.1`'s CI re-confirmation flaked on brittle L6 scorers (not product behavior): the `trajectory_required` scorer iterated spuriously on an empty `tools-required.json` under BSD `seq` (#576), and required an explicit `scan_run` call that the session-start auto-prescan already satisfies (#580); the step-12 chain now also pre-creates the resume task's branch (#578). Licensed by local L6 13/13.
+
 ## v0.8.2-rc.1 — 2026-06-13
 
 Multi-repo support, per-task token attribution, GitLab/offline parity in the guards, and the worktree-lifecycle fixes that ended the SubagentStop completion deadlock. Schema v10 → v12.

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.8.2-rc.1",
+  "version": "0.8.2-rc.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.8.2-rc.1",
+  "version": "0.8.2-rc.2",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Phase A re-cut for **v0.8.2-rc.2**. No issue (release mechanics). Functionally identical to rc.1 — only L6-chain test-fixture determinism fixes (#576/#578/#580) landed since. Local L6 13/13 holds (those fixes only loosen/repair scorers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)