### PR TITLE
🐛 fix(l1): bump no-raw-sql allowlist to query-task.sh:127 after #596 line shift

### DIFF
--- a/tests/l1-lint/no-raw-sql-interpolation.allowlist
+++ b/tests/l1-lint/no-raw-sql-interpolation.allowlist
@@ -11,7 +11,7 @@ scripts/hooks/swe-atomic-close.sh:264
 
 # query-task.sh tmb_sqlite_ro: $sql is the helper's whole-statement parameter;
 # sanitization is the CALLER's job and call sites are this lint's subjects.
-scripts/hooks/lib/query-task.sh:99
+scripts/hooks/lib/query-task.sh:127
 
 # swe-atomic-close.sh: AR_INSERT is assembled one line above exclusively from
 # sanitized values — tmb_sql_int (TASK_ID line 166, SAFE_ISSUE_ID line 310),


### PR DESCRIPTION
Fix-forward (no GH issue — release-mechanics/typo-class). #596's merge inserted tmb_db_schema_current above tmb_sqlite_ro in query-task.sh, shifting its sqlite3 $sql line from 99 to 127; the L1 no-raw-sql-interpolation allowlist still pinned :99, so L1 went red on dev. One-line allowlist bump :99->:127. `bash tests/l1-lint/no-raw-sql-interpolation.sh` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)