### PR TITLE
📝 docs(plugin): reframe world-model description to its real purpose

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tmb",
   "version": "0.8.3",
-  "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, on an MCP server pairing a SQLite trajectory log with a kuzu world-model graph for multi-repo navigation.",
+  "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",
     "url": "https://github.com/trustmybot"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Patch release. Fixes the world-model scan crashing on repos with non-ASCII track
 - `scan.sh` emitted invalid JSON on repos with a non-ASCII tracked path: git C-quoted the path into octal `\nnn` escapes the awk JSON emitter couldn't portably escape, so `scan_run` aborted with `jq: Invalid escape`. Both git calls now run with `-c core.quotePath=false`, keeping paths as raw UTF-8 (valid inside a JSON string). Added an L3 regression test. (#586)
 
 ### Changed
-- Plugin description refreshed to reflect the kuzu world-model graph and multi-repo navigation.
+- Plugin description refreshed to reflect the kuzu world model (helping agents understand and navigate complex codebases).
 
 ## v0.8.2 — 2026-06-13
 


### PR DESCRIPTION
Correct the v0.8.3 plugin description: the kuzu world model's purpose is helping agents understand/navigate complex codebases, not 'multi-repo navigation'. Updates plugin.json description + the CHANGELOG ### Changed bullet. Copy-only; no behavior change.