### PR TITLE
✨ feat(hooks): TMB attribution footer on PR/issue/MR bodies (#601)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -286,6 +286,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/attribution-footer.sh",
+            "timeout": 15
+          }
+        ]
       }
     ],
     "Stop": [

--- a/scripts/hooks/attribution-footer.sh
+++ b/scripts/hooks/attribution-footer.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# PostToolUse hook on Bash — normalizes the TMB attribution footer on PR/issue/MR
+# bodies after a successful create command (#601).
+#
+# After `gh pr create` / `gh issue create` / `glab mr create` / `glab issue create`
+# succeeds, the artifact's URL/number is parsed from the tool response, the current
+# body is fetched, and the body is rewritten to carry exactly the TMB footer:
+#   - any bare "🤖 Generated with [Claude Code]…" line lacking "powered by Bro"
+#     is stripped,
+#   - the TMB footer is appended if absent (idempotent).
+# The writeback uses `edit`/`update` (never `create`), so it can't re-trigger.
+#
+# Bodies only — never commits (amend would change SHAs and break atomic-close
+# tracking). Best-effort throughout: any missing tool, auth failure, or absent
+# URL makes the hook a silent no-op (exit 0).
+#
+# The `normalize_footer` function is pure and side-effect-free so tests can source
+# this file and exercise it directly without network.
+
+TMB_FOOTER='🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)'
+
+# normalize_footer — read body on stdin, write normalized body to stdout.
+# Pure: strips bare Claude-Code footer lines, ensures exactly the TMB footer.
+normalize_footer() {
+  local body stripped
+  body=$(cat)
+
+  # Drop any line carrying the Claude Code footer marker that is NOT the TMB
+  # footer (i.e. lacks "powered by Bro"). The TMB footer survives this pass.
+  stripped=$(printf '%s' "$body" | awk '
+    /🤖 Generated with \[Claude Code\]/ && $0 !~ /powered by Bro/ { next }
+    { print }
+  ')
+
+  # Already carries the exact TMB footer → idempotent, return as-is.
+  if printf '%s' "$stripped" | grep -qF -- "$TMB_FOOTER"; then
+    printf '%s' "$stripped"
+    return 0
+  fi
+
+  # Trim trailing blank lines, then append a blank line + the TMB footer.
+  stripped=$(printf '%s' "$stripped" | awk '
+    { lines[NR] = $0 }
+    END {
+      last = NR
+      while (last > 0 && lines[last] ~ /^[[:space:]]*$/) last--
+      for (i = 1; i <= last; i++) print lines[i]
+    }
+  ')
+
+  if [ -n "$stripped" ]; then
+    printf '%s\n\n%s' "$stripped" "$TMB_FOOTER"
+  else
+    printf '%s' "$TMB_FOOTER"
+  fi
+}
+
+# When sourced (e.g. by the test), expose normalize_footer and stop here.
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+  return 0 2>/dev/null || true
+fi
+
+set -uo pipefail
+
+INPUT=$(cat 2>/dev/null) || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
+[ "$TOOL_NAME" = "Bash" ] || exit 0
+
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
+RESP=$(printf '%s' "$INPUT" | jq -r '.tool_response | if type == "string" then . else tojson end' 2>/dev/null)
+[ -n "$CMD" ] || exit 0
+
+# Classify the creation command at a word boundary and extract the created
+# number from a URL in the tool response. KIND is one of: gh-pr gh-issue
+# glab-mr glab-issue. NUMBER is the parsed artifact number.
+KIND=""
+NUMBER=""
+if printf '%s' "$CMD" | grep -Eq '(^|[^[:alnum:]_-])gh[[:space:]]+pr[[:space:]]+create([^[:alnum:]_-]|$)'; then
+  KIND="gh-pr"
+  NUMBER=$(printf '%s' "$RESP" | grep -oE 'https://[^[:space:]"]+/pull/[0-9]+' | grep -oE '[0-9]+$' | head -n1)
+elif printf '%s' "$CMD" | grep -Eq '(^|[^[:alnum:]_-])gh[[:space:]]+issue[[:space:]]+create([^[:alnum:]_-]|$)'; then
+  KIND="gh-issue"
+  NUMBER=$(printf '%s' "$RESP" | grep -oE 'https://[^[:space:]"]+/issues/[0-9]+' | grep -oE '[0-9]+$' | head -n1)
+elif printf '%s' "$CMD" | grep -Eq '(^|[^[:alnum:]_-])glab[[:space:]]+mr[[:space:]]+create([^[:alnum:]_-]|$)'; then
+  KIND="glab-mr"
+  NUMBER=$(printf '%s' "$RESP" | grep -oE 'https://[^[:space:]"]+/-/merge_requests/[0-9]+' | grep -oE '[0-9]+$' | head -n1)
+elif printf '%s' "$CMD" | grep -Eq '(^|[^[:alnum:]_-])glab[[:space:]]+issue[[:space:]]+create([^[:alnum:]_-]|$)'; then
+  KIND="glab-issue"
+  NUMBER=$(printf '%s' "$RESP" | grep -oE 'https://[^[:space:]"]+/-/issues/[0-9]+' | grep -oE '[0-9]+$' | head -n1)
+fi
+
+[ -n "$KIND" ] || exit 0
+[ -n "$NUMBER" ] || exit 0
+
+# Fetch current body (best-effort). Resolve the binary; missing → no-op.
+ORIG=""
+case "$KIND" in
+  gh-pr)
+    command -v gh >/dev/null 2>&1 || exit 0
+    ORIG=$(gh pr view "$NUMBER" --json body -q .body 2>/dev/null) || exit 0
+    ;;
+  gh-issue)
+    command -v gh >/dev/null 2>&1 || exit 0
+    ORIG=$(gh issue view "$NUMBER" --json body -q .body 2>/dev/null) || exit 0
+    ;;
+  glab-mr)
+    command -v glab >/dev/null 2>&1 || exit 0
+    ORIG=$(glab mr view "$NUMBER" 2>/dev/null) || exit 0
+    ;;
+  glab-issue)
+    command -v glab >/dev/null 2>&1 || exit 0
+    ORIG=$(glab issue view "$NUMBER" 2>/dev/null) || exit 0
+    ;;
+esac
+
+NEW=$(printf '%s' "$ORIG" | normalize_footer)
+
+# No change → no write.
+[ "$NEW" = "$ORIG" ] && exit 0
+
+case "$KIND" in
+  gh-pr)      gh pr edit "$NUMBER" --body "$NEW" >/dev/null 2>&1 || true ;;
+  gh-issue)   gh issue edit "$NUMBER" --body "$NEW" >/dev/null 2>&1 || true ;;
+  glab-mr)    glab mr update "$NUMBER" --description "$NEW" >/dev/null 2>&1 || true ;;
+  glab-issue) glab issue update "$NUMBER" --description "$NEW" >/dev/null 2>&1 || true ;;
+esac
+
+exit 0

