### PR TITLE
🔖 chore(release): bump to v0.8.4-rc.1 + CHANGELOG

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.8.3",
+  "version": "0.8.4-rc.1",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.8.4-rc.1 — 2026-06-14
+
+Reliability + upgrade-smoothness release. Hardens the world-model cold start and the SWE enforcement gates, smooths the upgrade flow, defaults SWE to Opus, and retires the flawed-era benchmark narrative.
+
+### Added
+- **Smoother upgrades (#602):** SessionStart surfaces the active plugin version and a "restart to apply" note when a newer version is cached but not yet running; `heal-mcp-cache.sh` gains cache GC (`--dry-run`; prunes stale cached versions, keeps active + previous, never deletes the active one); the MCP server warns on a legacy pre-stamp DB (no `plugin_meta`) instead of silently adopting it. `docs/reference/UPGRADE.md` documents the flow.
+- **TMB attribution footer (#601):** bro/swe-generated PRs, issues, and MRs carry a TMB-branded footer (`🤖 Generated with Claude Code, powered by Bro`).
+
+### Changed
+- **Default SWE model is now Opus (#594):** at parity cost to Sonnet on the hard corpus, Opus avoids the retry-storm tail (better worst-case wall time). Project-local Sonnet overrides remain supported; cost rates updated to Opus tiers.
+- **Benchmarks retired from the plugin repo (#593, #595):** the contradicted benchmark section/table, the `tests/l7-benchmark/` tree, and `docs/contributing/BENCHMARK.md` are removed — methodology and receipts now live in the separate benchmarks repo. README reframed to long-term-project + reliability positioning. (The earlier campaign's figures were formally retracted.)
+
+### Fixed
+- **World-model cold-start race (#590, #591):** a kuzu single-writer lock race between the SessionStart prescan and the MCP server no longer leaves the world model unavailable for the whole session — the open path retries with bounded backoff, and a genuine lock failure surfaces as `graph_db_open_failed` rather than a phantom "scan already running (pid N)".
+- **SWE enforcement gates no longer misfire (#592, #596, #597, #606):** `no-source-edit-from-main` Rule 1 is scoped to the managed repo (`tmb_default_repo`), so sibling repos in a multi-repo workspace aren't blocked; the `prompt_bearing` gate no longer adopts a stale legacy `~/.claude/tmb/trajectory.db` (schema fail-safe) and resolves the task id via the worktree's checked-out branch; `swe-scope-fence` strips markdown backticks from spec `## Files` paths so backtick-wrapped paths no longer deny every in-scope edit.
+
+### Internal
+- Pre-release hygiene (#604): startup-log version derives from `package.json`, dead `l7-benchmark` lint-allowlist entries removed, architecture docs synced to current behavior. Test-fixture corrections for the prescan golden snapshot and the SQL-lint allowlist line drift.
+
 ## v0.8.3 — 2026-06-13
 
 Patch release. Fixes the world-model scan crashing on repos with non-ASCII tracked paths — surfaced when scanning django (the benchmark corpus), which ships `tests/staticfiles_tests/apps/test/static/test/⊗.txt` (U+2297). No Claude-side (agents/skills/CLAUDE.md) changes; the release-gate is skipped per hotfix policy.

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.8.3",
+  "version": "0.8.4-rc.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.8.3",
+  "version": "0.8.4-rc.1",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Release mechanics (no issue). Bumps the 3 manifests 0.8.3 → 0.8.4-rc.1 and adds the v0.8.4-rc.1 CHANGELOG section (covers the 14 merges since v0.8.3: #590/591, #592, #593, #594, #595, #596, #597, #601, #602, #604, #606 + fix-forwards). version-sync / changelog-current / dist-fresh all PASS. Next: local L6 chain on dev, then tag v0.8.4-rc.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)