### PR TITLE
🐛 fix(hooks): scope no-source-edit Rule 1 to the managed repo (#592)

### DIFF
--- a/scripts/hooks/no-source-edit-from-main.sh
+++ b/scripts/hooks/no-source-edit-from-main.sh
@@ -14,6 +14,10 @@
 #   - Normalized agent role == 'swe' (non-isolated SWE running in main checkout)
 #   Enforcement surfaces (scripts/hooks/, hooks/hooks.json) are ALWAYS denied from
 #   main, even for swe — they sit above the swe permit and are never re-opened.
+#   Managed-repo scope: in a multi-repo workspace Rule 1 only guards the managed
+#   product repo (plugin_config tmb_default_repo); absolute targets in sibling
+#   repos are allowed. Empty/'.' tmb_default_repo guards the whole tree (the
+#   normal single-repo user project).
 #
 # Rule 2 — Bash write-form targeting a prompt surface from main checkout:
 #   Denied for every agent identity (bro, subagent, swe, unknown) when outside a
@@ -229,6 +233,32 @@ TARGET=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.notebook_pa
 case "$TARGET" in
   */.claude/worktrees/*|.claude/worktrees/*) exit 0 ;;
 esac
+
+# Managed-repo scope (#592): in a multi-repo workspace, Rule 1 must only guard
+# the managed product repo (plugin_config tmb_default_repo), not its siblings.
+# The DB lives at <workspace_root>/.claude/<plugin>/trajectory.db, so the
+# workspace root is three levels above DB_PATH and the managed repo is
+# <workspace_root>/<tmb_default_repo>. An absolute target outside that subtree
+# belongs to a sibling repo and is allowed. When tmb_default_repo is empty or
+# '.' (the normal single-repo user project), the whole tree is guarded as before.
+DEFAULT_REPO=""
+if command -v sqlite3 >/dev/null 2>&1; then
+  DEFAULT_REPO=$(sqlite3 -readonly -cmd '.timeout 500' "$DB_PATH" \
+    "SELECT json_extract(value_json, '\$') FROM plugin_config WHERE key='tmb_default_repo' LIMIT 1;" \
+    2>/dev/null || true)
+fi
+if [ -n "$DEFAULT_REPO" ] && [ "$DEFAULT_REPO" != "." ]; then
+  case "$TARGET" in
+    /*)
+      WORKSPACE_ROOT=$(dirname "$(dirname "$(dirname "$DB_PATH")")")
+      MANAGED_ROOT="$WORKSPACE_ROOT/$DEFAULT_REPO"
+      case "$TARGET" in
+        "$MANAGED_ROOT"/*) : ;;       # inside the managed repo — keep guarding
+        *) exit 0 ;;                  # sibling repo — outside Rule 1 scope
+      esac
+      ;;
+  esac
+fi
 
 # Enforcement surfaces: deny before any allowlist entry is evaluated.
 # No pattern — including *.md or docs/ — can re-open these paths from

--- a/tests/l3-integration/hooks/no-source-edit-from-main.test.sh
+++ b/tests/l3-integration/hooks/no-source-edit-from-main.test.sh
@@ -347,4 +347,33 @@ out=$(run_hook "$(input_with_agent 'Edit' 'src/foo.ts' 'bro')")
 assert_not_contains "$out" 'bashrc' "deny message must not mention bashrc"
 assert_contains "$out" 'non-isolated' "deny message mentions non-isolated mode"
 
+# ---- Managed-repo scope (#592): multi-repo workspace ----
+# DB lives at <workspace_root>/.claude/<plugin>/trajectory.db, so the hook
+# derives the workspace root three levels above DB_PATH and the managed repo as
+# <workspace_root>/<tmb_default_repo>. Build that exact layout so MANAGED_ROOT
+# is deterministic.
+WS_ROOT="$TMPDIR/ws"
+MANAGED_DB="$WS_ROOT/.claude/tmb/trajectory.db"
+mkdir -p "$WS_ROOT/.claude/tmb"
+sqlite3 "$MANAGED_DB" "CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT);"
+sqlite3 "$MANAGED_DB" "INSERT INTO plugin_config (key, value_json) VALUES ('tmb_default_repo', '\"plugin\"');"
+
+run_hook_db() {
+  echo "$2" | env TRAJECTORY_DB_PATH="$1" bash "$HOOK" 2>&1 || true
+}
+
+test_case "managed repo scope + edit inside managed repo from main: BLOCK"
+out=$(run_hook_db "$MANAGED_DB" "$(input 'Edit' "$WS_ROOT/plugin/src/foo.ts" "$TRANSCRIPT_BRO")")
+assert_contains "$out" '"permissionDecision":"deny"' "source edit inside the managed repo still denied from main"
+
+test_case "managed repo scope + edit in sibling repo from main: ALLOWED"
+out=$(run_hook_db "$MANAGED_DB" "$(input 'Edit' "$WS_ROOT/benchmarks/src/foo.ts" "$TRANSCRIPT_BRO")")
+assert_eq "" "$out" "sibling-repo source edit allowed — outside managed-repo scope"
+
+test_case "single-repo project (empty tmb_default_repo) + src/foo.ts: BLOCK (whole tree guarded)"
+SINGLE_DB="$TMPDIR/single.db"
+sqlite3 "$SINGLE_DB" "CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT);"
+out=$(run_hook_db "$SINGLE_DB" "$(input 'Edit' '/some/project/src/foo.ts' "$TRANSCRIPT_BRO")")
+assert_contains "$out" '"permissionDecision":"deny"' "empty tmb_default_repo guards the whole tree as before"
+
 summarize


### PR DESCRIPTION
Closes #592.

no-source-edit-from-main.sh Rule 1 now scopes to the managed repo (`tmb_default_repo`): only guards targets under <workspace_root>/<tmb_default_repo>, allowing sibling-repo edits in a multi-repo workspace. Empty/'.' tmb_default_repo preserves whole-tree guarding for single-repo projects. Fails closed on any sqlite3 error.

pr-reviewer: PASS (id 83). l3 70/70, shellcheck clean.