### PR TITLE
📝 docs(arch): sync RESPONSIBILITIES/WORLD_MODEL/FLOWS to v0.8.4 behavior (#604)

### DIFF
--- a/docs/architecture/FLOWS.md
+++ b/docs/architecture/FLOWS.md
@@ -239,6 +239,8 @@ When a workspace has multiple inner git repos (siblings or submodules), `tmb_def
 
 The L5 row `tests/l5-l6/rows/33-multirepo-commit/` catches regressions at the storage layer: a Cypher `MATCH (d:Directory) WHERE d.path STARTS WITH 'api/' OR d.path STARTS WITH 'app/'` returns ≥1 node only on a workspace-rooted path leak.
 
+`tmb_default_repo` also scopes the `no-source-edit-from-main.sh` guard: Rule 1 only protects the managed-repo subtree, so absolute edits to sibling repos are allowed (an empty/`.` default guards the whole tree). See `docs/architecture/RESPONSIBILITIES.md` (#592).
+
 ---
 
 ## C. Consultant invocation

--- a/docs/architecture/RESPONSIBILITIES.md
+++ b/docs/architecture/RESPONSIBILITIES.md
@@ -74,9 +74,9 @@ Bro is the only agent allowed to call:
 | Hook | When | Effect |
 |---|---|---|
 | `activation-routine.sh` | UserPromptSubmit | Inject onboarded marker + pending issue as context |
-| `session-start-prescan.sh` | SessionStart | Inject project inventory (git state, stacks, world-model warmth) |
+| `session-start-prescan.sh` | SessionStart | Inject project inventory (git state, stacks, world-model warmth); emit the active `Plugin version:` line, plus a "restart to apply" note when a newer version sits in the marketplace cache (#602) |
 | `ensure-gitignore.sh` | SessionStart | Ensure `.claude/` is gitignored |
-| `no-source-edit-from-main.sh` | PreToolUse Edit/Write | Deny bro source edits outside SWE worktree |
+| `no-source-edit-from-main.sh` | PreToolUse Edit/Write | Deny bro source edits outside SWE worktree, scoped to the managed repo: Rule 1 only guards the `tmb_default_repo` subtree, so absolute edits to sibling repos in a multi-repo workspace are allowed; an empty or `.` `tmb_default_repo` guards the whole tree (#592) |
 | `no-worktree-branch-create.sh` | PreToolUse Bash | Deny `git worktree add -b/-B/--detach` (branch authority is bro's pre-creation; attached worktrees only) |
 | `branch-up-to-date-with-remote.sh` | PreToolUse Bash | Deny worktree-add to a branch behind `origin/<pr_target>` |
 | `cleanup-worktree-on-task-close.sh` | PostToolUse `task_update_status` | Remove worktree after bro closes task |
@@ -84,7 +84,7 @@ Bro is the only agent allowed to call:
 
 ### Universal rules
 
-- **Bro never edits source code** — every code change goes through SWE (Layer 2 hook enforces).
+- **Bro never edits source code** — every code change goes through SWE (Layer 2 hook enforces). The guard is scoped to the managed repo (`tmb_default_repo`): sibling repos in a multi-repo workspace are outside Rule 1's scope, while an empty/`.` default guards the whole tree (#592).
 - **Voice**: relaxed tone, action-first, no padding.
 
 ---

--- a/docs/architecture/WORLD_MODEL.md
+++ b/docs/architecture/WORLD_MODEL.md
@@ -33,6 +33,10 @@ Follow-up slices (post-v0.7) add `File`, `Symbol`, `IMPORTS`, `CALLS`, `DEFINES`
 
 Re-running `scan_run` is summary-preserving via MERGE — existing nodes update structural fields and refresh README-derived summaries.
 
+## Concurrency
+
+kuzu is **single-writer**: only one process may hold the database's write lock, so a `scan_run` can collide with another opener (e.g. the SessionStart prescan warming the graph). `src/graph-db.ts` opens with bounded exponential backoff — up to 8 attempts starting at 50 ms — retrying only on a write-lock error and rethrowing any non-lock error (missing binary, corrupt file) immediately. When the retries exhaust, the open surfaces as `graph_db_open_failed`, and `scan_run` reports that distinct error rather than a phantom "scan already running" — restart the session to retry (#590/591).
+
 ## Querying
 
 `world_model_get(repo, path, depth)` returns a directory tree. Implementation reads all Directory nodes for the repo from kuzu, then builds the tree in TypeScript by linking each node to its `parent_path`. Default `depth=2` (root + immediate children); `depth=null` returns the full subtree.


### PR DESCRIPTION
Part of #604. Syncs dev-internal architecture docs to shipped behavior: RESPONSIBILITIES.md (no-source-edit managed-repo scoping #592 + prescan version-skew #602), WORLD_MODEL.md (new Concurrency note: kuzu single-writer + bounded backoff + graph_db_open_failed #590/591), FLOWS.md flow 33 cross-ref. ENFORCEMENT.md doesn't exist (consolidated into RESPONSIBILITIES.md); edits routed there. Docs only; link-check PASS. pr-reviewer PASS (id 92).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)