### PR TITLE
🧪 test(l3): mask plugin version + refresh prescan golden after #602 banner

### DIFF
--- a/tests/l3-integration/hooks/fixtures/session-start-prescan.golden.txt
+++ b/tests/l3-integration/hooks/fixtures/session-start-prescan.golden.txt
@@ -1,4 +1,5 @@
 === Project Inventory (auto, deterministic) ===
+Plugin version: __VOLATILE__
 Top-level dirs: __VOLATILE__
 Stacks detected: __VOLATILE__
 Architecture docs: __VOLATILE__

--- a/tests/l3-integration/hooks/hook-content-preservation.test.sh
+++ b/tests/l3-integration/hooks/hook-content-preservation.test.sh
@@ -30,6 +30,7 @@ mask_session_start_prescan() {
   local input="$1"
   printf '%s\n' "$input" \
     | sed \
+        -e 's/Plugin version:.*/Plugin version: __VOLATILE__/' \
         -e 's/Top-level dirs:.*/Top-level dirs: __VOLATILE__/' \
         -e 's/Stacks detected:.*/Stacks detected: __VOLATILE__/' \
         -e 's/Architecture docs:.*/Architecture docs: __VOLATILE__/' \


### PR DESCRIPTION
Fix-forward (no GH issue — test-fixture update for the merged #602 banner). #602 added a 'Plugin version:' line to session-start-prescan.sh, staling the L3 hook-content-preservation golden (L3 red on dev). Masks the version value as __VOLATILE__ (futureproof against version bumps) + regenerates the golden. hook-content-preservation 3/3; run-all.sh all layers pass. session-start-prescan.sh untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)