### PR TITLE
🔖 chore(release): bump to v0.8.5 (#630, #631)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.8.5 — 2026-06-14
+
+Release-process + multi-repo guard follow-ups to v0.8.4.
+
+### Changed
+- **release-gate runs on rc tags only (#630):** dropped the stable-tag trigger from the CI release-gate. The stable tag is functionally identical to the green rc (functional-identity rule), so it's no longer re-gated — saves a full real-CC L6 run per release. rc tags + manual `workflow_dispatch` still trigger it.
+
+### Fixed
+- **git-guards scoped to the managed repo (#631):** the no-direct-commit, branch-from-`pr_target`, and PR-target guards now fire only for the managed repo (`tmb_default_repo`), so they no longer block legitimate commits/branches in sibling repos of a multi-repo workspace (e.g. the marketplace channel repos). Single-repo projects are unaffected (the guards stay active when `tmb_default_repo` is empty). Mirrors the #592 no-source-edit scoping.
+
 ## v0.8.4 — 2026-06-14
 
 Reliability + upgrade-smoothness release. Hardens the world-model cold start and the SWE enforcement gates, smooths the upgrade flow, defaults SWE to Opus, and retires the flawed-era benchmark narrative.

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
v0.8.5: release-gate rc-only trigger (#630) + git-guards managed-repo scoping (#631). Bump 0.8.4 → 0.8.5 + CHANGELOG. Per Human directive, v0.8.5 skips the rc cycle + L6 + CI release-gate (kept cheap sanity: pr-reviewer + L3 git-guards 98/98 + shellcheck + L1 lints).