### PR TITLE
🧹 chore(docs): purge stale dogfood release-gate text from tests/manual (#622)

### DIFF
--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -15,11 +15,10 @@ L0–L6 are automated (Docker install-smoke, lint, MCP unit + integration, workf
 |---|---|---|
 | Active development on a feature/skill/hook | A (local) | optional, for sanity |
 | About to merge a PR that touches install path / schema / agent doctrine | A then C | yes |
-| Validating a release candidate before promoting `tmb-rc` → `tmb` (stable) | **B (marketplace RC) — mandatory** | yes |
-| About to tag a release | walk Path B + set `MANUAL_DOGFOOD_PASSED=v<X.Y.Z>` | yes (`scripts/release.sh` enforces) |
-| Hotfix release that demonstrably can't change Claude-side behavior | skip with `BYPASS_DOGFOOD=1` | no — but document the bypass reason in the release commit |
+| Validating a release candidate before promoting `tmb-rc` → `tmb` (stable) | B (marketplace RC) | optional spot-check — recommended |
+| About to tag a release | — | no — the tag is gated by the CI release-gate (= local L6), not this walk |
 
-## Why Path B is mandatory for RC validation
+## Why Path B is the right path for RC spot-checks
 
 v0.2.0 and v0.3.0 both shipped install-path bugs that broke every stable user. Both were validated locally via Path A and passed. **Path A doesn't exercise the marketplace install lifecycle** (`bun install --ignore-scripts`) where both bugs lived. Path B is the only manual path that catches that bug class.
 

--- a/tests/manual/scenarios.md
+++ b/tests/manual/scenarios.md
@@ -2,11 +2,7 @@
 
 > **What this is:** a tight, ~15-item checklist of the things **only a human walking through Claude Code can verify**. L0–L4 cover the rest structurally (Docker install-smoke, lint, MCP unit + integration, workflow-simulation trajectory tests). L5 (`tests/l5-l6/`) covers automated CC behavior.
 >
-> **When you must run this:**
-> - **Before promoting a release candidate to stable** (the canonical RC validation step — see [`CONTRIBUTING.md` § Release ritual](../../CONTRIBUTING.md#release-ritual) Path 2).
-> - **Before tagging any release** ≥ v0.2.0. The release script (`scripts/release.sh`) refuses to tag until `MANUAL_DOGFOOD_PASSED=v<X.Y.Z>` matches the version being released.
->
-> **Hotfixes** can bypass via `BYPASS_DOGFOOD=1`, with the bypass reason documented in the release commit. Acceptable when the change demonstrably can't affect Claude-side behavior (doc-only releases, CI-only fixes).
+> **When to run this:** This is an **optional spot-check**, not a tag-blocking sign-off. The release is gated by the automated CI release-gate (= local L6: 13/13 + the CI re-confirmation). Walk these scenarios when you want eyes on UX and interactive surfaces the automated layers can't model — most usefully before promoting a release candidate to stable (see [`CONTRIBUTING.md` § Release ritual](../../CONTRIBUTING.md#release-ritual) Path 2), or before a PR that touches the install path, schema, or agent doctrine.
 
 ---
 
@@ -405,18 +401,9 @@ Expected: an entry with `kind=issue_sync_active`, `backend=glab`, and the new is
 
 ---
 
-## How to sign off
+## What to do with the result
 
-Once every checkbox passes for the version you're about to release:
-
-```bash
-export MANUAL_DOGFOOD_PASSED=v0.2.0
-bash scripts/release.sh
-```
-
-`release.sh` checks `$MANUAL_DOGFOOD_PASSED` matches `plugin.json` version. If not set or mismatched, it refuses to tag.
-
-If something fails, **do not tag**. File an issue, fix it, re-run the affected checklist item, then sign off.
+This walk is an optional spot-check — the release is gated by the automated CI release-gate (= local L6), not by this checklist. If a scenario fails, file an issue and fix it; a failure here is a real bug even though it doesn't itself block the tag. Re-run the affected item once fixed.
 
 ## Why this is the only manual layer
 

--- a/tests/manual/setup.md
+++ b/tests/manual/setup.md
@@ -175,13 +175,7 @@ echo init > README.md && git add . && git commit -qm init
 claude   # bare CC, no --plugin-dir; uses the marketplace install
 ```
 
-Then `@bro hello` and walk the 10-item checklist in [`scenarios.md`](./scenarios.md). After completing all 10:
-
-```bash
-export MANUAL_DOGFOOD_PASSED=v<X.Y.Z>   # the FINAL tag, not the rc.N tag
-```
-
-This sets the gate that `scripts/release.sh` checks before tagging the stable release.
+Then `@bro hello` and walk the checklist in [`scenarios.md`](./scenarios.md). This walk is an optional spot-check, not a tag-blocking sign-off — the stable release is gated by the automated CI release-gate (= local L6). If a scenario surfaces a bug, file an issue and fix it before promoting.
 
 ### Reset between test runs
 


### PR DESCRIPTION
Companion to #622 (release.sh gate retirement, PR #623). Removes MANUAL_DOGFOOD_PASSED / BYPASS_DOGFOOD / 'release.sh refuses to tag' text from tests/manual/{scenarios,README,setup}.md and reframes the manual scenario walk as an optional spot-check (the CI release-gate = local L6 is the gate). Scenario checklist content kept byte-for-byte. pr-reviewer PASS (id 94); link-check 82 links.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)