### PR TITLE
🐛 fix(hooks): robust prompt_bearing task_id resolution (#597)

### DIFF
--- a/scripts/hooks/lib/query-task.sh
+++ b/scripts/hooks/lib/query-task.sh
@@ -239,6 +239,103 @@ tmb_sql_quote() {
   printf '%s' "${1:-}" | sed "s/'/''/g"
 }
 
+# tmb_worktree_root_for_target <target_path>
+# Determine the worktree root for a prompt_bearing resolution.
+# Priority:
+#   1. The TARGET path if it is under .claude/worktrees/<slug>.
+#   2. Fall back to $PWD when $PWD is under a worktree.
+# Prints the worktree root (.../.claude/worktrees/<slug>) or empty string.
+# Never fails the caller.
+tmb_worktree_root_for_target() {
+  local target="${1:-}"
+  case "$target" in
+    */.claude/worktrees/*)
+      echo "$target" | sed -E 's|(.*/.claude/worktrees/[^/]+).*|\1|'
+      return 0
+      ;;
+  esac
+  case "$PWD" in
+    */.claude/worktrees/*)
+      echo "$PWD" | sed -E 's|(.*/.claude/worktrees/[^/]+).*|\1|'
+      return 0
+      ;;
+  esac
+  return 0
+}
+
+# tmb_resolve_task_id_for_target <target_path> <input_json> [<db>]
+# Robustly resolve the active task_id that gates a prompt_bearing edit/write.
+# Resolution order (first non-empty wins):
+#   1. Worktree's checked-out branch: derive WORKTREE_ROOT from the TARGET path
+#      (or $PWD), then `git -C <wt> rev-parse --abbrev-ref HEAD` → exact
+#      `branch_id = '<branch>'` (NO status filter).
+#   2. Slug fallback: `branch_id LIKE '%/<slug>'` from the worktree root (NO
+#      status filter).
+#   3. Transcript fallback: parse `task_id=[0-9]+` from the WHOLE transcript
+#      message content (not only type:"text" blocks).
+# All SQL is sanitized via tmb_sql_quote. Prints the resolved task_id (decimal)
+# or empty string. Never fails the caller.
+tmb_resolve_task_id_for_target() {
+  local target="${1:-}"
+  local input="${2:-}"
+  local db="${3:-}"
+  if [ -z "$db" ]; then
+    db=$(tmb_db_path) || true
+  fi
+
+  local wt_root
+  wt_root=$(tmb_worktree_root_for_target "$target")
+
+  local task_id=""
+
+  if [ -n "$db" ] && tmb_have_sqlite && [ -n "$wt_root" ]; then
+    # (1) Exact branch match from the worktree's checked-out branch.
+    local branch
+    branch=$(git -C "$wt_root" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+    if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
+      local safe_branch
+      safe_branch=$(tmb_sql_quote "$branch")
+      task_id=$(tmb_sqlite_ro "$db" "
+        SELECT id FROM tasks
+         WHERE branch_id = '${safe_branch}'
+         ORDER BY id DESC
+         LIMIT 1;
+      " 2>/dev/null || true)
+      case "$task_id" in ''|*[!0-9]*) task_id="" ;; esac
+    fi
+
+    # (2) Slug fallback — no status filter.
+    if [ -z "$task_id" ]; then
+      local slug
+      slug=$(echo "$wt_root" | sed -E 's|.*/.claude/worktrees/([^/]+)$|\1|')
+      if [ -n "$slug" ]; then
+        local safe_slug
+        safe_slug=$(tmb_sql_quote "$slug")
+        task_id=$(tmb_sqlite_ro "$db" "
+          SELECT id FROM tasks
+           WHERE branch_id LIKE '%/${safe_slug}'
+           ORDER BY id DESC
+           LIMIT 1;
+        " 2>/dev/null || true)
+        case "$task_id" in ''|*[!0-9]*) task_id="" ;; esac
+      fi
+    fi
+  fi
+
+  # (3) Transcript fallback — parse the whole message content.
+  if [ -z "$task_id" ] && [ -n "$input" ]; then
+    local transcript
+    transcript=$(echo "$input" | jq -r '.agent_transcript_path // ""' 2>/dev/null || true)
+    if [ -n "$transcript" ] && [ -f "$transcript" ]; then
+      task_id=$(jq -r '.message.content // [] | tostring' "$transcript" 2>/dev/null \
+        | grep -oE 'task_id=[0-9]+' | head -1 | sed 's/task_id=//' || true)
+      case "$task_id" in ''|*[!0-9]*) task_id="" ;; esac
+    fi
+  fi
+
+  echo "$task_id"
+}
+
 # tmb_task_spec_status <task_id> [<db>]
 # Prints two lines: <status>\n<body_len> for the given tasks row.
 # Prints nothing when the row does not exist, DB is absent, sqlite3 is unavailable,

