### PR TITLE
🐛 fix(hooks): fail safe on stale-schema trajectory.db in swe-boundary gate (#596)

### DIFF
--- a/scripts/hooks/lib/query-task.sh
+++ b/scripts/hooks/lib/query-task.sh
@@ -30,6 +30,27 @@ _TMB_DB_PATH_CACHE=""
 #      explicitly to pin the resolution.
 # Prints the path only if the file exists; non-zero exit if no DB found.
 # Memoizes the result in _TMB_DB_PATH_CACHE for the lifetime of the process.
+# tmb_db_schema_current <db>
+# Returns 0 when <db> carries the current TMB schema, non-zero otherwise.
+# Cheap probe: the tasks table must have a prompt_bearing column — the column
+# the swe-boundary gate actually reads. A legacy ~/.claude/tmb/trajectory.db
+# from a prior schema lacks it; querying such a DB returns empty and would
+# default prompt_bearing to 0, silently denying a legitimate prompt edit.
+# Treat a schema-mismatched DB as UNRESOLVED instead.
+# When sqlite3 is unavailable the caller cannot query anyway; report current
+# (0) so resolution is not blocked on a missing tool.
+tmb_db_schema_current() {
+  local db="${1:-}"
+  [ -n "$db" ] && [ -f "$db" ] || return 1
+  tmb_have_sqlite || return 0
+  local cols
+  cols=$(tmb_sqlite_ro "$db" "SELECT name FROM pragma_table_info('tasks');")
+  case "$cols" in
+    *prompt_bearing*) return 0 ;;
+  esac
+  return 1
+}
+
 tmb_db_path() {
   if [ -n "$_TMB_DB_PATH_CACHE" ]; then
     echo "$_TMB_DB_PATH_CACHE"
@@ -60,7 +81,12 @@ tmb_db_path() {
       break
     fi
     local candidate="$dir/.claude/$plugin_name/trajectory.db"
-    [ -f "$candidate" ] && candidates+=("$candidate")
+    # Schema-mismatch fail-safe: a candidate whose tasks table lacks the
+    # prompt_bearing column is a stale legacy DB. Skip it rather than adopt
+    # it and silently default prompt_bearing to 0.
+    if [ -f "$candidate" ] && tmb_db_schema_current "$candidate"; then
+      candidates+=("$candidate")
+    fi
     dir="$(dirname "$dir")"
   done
   if [ ${#candidates[@]} -gt 0 ]; then
@@ -75,7 +101,9 @@ tmb_db_path() {
     ws=$(head -1 "$sentinel" 2>/dev/null)
     if [ -n "$ws" ]; then
       local sentinel_db="$ws/.claude/$plugin_name/trajectory.db"
-      if [ -f "$sentinel_db" ]; then
+      # Same fail-safe on the sentinel path: a stale-schema sentinel DB is
+      # treated as unresolved rather than queried-and-defaulted-to-0.
+      if [ -f "$sentinel_db" ] && tmb_db_schema_current "$sentinel_db"; then
         _TMB_DB_PATH_CACHE="$sentinel_db"
         echo "$_TMB_DB_PATH_CACHE"
         return 0

--- a/scripts/hooks/write-active-workspace-sentinel.sh
+++ b/scripts/hooks/write-active-workspace-sentinel.sh
@@ -15,6 +15,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/resolve-plugin-name.sh
 . "$SCRIPT_DIR/../lib/resolve-plugin-name.sh"
+# shellcheck source=scripts/hooks/lib/query-task.sh
+. "$SCRIPT_DIR/lib/query-task.sh"
 
 # Cwd walk-up DB resolution. Skips the sentinel-fallback step that the
 # regular tmb_db_path helper uses, breaking the circular dependency.
@@ -43,8 +45,18 @@ PLUGIN_NAME=$(tmb_resolve_plugin_name)
 DB_PATH=$(resolve_db_cwd_only "$PLUGIN_NAME") || exit 0
 [ -z "$DB_PATH" ] && exit 0
 
+# Schema-mismatch guard: never adopt a stale legacy DB (no prompt_bearing
+# column). A sentinel pointing at a legacy ~/.claude/<plugin> DB is exactly
+# what silently denied prompt_bearing=1 edits. Require the current schema.
+tmb_db_schema_current "$DB_PATH" || exit 0
+
 # Workspace = dirname x 3 of DB path: <ws>/.claude/<plugin>/trajectory.db -> <ws>/.claude/<plugin> -> <ws>/.claude -> <ws>
 WORKSPACE=$(dirname "$(dirname "$(dirname "$DB_PATH")")")
+
+# Never record $HOME as the workspace. A DB resolved to $HOME/.claude/<plugin>
+# is the legacy home DB; writing it would re-poison every subagent that reads
+# the sentinel.
+[ "$WORKSPACE" = "$HOME" ] && exit 0
 
 SENTINEL_DIR="$HOME/.claude"
 SENTINEL="$SENTINEL_DIR/${PLUGIN_NAME}-active-workspace"

--- a/tests/l3-integration/hooks/swe-boundary.test.sh
+++ b/tests/l3-integration/hooks/swe-boundary.test.sh
@@ -423,4 +423,119 @@ test_case "(e/fp) git commit -m message mentioning agents/swe.md: NOT denied"
 out=$(run_hook_swe "$(make_bash_with_transcript swe 'git commit -m "touch agents/swe.md"' 10)")
 assert_not_contains "$out" '"permissionDecision":"deny"' "commit message mentioning prompt path should not be denied"
 
+# ===========================================================================
+# Layer 1 — schema-mismatch fail-safe (#596)
+# A stale legacy ~/.claude/tmb/trajectory.db (old schema, no prompt_bearing
+# column) up-tree from the hook's cwd must be treated as UNRESOLVED, not
+# queried-and-defaulted-to-0. The hook resolves the live DB instead.
+# These cases do NOT set TRAJECTORY_DB_PATH (that override bypasses walk-up);
+# they exercise the cwd walk-up + sentinel resolution directly.
+# ===========================================================================
+
+# Build a fake HOME containing a stale legacy DB, plus a real project workspace
+# (current schema) one level under it with a worktree for a prompt_bearing=1 task.
+SCHEMA_HOME="$TMPDIR/schema-home"
+mkdir -p "$SCHEMA_HOME/.claude/tmb"
+sqlite3 "$SCHEMA_HOME/.claude/tmb/trajectory.db" "
+  CREATE TABLE tasks (
+    id INTEGER PRIMARY KEY,
+    issue_id INTEGER NOT NULL,
+    branch_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    spec_body TEXT NOT NULL DEFAULT ''
+  );
+  INSERT INTO tasks VALUES (10, 1, 'feat/prompt-task', 'pending', '');
+"
+
+# Live project workspace under that HOME, with the current schema.
+LIVE_WS="$SCHEMA_HOME/project"
+mkdir -p "$LIVE_WS/.claude/tmb"
+sqlite3 "$LIVE_WS/.claude/tmb/trajectory.db" "
+  CREATE TABLE tasks (
+    id INTEGER PRIMARY KEY,
+    issue_id INTEGER NOT NULL,
+    branch_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    spec_body TEXT NOT NULL DEFAULT '',
+    prompt_bearing INTEGER NOT NULL DEFAULT 0
+  );
+  INSERT INTO tasks VALUES (10, 1, 'feat/prompt-task', 'pending', '', 1);
+"
+LIVE_WT_PROMPT="$LIVE_WS/.claude/worktrees/prompt-task"
+mkdir -p "$LIVE_WT_PROMPT/agents"
+
+test_case "(L1) stale legacy DB up-tree, live DB at workspace: prompt_bearing=1 edit ALLOWED"
+out=$(cd "$LIVE_WT_PROMPT" && \
+  echo "$(make_edit_no_transcript swe "$LIVE_WT_PROMPT/agents/swe.md")" | \
+  HOME="$SCHEMA_HOME" env -u TRAJECTORY_DB_PATH bash "$HOOK" 2>&1 || true)
+assert_not_contains "$out" '"permissionDecision":"deny"' "live current-schema DB should be resolved, prompt edit allowed"
+
+# The schema probe rejects the legacy DB and accepts the current-schema one.
+test_case "(L1) schema probe: rejects legacy DB"
+probe_legacy=$( . "$PLUGIN_ROOT/scripts/hooks/lib/query-task.sh"; \
+  if tmb_db_schema_current "$SCHEMA_HOME/.claude/tmb/trajectory.db"; then echo current; else echo stale; fi )
+assert_eq "stale" "$probe_legacy" "legacy DB (no prompt_bearing) probed as stale"
+
+test_case "(L1) schema probe: accepts current-schema DB"
+probe_live=$( . "$PLUGIN_ROOT/scripts/hooks/lib/query-task.sh"; \
+  if tmb_db_schema_current "$LIVE_WS/.claude/tmb/trajectory.db"; then echo current; else echo stale; fi )
+assert_eq "current" "$probe_live" "current-schema DB probed as current"
+
+# The #596 failure mode exactly: hook cwd=$HOME, walk-up finds nothing, the
+# sentinel points at $HOME, and $HOME's only DB is the stale legacy one. The
+# resolver must NOT adopt the stale sentinel DB (would default prompt_bearing
+# to 0 and silently deny). tmb_db_path must report unresolved.
+test_case "(L1) stale sentinel DB at \$HOME is NOT adopted by tmb_db_path"
+SENTINEL_HOME="$TMPDIR/sentinel-stale-home"
+mkdir -p "$SENTINEL_HOME/.claude/tmb"
+sqlite3 "$SENTINEL_HOME/.claude/tmb/trajectory.db" "
+  CREATE TABLE tasks (id INTEGER PRIMARY KEY, branch_id TEXT, status TEXT);
+"
+printf '%s\n' "$SENTINEL_HOME" > "$SENTINEL_HOME/.claude/tmb-active-workspace"
+resolved=$( cd "$SENTINEL_HOME" && \
+  HOME="$SENTINEL_HOME" env -u TRAJECTORY_DB_PATH \
+  bash -c '. "'"$PLUGIN_ROOT"'/scripts/hooks/lib/query-task.sh"; tmb_db_path || true' )
+assert_eq "" "$resolved" "stale sentinel DB must be treated as unresolved"
+
+# ===========================================================================
+# Layer 2 — sentinel writer hardening (#596)
+# ===========================================================================
+SENTINEL_WRITER="$PLUGIN_ROOT/scripts/hooks/write-active-workspace-sentinel.sh"
+
+test_case "(L2) sentinel writer refuses to record \$HOME (legacy home DB)"
+FAKE_HOME="$TMPDIR/l2-home"
+mkdir -p "$FAKE_HOME/.claude/tmb"
+sqlite3 "$FAKE_HOME/.claude/tmb/trajectory.db" "
+  CREATE TABLE tasks (id INTEGER PRIMARY KEY, prompt_bearing INTEGER DEFAULT 0);
+"
+rm -f "$FAKE_HOME/.claude/tmb-active-workspace"
+( cd "$FAKE_HOME" && HOME="$FAKE_HOME" env -u TRAJECTORY_DB_PATH bash "$SENTINEL_WRITER" ) || true
+[ -f "$FAKE_HOME/.claude/tmb-active-workspace" ] && l2_home_wrote="wrote" || l2_home_wrote="refused"
+assert_eq "refused" "$l2_home_wrote" "sentinel writer must not record \$HOME"
+
+test_case "(L2) sentinel writer refuses a stale-schema DB"
+FAKE_WS="$TMPDIR/l2-stale-ws"
+mkdir -p "$FAKE_WS/.claude/tmb"
+sqlite3 "$FAKE_WS/.claude/tmb/trajectory.db" "
+  CREATE TABLE tasks (id INTEGER PRIMARY KEY, branch_id TEXT);
+"
+SENT_HOME="$TMPDIR/l2-stale-home"
+mkdir -p "$SENT_HOME/.claude"
+rm -f "$SENT_HOME/.claude/tmb-active-workspace"
+( cd "$FAKE_WS" && HOME="$SENT_HOME" env -u TRAJECTORY_DB_PATH bash "$SENTINEL_WRITER" ) || true
+[ -f "$SENT_HOME/.claude/tmb-active-workspace" ] && l2_stale_wrote="wrote" || l2_stale_wrote="refused"
+assert_eq "refused" "$l2_stale_wrote" "sentinel writer must refuse stale-schema DB"
+
+test_case "(L2) sentinel writer records a current-schema project workspace"
+GOOD_WS="$TMPDIR/l2-good-ws"
+mkdir -p "$GOOD_WS/.claude/tmb"
+sqlite3 "$GOOD_WS/.claude/tmb/trajectory.db" "
+  CREATE TABLE tasks (id INTEGER PRIMARY KEY, branch_id TEXT, prompt_bearing INTEGER DEFAULT 0);
+"
+GOOD_HOME="$TMPDIR/l2-good-home"
+mkdir -p "$GOOD_HOME/.claude"
+rm -f "$GOOD_HOME/.claude/tmb-active-workspace"
+( cd "$GOOD_WS" && HOME="$GOOD_HOME" env -u TRAJECTORY_DB_PATH bash "$SENTINEL_WRITER" ) || true
+assert_eq "$GOOD_WS" "$(head -1 "$GOOD_HOME/.claude/tmb-active-workspace" 2>/dev/null || true)" "sentinel writer records current-schema workspace"
+
 summarize

--- a/tests/l3-integration/hooks/write-active-workspace-sentinel.test.sh
+++ b/tests/l3-integration/hooks/write-active-workspace-sentinel.test.sh
@@ -16,6 +16,14 @@ run_hook() {
   echo '{}' | bash "$HOOK" 2>&1 || true
 }
 
+# Create a trajectory.db carrying the current schema (a tasks table with a
+# prompt_bearing column). The schema-mismatch fail-safe (#596) treats a DB
+# lacking that column as unresolved, so fixtures must seed the real schema
+# rather than touch an empty file.
+seed_db() {
+  sqlite3 "$1" "CREATE TABLE tasks (id INTEGER PRIMARY KEY, branch_id TEXT, prompt_bearing INTEGER DEFAULT 0);"
+}
+
 # ---- sentinel writer hook tests --------------------------------------------
 
 test_case "no DB found: hook exits silently"
@@ -31,7 +39,7 @@ test_case "DB found: sentinel written at \$HOME/.claude/tmb-active-workspace"
 WS="$TMPDIR/workspace"
 DB_DIR="$WS/.claude/tmb"
 mkdir -p "$DB_DIR"
-touch "$DB_DIR/trajectory.db"
+seed_db "$DB_DIR/trajectory.db"
 export TRAJECTORY_DB_PATH="$DB_DIR/trajectory.db"
 export HOME="$TMPDIR/fakehome2"
 mkdir -p "$HOME/.claude"
@@ -48,7 +56,7 @@ test_case "sentinel written: hook is idempotent (rewrite on each call)"
 WS="$TMPDIR/workspace2"
 DB_DIR="$WS/.claude/tmb"
 mkdir -p "$DB_DIR"
-touch "$DB_DIR/trajectory.db"
+seed_db "$DB_DIR/trajectory.db"
 export TRAJECTORY_DB_PATH="$DB_DIR/trajectory.db"
 export HOME="$TMPDIR/fakehome3"
 mkdir -p "$HOME/.claude"
@@ -66,7 +74,7 @@ test_case "tmb_db_path: sentinel resolver finds DB (cwd unrelated)"
 WS="$TMPDIR/sentws"
 DB_DIR="$WS/.claude/tmb"
 mkdir -p "$DB_DIR"
-touch "$DB_DIR/trajectory.db"
+seed_db "$DB_DIR/trajectory.db"
 FAKE_HOME="$TMPDIR/fakehome4"
 mkdir -p "$FAKE_HOME/.claude"
 printf '%s\n' "$WS" > "$FAKE_HOME/.claude/tmb-active-workspace"
@@ -81,7 +89,7 @@ printf '%s\n' "$WS2" > "$FAKE_HOME2/.claude/tmb-active-workspace"
 WALK_DIR="$TMPDIR/walkdir"
 DB_WALK="$WALK_DIR/.claude/tmb"
 mkdir -p "$DB_WALK"
-touch "$DB_WALK/trajectory.db"
+seed_db "$DB_WALK/trajectory.db"
 result=$(cd "$WALK_DIR" && HOME="$FAKE_HOME2" bash -c ". '$QUERY_LIB'; tmb_db_path" 2>/dev/null)
 assert_eq "$DB_WALK/trajectory.db" "$result" "walk-up fallback when sentinel DB absent"
 
@@ -89,7 +97,7 @@ test_case "tmb_db_path: no sentinel, walk-up still works"
 WALK_DIR2="$TMPDIR/walkdir2"
 DB_WALK2="$WALK_DIR2/.claude/tmb"
 mkdir -p "$DB_WALK2"
-touch "$DB_WALK2/trajectory.db"
+seed_db "$DB_WALK2/trajectory.db"
 FAKE_HOME3="$TMPDIR/fakehome6"
 mkdir -p "$FAKE_HOME3/.claude"
 result=$(cd "$WALK_DIR2" && HOME="$FAKE_HOME3" bash -c ". '$QUERY_LIB'; tmb_db_path" 2>/dev/null)
@@ -99,7 +107,7 @@ test_case "tmb_db_path: TRAJECTORY_DB_PATH env wins over sentinel"
 WS3="$TMPDIR/envws"
 DB_DIR3="$WS3/.claude/tmb"
 mkdir -p "$DB_DIR3"
-touch "$DB_DIR3/trajectory.db"
+seed_db "$DB_DIR3/trajectory.db"
 OVERRIDE_DB="$TMPDIR/override.db"
 touch "$OVERRIDE_DB"
 FAKE_HOME4="$TMPDIR/fakehome7"
@@ -114,8 +122,8 @@ trap 'rm -rf "$OUTER_ROOT"' EXIT
 OUTER_DB_DIR="$OUTER_ROOT/outer/.claude/tmb"
 INNER_DB_DIR="$OUTER_ROOT/outer/inner/.claude/tmb"
 mkdir -p "$OUTER_DB_DIR" "$INNER_DB_DIR"
-touch "$OUTER_DB_DIR/trajectory.db"
-touch "$INNER_DB_DIR/trajectory.db"
+seed_db "$OUTER_DB_DIR/trajectory.db"
+seed_db "$INNER_DB_DIR/trajectory.db"
 FAKE_HOME_NOSENTINEL="$TMPDIR/fakehome_nosentinel"
 mkdir -p "$FAKE_HOME_NOSENTINEL/.claude"
 SUB_DIR="$OUTER_ROOT/outer/inner/some/sub/dir"


### PR DESCRIPTION
Closes #596.

query-task.sh gains a tmb_db_schema_current probe (PRAGMA table_info('tasks') for prompt_bearing); the cwd walk-up + sentinel fallback skip a stale legacy ~/.claude/tmb/trajectory.db instead of adopting it and defaulting prompt_bearing=0. write-active-workspace-sentinel.sh refuses $HOME / stale-schema DBs. Builds on PR #598's resolver (untouched).

pr-reviewer: PASS (id 86). swe-boundary 72/72, sentinel 9/9.