### PR TITLE
🔖 release: v0.8.3 (scan non-ASCII fix #586)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tmb",
   "version": "0.8.3",
-  "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, on an MCP server pairing a SQLite trajectory log with a kuzu world-model graph for multi-repo navigation.",
+  "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",
     "url": "https://github.com/trustmybot"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tmb",
-  "version": "0.8.2",
-  "description": "TMB plugin \u2014 bro orchestrates SWE + pr-reviewer in two gates (task gate, push gate) backed by a SQLite trajectory MCP server.",
+  "version": "0.8.3",
+  "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, on an MCP server pairing a SQLite trajectory log with a kuzu world-model graph for multi-repo navigation.",
   "author": {
     "name": "trustmybot",
     "url": "https://github.com/trustmybot"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.8.3 — 2026-06-13
+
+Patch release. Fixes the world-model scan crashing on repos with non-ASCII tracked paths — surfaced when scanning django (the benchmark corpus), which ships `tests/staticfiles_tests/apps/test/static/test/⊗.txt` (U+2297). No Claude-side (agents/skills/CLAUDE.md) changes; the release-gate is skipped per hotfix policy.
+
+### Fixed
+- `scan.sh` emitted invalid JSON on repos with a non-ASCII tracked path: git C-quoted the path into octal `\nnn` escapes the awk JSON emitter couldn't portably escape, so `scan_run` aborted with `jq: Invalid escape`. Both git calls now run with `-c core.quotePath=false`, keeping paths as raw UTF-8 (valid inside a JSON string). Added an L3 regression test. (#586)
+
+### Changed
+- Plugin description refreshed to reflect the kuzu world-model graph and multi-repo navigation.
+
 ## v0.8.2 — 2026-06-13
 
 Promotes `v0.8.2-rc.2` to stable — functionally identical to the rc (version manifests + CHANGELOG only). See the rc sections below for the full change list: multi-repo / per-repo branching config (#550/#549/#560), per-task bro token attribution (schema v12, #542), GitLab + offline guard parity (#564/#548/#546), worktree-lifecycle and completion-deadlock fixes (#551/#559/#547), and the non-isolated-SWE first-class mode (#547). Licensed by the local L6 chain 13/13 (the rc-tag CI is re-confirmation, not the gate).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Patch release. Fixes the world-model scan crashing on repos with non-ASCII track
 - `scan.sh` emitted invalid JSON on repos with a non-ASCII tracked path: git C-quoted the path into octal `\nnn` escapes the awk JSON emitter couldn't portably escape, so `scan_run` aborted with `jq: Invalid escape`. Both git calls now run with `-c core.quotePath=false`, keeping paths as raw UTF-8 (valid inside a JSON string). Added an L3 regression test. (#586)
 
 ### Changed
-- Plugin description refreshed to reflect the kuzu world-model graph and multi-repo navigation.
+- Plugin description refreshed to reflect the kuzu world model (helping agents understand and navigate complex codebases).
 
 ## v0.8.2 — 2026-06-13
 

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [

--- a/scripts/scan.sh
+++ b/scripts/scan.sh
@@ -126,7 +126,7 @@ while IFS= read -r repo_root; do
 
   name=$(basename "$repo_root")
 
-  files_list=$(git -C "$repo_root" ls-files 2>/dev/null || true)
+  files_list=$(git -C "$repo_root" -c core.quotePath=false ls-files 2>/dev/null || true)
   if [ -z "$files_list" ]; then
     jq -nc \
       --arg name "$name" --arg path "$repo_root" \
@@ -139,7 +139,7 @@ while IFS= read -r repo_root; do
   # Single-pass git log: build relpath→sha map in one subprocess.
   # awk: 40-hex lines update current SHA; file lines record first (most-recent) SHA.
   sha_map_file=$(mktemp -t tmb-shamap.XXXXXX)
-  git -C "$repo_root" log --format='%H' --name-only --no-renames 2>/dev/null \
+  git -C "$repo_root" -c core.quotePath=false log --format='%H' --name-only --no-renames 2>/dev/null \
   | awk '
       /^[0-9a-f]{40}$/ { cur = $0; next }
       /^$/              { next }

--- a/tests/l3-integration/hooks/scan-non-ascii-paths.test.sh
+++ b/tests/l3-integration/hooks/scan-non-ascii-paths.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Regression test: scan.sh emits valid JSON when a repo contains a non-ASCII tracked path.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../lib/assert.sh"
+PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
+
+command -v jq >/dev/null 2>&1 || { printf "SKIP jq not found\n"; exit 0; }
+
+WORKSPACE=$(mktemp -d)
+trap 'rm -rf "$WORKSPACE"' EXIT
+
+REPO="$WORKSPACE/testrepo"
+mkdir -p "$REPO/subdir"
+
+printf 'content\n' > "$REPO/subdir/⊗.txt"
+printf 'plain\n' > "$REPO/plain.txt"
+
+git -C "$REPO" init -q
+git -C "$REPO" config user.email "test@example.com"
+git -C "$REPO" config user.name "Test"
+git -C "$REPO" add .
+git -C "$REPO" commit -q -m "initial commit"
+
+SCAN_OUT=$(bash "$PLUGIN_ROOT/scripts/scan.sh" "$WORKSPACE")
+SCAN_RC=$?
+
+test_case "scan exits 0 on repo with non-ASCII path"
+assert_exit_code 0 "$SCAN_RC" "scan exit code"
+
+test_case "scan output is valid JSON"
+if printf '%s' "$SCAN_OUT" | jq -e . >/dev/null 2>&1; then
+  _pass
+else
+  _fail "scan output is not valid JSON: $SCAN_OUT"
+fi
+
+test_case "non-ASCII path appears in .files[].path"
+match=$(printf '%s' "$SCAN_OUT" | jq -e '.files[] | select(.path | endswith("⊗.txt"))' 2>/dev/null || true)
+if [ -n "$match" ]; then
+  _pass
+else
+  _fail "⊗.txt not found in .files[].path"
+fi
+
+summarize
+printf "PASS scan-non-ascii-paths\n"


### PR DESCRIPTION
Promotes dev to main for the v0.8.3 patch release. Contents: scan.sh non-ASCII JSON fix + L3 regression test (#586), 3-manifest version bump, CHANGELOG, plugin description refresh. L0–L4 green; pr-reviewer PASS. Hotfix — no Claude-side change; release-gate skipped per policy.