--- a/scripts/hooks/swe-boundary.sh
+++ b/scripts/hooks/swe-boundary.sh
@@ -281,37 +281,13 @@ if [ "$TOOL_NAME" = "Bash" ] && [ "$SWE_CTX" = "yes" ]; then
   fi
 
   if [ "$BASH_PROMPT_WRITE" = "yes" ]; then
-    # Resolve prompt_bearing via transcript or slug fallback (mirrors rule (d)).
-    _PB_TASK_ID=""
-    _PB_TRANSCRIPT=$(echo "$INPUT" | jq -r '.agent_transcript_path // ""' 2>/dev/null || true)
-    if [ -n "$_PB_TRANSCRIPT" ] && [ -f "$_PB_TRANSCRIPT" ]; then
-      _PB_TASK_ID=$(jq -r '
-        .message.content // [] |
-        .[] | select(.type == "text") | .text // ""
-      ' "$_PB_TRANSCRIPT" 2>/dev/null \
-        | grep -oE 'task_id=[0-9]+' | head -1 | sed 's/task_id=//' || true)
-      case "$_PB_TASK_ID" in ''|*[!0-9]*) _PB_TASK_ID="" ;; esac
-    fi
-    if [ -z "$_PB_TASK_ID" ] && [ -n "$WORKTREE_ROOT" ]; then
-      _PB_SLUG=$(echo "$WORKTREE_ROOT" | sed -E 's|.*/.claude/worktrees/([^/]+)$|\1|')
-      if [ -n "$_PB_SLUG" ]; then
-        _PB_DB=$(tmb_db_path || true)
-        if [ -n "$_PB_DB" ] && tmb_have_sqlite; then
-          _SAFE_SLUG=$(tmb_sql_quote "$_PB_SLUG")
-          _PB_TASK_ID=$(tmb_sqlite_ro "$_PB_DB" "
-            SELECT id FROM tasks
-             WHERE branch_id LIKE '%/${_SAFE_SLUG}'
-               AND status IN ('pending','running','completed')
-             ORDER BY id DESC
-             LIMIT 1;
-          " 2>/dev/null || true)
-          case "$_PB_TASK_ID" in ''|*[!0-9]*) _PB_TASK_ID="" ;; esac
-        fi
-      fi
-    fi
+    # Resolve prompt_bearing via the shared resolver (worktree branch → slug →
+    # transcript). Bash write-forms have no Edit target path; pass empty so the
+    # resolver derives the worktree from $PWD.
+    _PB_DB=$(tmb_db_path || true)
+    _PB_TASK_ID=$(tmb_resolve_task_id_for_target "" "$INPUT" "$_PB_DB")
     _PB_ALLOWED=""
     if [ -n "$_PB_TASK_ID" ]; then