--- a/tests/l3-integration/hooks/attribution-footer.test.sh
+++ b/tests/l3-integration/hooks/attribution-footer.test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Tests for scripts/hooks/attribution-footer.sh (#601).
+#
+# The hook normalizes the TMB attribution footer on PR/issue/MR bodies after a
+# successful create command. We exercise:
+#   - normalize_footer (sourced directly): idempotency, bare-CC→TMB rewrite,
+#     already-TMB unchanged, empty/no-op bodies.
+#   - the full hook end-to-end with stubbed gh/glab on PATH (no network): a
+#     create command rewrites the body via edit/update; a non-create or
+#     failed-create command makes no edit call.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../lib/assert.sh"
+PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
+HOOK="$PLUGIN_ROOT/scripts/hooks/attribution-footer.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq unavailable"; exit 0; }
+
+TMB_FOOTER='🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)'
+BARE_CC='🤖 Generated with [Claude Code](https://claude.com/claude-code)'
+
+# ── normalize_footer (pure function, sourced) ────────────────────────────────
+# shellcheck source=scripts/hooks/attribution-footer.sh
+. "$HOOK"
+
+test_case "bare Claude-Code footer is rewritten to the TMB footer"
+OUT=$(printf '%s\n\n%s' "Fixes the thing." "$BARE_CC" | normalize_footer)
+assert_contains "$OUT" "$TMB_FOOTER" "TMB footer present after rewrite"
+assert_eq "$TMB_FOOTER" "$(printf '%s' "$OUT" | tail -n1)" "body ends with exactly the TMB footer"
+test_case "bare-CC line is stripped (not left alongside TMB footer)"
+BARE_ONLY=$(printf '%s\n' "$OUT" | grep -F -- "$BARE_CC" | grep -vF -- 'powered by' || true)
+assert_eq "" "$BARE_ONLY" "no bare Claude-Code-only line remains"
+
+test_case "normalize_footer is idempotent (twice == once)"
+ONCE=$(printf '%s\n\n%s' "Body text." "$BARE_CC" | normalize_footer)
+TWICE=$(printf '%s' "$ONCE" | normalize_footer)
+assert_eq "$ONCE" "$TWICE" "applying normalize twice equals once"
+
+test_case "body already carrying the TMB footer is unchanged"
+ALREADY=$(printf '%s\n\n%s' "Already attributed." "$TMB_FOOTER")
+assert_eq "$ALREADY" "$(printf '%s' "$ALREADY" | normalize_footer)" "TMB-footer body unchanged"
+
+test_case "plain body gains the TMB footer"
+PLAIN=$(printf '%s' "Just a description." | normalize_footer)
+assert_contains "$PLAIN" "$TMB_FOOTER" "TMB footer appended to plain body"
+assert_contains "$PLAIN" "Just a description." "original body text preserved"
+
+# ── full hook end-to-end with stubbed gh/glab ────────────────────────────────
+STUB_DIR=$(mktemp -d)
+EDIT_LOG="$STUB_DIR/edit.log"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+# gh stub: `gh pr view N --json body -q .body` prints a bare-CC body;
+# `gh pr edit N --body X` records the body to EDIT_LOG.
+cat > "$STUB_DIR/gh" <<STUB
+#!/usr/bin/env bash
+case "\$1 \$2" in
+  "pr view"|"issue view")
+    printf '%s\n\n%s' "Stub body." '$BARE_CC'
+    ;;
+  "pr edit"|"issue edit")
+    # last arg is the body
+    body="\${!#}"
+    printf '%s' "\$body" > "$EDIT_LOG"
+    ;;
+esac
+exit 0
+STUB
+chmod +x "$STUB_DIR/gh"
+
+run_hook() { printf '%s' "$1" | PATH="$STUB_DIR:$PATH" bash "$HOOK"; }
+
+test_case "gh pr create with a pull URL triggers an edit carrying the TMB footer"
+rm -f "$EDIT_LOG"
+PAYLOAD=$(jq -cn '{
+  tool_name: "Bash",
+  tool_input: { command: "gh pr create --fill" },
+  tool_response: "https://github.com/o/r/pull/42\n"
+}')
+run_hook "$PAYLOAD"
+if [ -f "$EDIT_LOG" ]; then
+  EDITED=$(cat "$EDIT_LOG")
+  assert_contains "$EDITED" "$TMB_FOOTER" "edit body carries the TMB footer"
+else
+  _fail "expected gh edit to be called"
+fi
+
+test_case "gh issue create with an issues URL triggers an edit"
+rm -f "$EDIT_LOG"
+PAYLOAD=$(jq -cn '{
+  tool_name: "Bash",
+  tool_input: { command: "gh issue create --title x" },
+  tool_response: "https://github.com/o/r/issues/7\n"
+}')
+run_hook "$PAYLOAD"
+assert_eq "true" "$([ -f "$EDIT_LOG" ] && echo true || echo false)" "gh issue edit called"
+
+test_case "non-create Bash command makes no edit call"
+rm -f "$EDIT_LOG"
+PAYLOAD=$(jq -cn '{
+  tool_name: "Bash",
+  tool_input: { command: "gh pr view 42" },
+  tool_response: "some output\n"
+}')
+run_hook "$PAYLOAD"
+assert_eq "false" "$([ -f "$EDIT_LOG" ] && echo true || echo false)" "no edit on non-create command"
+
+test_case "create command but no URL in response (failed create) → no edit"
+rm -f "$EDIT_LOG"
+PAYLOAD=$(jq -cn '{
+  tool_name: "Bash",
+  tool_input: { command: "gh pr create --fill" },
+  tool_response: "error: could not create pull request\n"
+}')
+run_hook "$PAYLOAD"
+assert_eq "false" "$([ -f "$EDIT_LOG" ] && echo true || echo false)" "no edit when create produced no URL"
+
+test_case "non-Bash tool is ignored"
+rm -f "$EDIT_LOG"
+PAYLOAD=$(jq -cn '{
+  tool_name: "Read",
+  tool_input: { command: "gh pr create" },
+  tool_response: "https://github.com/o/r/pull/9"
+}')
+run_hook "$PAYLOAD"
+assert_eq "false" "$([ -f "$EDIT_LOG" ] && echo true || echo false)" "no edit for non-Bash tool"
+
+# ── glab parity: stub glab, mr create → update ───────────────────────────────
+cat > "$STUB_DIR/glab" <<STUB
+#!/usr/bin/env bash
+case "\$1 \$2" in
+  "mr view"|"issue view")
+    printf '%s\n\n%s' "Glab body." '$BARE_CC'
+    ;;
+  "mr update"|"issue update")
+    body="\${!#}"
+    printf '%s' "\$body" > "$EDIT_LOG"
+    ;;
+esac
+exit 0
+STUB
+chmod +x "$STUB_DIR/glab"
+
+test_case "glab mr create with a merge_requests URL triggers an update"
+rm -f "$EDIT_LOG"
+PAYLOAD=$(jq -cn '{
+  tool_name: "Bash",
+  tool_input: { command: "glab mr create --fill" },
+  tool_response: "https://gitlab.com/o/r/-/merge_requests/13\n"
+}')
+run_hook "$PAYLOAD"
+if [ -f "$EDIT_LOG" ]; then
+  assert_contains "$(cat "$EDIT_LOG")" "$TMB_FOOTER" "glab update carries the TMB footer"
+else
+  _fail "expected glab update to be called"
+fi
+
+summarize


### PR DESCRIPTION
Closes #601.

PostToolUse Bash hook `attribution-footer.sh`: after a successful `gh pr/issue create` or `glab mr/issue create`, normalizes the body to carry the TMB footer — `🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)` — stripping any bare Claude-Code-only footer. Idempotent; writes back via `edit`/`update` (no re-trigger).

- **Bodies only** — commits untouched (an `--amend` would change the SHA after swe reports it, breaking atomic-close tracking).
- git + gh + glab parity; best-effort (no jq/gh/glab or failed create → silent no-op).
- Tests: 13/13 (idempotency, bare-CC→TMB, gh/glab create→edit, non-create + failed-create no-ops). shellcheck + hooks-executable green.

Footer text is a constant for v1; config-key override noted as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)