-      _PB_DB=$(tmb_db_path || true)
       if [ -n "$_PB_DB" ] && tmb_have_sqlite; then
         _PB_VAL=$(tmb_sqlite_ro "$_PB_DB" "
           SELECT COALESCE(prompt_bearing, 0) FROM tasks WHERE id = ${_PB_TASK_ID} LIMIT 1;
@@ -382,33 +358,9 @@ esac
 if [ "$IS_PROMPT_SURFACE" = "yes" ]; then
   DB=$(tmb_db_path || true)
   if [ -n "$DB" ] && tmb_have_sqlite; then
-    # Resolve task_id from transcript.
-    TASK_ID=""
-    TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.agent_transcript_path // ""' 2>/dev/null || true)
-    if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
-      TASK_ID=$(jq -r '
-        .message.content // [] |
-        .[] | select(.type == "text") | .text // ""
-      ' "$TRANSCRIPT_PATH" 2>/dev/null \
-        | grep -oE 'task_id=[0-9]+' | head -1 | sed 's/task_id=//' || true)
-      case "$TASK_ID" in ''|*[!0-9]*) TASK_ID="" ;; esac
-    fi
-    # Slug fallback: when transcript provides no task_id but a worktree root is
-    # known, resolve the task by branch_id slug (same query as swe-scope-fence.sh).
-    if [ -z "$TASK_ID" ] && [ -n "$WORKTREE_ROOT" ]; then
-      WORKTREE_SLUG=$(echo "$WORKTREE_ROOT" | sed -E 's|.*/.claude/worktrees/([^/]+)$|\1|')
-      if [ -n "$WORKTREE_SLUG" ]; then
-        SAFE_SLUG=$(tmb_sql_quote "$WORKTREE_SLUG")
-        TASK_ID=$(tmb_sqlite_ro "$DB" "
-          SELECT id FROM tasks
-           WHERE branch_id LIKE '%/${SAFE_SLUG}'
-             AND status IN ('pending','running','completed')
-           ORDER BY id DESC
-           LIMIT 1;
-        " 2>/dev/null || true)
-        case "$TASK_ID" in ''|*[!0-9]*) TASK_ID="" ;; esac
-      fi
-    fi
+    # Resolve task_id robustly (worktree branch → slug → transcript), deriving
+    # the worktree from the TARGET when $PWD isn't inside one.
+    TASK_ID=$(tmb_resolve_task_id_for_target "$TARGET" "$INPUT" "$DB")
     if [ -n "$TASK_ID" ]; then
       PROMPT_BEARING=$(tmb_sqlite_ro "$DB" "
         SELECT COALESCE(prompt_bearing, 0) FROM tasks WHERE id = ${TASK_ID} LIMIT 1;

--- a/scripts/hooks/swe-scope-fence.sh
+++ b/scripts/hooks/swe-scope-fence.sh
@@ -41,31 +41,25 @@ SWE_CTX=$(tmb_swe_context "$AGENT_TYPE")
 
 [ "$SWE_CTX" = "yes" ] || exit 0
 
-# Only fire when PWD is inside a worktree — we need the slug to resolve the task.
-case "$PWD" in
-  */.claude/worktrees/*)
-    WORKTREE_SLUG=$(echo "$PWD" | sed -E 's|.*/.claude/worktrees/([^/]+).*|\1|')
-    ;;
-  *)
-    exit 0
-    ;;
-esac
-
 TARGET=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.notebook_path // ""' 2>/dev/null || true)
 [ -n "$TARGET" ] || exit 0
+
+# Resolve the worktree root from the TARGET (or $PWD). Fail open when neither
+# yields a worktree — we need it to scope the spec lookup and target comparison.
+WORKTREE_ROOT=$(tmb_worktree_root_for_target "$TARGET")
+[ -n "$WORKTREE_ROOT" ] || exit 0
 
 DB=$(tmb_db_path 2>/dev/null || true)
 [ -n "$DB" ] || exit 0
 tmb_have_sqlite || exit 0
 
-# Resolve the active task by worktree slug (slug = branch_id without the type/ prefix,
-# or more precisely the last component of branch_id: feat/<slug>).
-SAFE_SLUG=$(tmb_sql_quote "$WORKTREE_SLUG")
+# Resolve the active task (worktree branch → slug → transcript), no status filter.
+TASK_ID=$(tmb_resolve_task_id_for_target "$TARGET" "$INPUT" "$DB")
+[ -n "$TASK_ID" ] || exit 0
+
 SPEC_BODY=$(tmb_sqlite_ro "$DB" "
   SELECT spec_body FROM tasks
-   WHERE branch_id LIKE '%/${SAFE_SLUG}'
-     AND status IN ('pending','running','completed')
-   ORDER BY id DESC
+   WHERE id = ${TASK_ID}
    LIMIT 1;
 " 2>/dev/null || true)
 
@@ -113,10 +107,7 @@ done <<< "$FILES_SECTION"
 # Fail open: no parseable paths.
 [ "${#ALLOWED_DIRS[@]}" -gt 0 ] || exit 0
 
-# Normalize target to a repo-relative path for comparison.
-# Strip the worktree root prefix so we can compare against spec paths.
-WORKTREE_ROOT=$(echo "$PWD" | sed -E 's|(.*/.claude/worktrees/[^/]+).*|\1|')
-
+# Normalize target to a repo-relative path for comparison (strip WORKTREE_ROOT).
 case "$TARGET" in
   /*) ABS_TARGET="$TARGET" ;;
   *)  ABS_TARGET="${PWD}/${TARGET}" ;;

--- a/tests/l3-integration/hooks/swe-boundary.test.sh
+++ b/tests/l3-integration/hooks/swe-boundary.test.sh
@@ -44,11 +44,18 @@ sqlite3 "$DB" "
   INSERT INTO issues VALUES (1, 'test', '', 'open', datetime('now'), datetime('now'));
   INSERT INTO tasks VALUES (10, 1, 'feat/my-feature', 'pending', '', 0);
   INSERT INTO tasks VALUES (11, 1, 'feat/prompt-task', 'pending', '', 1);
+  INSERT INTO tasks VALUES (12, 1, 'fix/failed-pb', 'failed', '', 1);
+  INSERT INTO tasks VALUES (13, 1, 'fix/failed-nonpb', 'failed', '', 0);
 "
 
 # Worktree for the prompt-bearing task (slug matches feat/prompt-task).
 WT_PROMPT="$WT_ROOT/prompt-task"
 mkdir -p "$WT_PROMPT"
+
+# Worktrees for the failed-status tasks (slug matches branch_id suffix).
+WT_FAILED_PB="$WT_ROOT/failed-pb"
+WT_FAILED_NONPB="$WT_ROOT/failed-nonpb"
+mkdir -p "$WT_FAILED_PB" "$WT_FAILED_NONPB"
 
 run_hook_swe() {
   local input="$1"
@@ -292,6 +299,21 @@ out=$(cd "$WT_UNKNOWN" && echo "$(make_edit_no_transcript swe "$WT_UNKNOWN/agent
 assert_contains "$out" '"permissionDecision":"deny"' "no matching task slug should deny prompt-surface edit"
 
 # ===========================================================================
+# Rule (d) — failed-status + absolute target + PWD NOT in worktree (#597)
+# The regression: a prompt_bearing=1 task whose row is `failed`, edited via an
+# ABSOLUTE path while $PWD is outside any worktree, was wrongly denied because
+# WORKTREE_ROOT came from $PWD and the slug query filtered on transient status.
+# ===========================================================================
+
+test_case "(d/597) failed-status prompt_bearing=1, absolute target, PWD outside worktree: ALLOWED"
+out=$(cd "$NONWT_DIR" && echo "$(make_edit_no_transcript swe "$WT_FAILED_PB/agents/swe.md")" | bash "$HOOK" 2>&1 || true)
+assert_not_contains "$out" '"permissionDecision":"deny"' "failed-status prompt_bearing=1 via absolute target should be allowed"
+
+test_case "(d/597) failed-status prompt_bearing=0, absolute target, PWD outside worktree: DENIED"
+out=$(cd "$NONWT_DIR" && echo "$(make_edit_no_transcript swe "$WT_FAILED_NONPB/agents/swe.md")" | bash "$HOOK" 2>&1 || true)
+assert_contains "$out" '"permissionDecision":"deny"' "failed-status prompt_bearing=0 via absolute target should still be denied"
+
+# ===========================================================================
 # Rule (e): Bash write-forms targeting prompt surfaces
 # ===========================================================================
 
@@ -364,8 +386,9 @@ test_case "(e) SWE redirect > to non-prompt file: NOT denied"
 out=$(run_hook_swe "$(make_bash_with_transcript swe 'echo "content" > src/index.ts' 10)")
 assert_not_contains "$out" '"permissionDecision":"deny"' "redirect to non-prompt file should not be denied by rule (e)"
 
-test_case "(e) SWE redirect > to agents/swe.md with prompt_bearing=1: ALLOWED"
-out=$(run_hook_swe "$(make_bash_with_transcript swe 'echo "content" > agents/swe.md' 11)")
+test_case "(e) SWE redirect > to agents/swe.md with prompt_bearing=1 (transcript resolves task): ALLOWED"
+# Run from a non-worktree PWD so the transcript is the resolver (no slug match).
+out=$(run_hook_swe_pwd "$(make_bash_with_transcript swe 'echo "content" > agents/swe.md' 11)" "$NONWT_DIR")
 assert_not_contains "$out" '"permissionDecision":"deny"' "prompt_bearing=1 task should allow Bash write to prompt surface"
 
 test_case "(e) SWE sed -i on CLAUDE.md via slug fallback (prompt_bearing=1): ALLOWED"

--- a/tests/l3-integration/hooks/swe-scope-fence.test.sh
+++ b/tests/l3-integration/hooks/swe-scope-fence.test.sh
@@ -250,9 +250,21 @@ assert_contains "$out" '"permissionDecision":"deny"' "editing a different root f
 NON_WT_DIR="$TMPDIR/non-worktree"
 mkdir -p "$NON_WT_DIR"
 
-test_case "non-worktree: hook passes through when PWD is not a worktree"
+test_case "non-worktree: hook passes through when PWD is not a worktree (relative target)"
 out=$( (cd "$NON_WT_DIR" && echo "$(make_edit_input "anything/file.ts")" | bash "$HOOK" 2>&1) || true)
-assert_not_contains "$out" '"permissionDecision":"deny"' "non-worktree PWD should not be blocked"
+assert_not_contains "$out" '"permissionDecision":"deny"' "non-worktree PWD + relative target should not be blocked"
+
+# ===========================================================================
+# Worktree derived from the TARGET when PWD is outside any worktree (#597)
+# ===========================================================================
+
+test_case "target-derived: absolute in-scope target resolves the worktree from PWD-outside: passes"
+out=$( (cd "$NON_WT_DIR" && echo "$(make_edit_input "$WT_A/scripts/hooks/my-hook.sh")" | bash "$HOOK" 2>&1) || true)
+assert_not_contains "$out" '"permissionDecision":"deny"' "in-scope absolute target should pass even when PWD is outside a worktree"
+
+test_case "target-derived: absolute out-of-scope target resolves the worktree from PWD-outside: denied"
+out=$( (cd "$NON_WT_DIR" && echo "$(make_edit_input "$WT_A/src/api/handler.ts")" | bash "$HOOK" 2>&1) || true)
+assert_contains "$out" '"permissionDecision":"deny"' "out-of-scope absolute target should be denied even when PWD is outside a worktree"
 
 # ===========================================================================
 # Non-Edit/Write tools are ignored


### PR DESCRIPTION
Closes #597.

Fixes the swe-boundary / scope-fence `prompt_bearing` gate that wrongly denied legit prompt-bearing edits.

- Shared resolver in `scripts/hooks/lib/query-task.sh`: resolves the task by the worktree's checked-out branch (target-derived, exact `branch_id` match), no transient-status filter.
- Applied in `swe-boundary.sh` (rule d + Bash mirror) and `swe-scope-fence.sh`.
- Tests: swe-boundary **65/65**, scope-fence **24/24** (incl. new failed-status + absolute-path ALLOW case).

Surfaced live this session: a prompt_bearing=1 task in `failed` status, edited via absolute path, was denied because the worktree was derived from `$PWD` and the slug query filtered on status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)