### PR TITLE
🚀 release: v0.8.5 (dev → main)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,11 +1,11 @@
 name: release-gate
 on:
-  # Release gate: fires ONLY on release tags (rc.N + stable) + manual dispatch.
+  # Release gate: fires ONLY on rc tags + manual dispatch.
+  # The stable tag is functionally identical to the green rc, so it isn't re-gated.
   # Not on dev pushes/PRs — the full gate (incl. L6) is a release-time check.
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       skip_l6:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.8.5 — 2026-06-14
+
+Release-process + multi-repo guard follow-ups to v0.8.4.
+
+### Changed
+- **release-gate runs on rc tags only (#630):** dropped the stable-tag trigger from the CI release-gate. The stable tag is functionally identical to the green rc (functional-identity rule), so it's no longer re-gated — saves a full real-CC L6 run per release. rc tags + manual `workflow_dispatch` still trigger it.
+
+### Fixed
+- **git-guards scoped to the managed repo (#631):** the no-direct-commit, branch-from-`pr_target`, and PR-target guards now fire only for the managed repo (`tmb_default_repo`), so they no longer block legitimate commits/branches in sibling repos of a multi-repo workspace (e.g. the marketplace channel repos). Single-repo projects are unaffected (the guards stay active when `tmb_default_repo` is empty). Mirrors the #592 no-source-edit scoping.
+
 ## v0.8.4 — 2026-06-14
 
 Reliability + upgrade-smoothness release. Hardens the world-model cold start and the SWE enforcement gates, smooths the upgrade flow, defaults SWE to Opus, and retires the flawed-era benchmark narrative.

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [

--- a/scripts/hooks/git-guards.sh
+++ b/scripts/hooks/git-guards.sh
@@ -104,6 +104,32 @@ _CMD_CWD=$(cmd_cwd "$CMD")
 _GIT_ROOT=$(tmb_repo_git_root "$_CMD_CWD")
 _DB=$(tmb_db_path 2>/dev/null || true)
 
+# --- Managed-repo scope (#631, mirrors #592) ---
+# In a multi-repo workspace these guards (Rule 1 PR-target, Rule 2
+# no-direct-commit, Rule 4 branch-from-pr_target) must only fire for the managed
+# product repo, not its siblings (e.g. marketplace-rc, which is main-only and has
+# no dev branch). The DB lives at <workspace_root>/.claude/<plugin>/trajectory.db,
+# so the workspace root is three levels above _DB and the managed repo is
+# <workspace_root>/<tmb_default_repo>. When the command's git root is outside that
+# subtree it belongs to a sibling repo — the guards no-op (exit 0). When
+# tmb_default_repo is empty or '.' (the normal single-repo user project), the gate
+# is inert and the whole tree is guarded as before.
+if [ -n "$_DB" ] && [ -f "$_DB" ] && tmb_have_sqlite && [ -n "$_GIT_ROOT" ]; then
+  _DEFAULT_REPO=$(tmb_config_get "tmb_default_repo" "$_DB")
+  if [ -n "$_DEFAULT_REPO" ] && [ "$_DEFAULT_REPO" != "." ]; then
+    _WORKSPACE_ROOT=$(dirname "$(dirname "$(dirname "$_DB")")")
+    _MANAGED_ROOT="$_WORKSPACE_ROOT/$_DEFAULT_REPO"
+    # Canonicalize the managed root so it compares equal to git's already-
+    # canonical _GIT_ROOT (e.g. /tmp vs /private/tmp on macOS).
+    if [ -d "$_MANAGED_ROOT" ]; then
+      _MANAGED_ROOT=$(cd "$_MANAGED_ROOT" 2>/dev/null && pwd -P || echo "$_MANAGED_ROOT")
+    fi
+    if [ "$_GIT_ROOT" != "$_MANAGED_ROOT" ]; then
+      exit 0
+    fi
+  fi
+fi
+
 if [ -n "$_DB" ] && [ -f "$_DB" ] && tmb_have_sqlite && [ -n "$_GIT_ROOT" ]; then
   if ! tmb_repo_is_registered "$_DB" "$_GIT_ROOT"; then
     exit 0

--- a/tests/l3-integration/hooks/git-guards.test.sh
+++ b/tests/l3-integration/hooks/git-guards.test.sh
@@ -498,4 +498,98 @@ out=$(run_hook_in_repo "echo \"run glab mr create --target-branch dev from your 
 assert_not_contains "$out" '"permissionDecision":"deny"' "glab mr create inside quoted echo must not block"
 cleanup_repo
 
+# ---- #631: managed-repo scope (mirrors #592) -----------------------------------
+# In a multi-repo workspace, git-guards' Rule 1/2/4 must only fire for the
+# managed product repo (plugin_config tmb_default_repo). Sibling repos
+# (e.g. marketplace-rc, main-only with no dev branch) are exempt. When
+# tmb_default_repo is empty/'.', behavior is unchanged (single-repo guarding).
+#
+# Layout: <ws>/.claude/tmb/trajectory.db with managed + sibling repos as
+# siblings under <ws>. The DB is three levels above each repo's git root, so
+# managed = <ws>/<tmb_default_repo>; sibling git roots fall outside that subtree.
+
+setup_multirepo_workspace() {
+  # $1 = tmb_default_repo value to store (e.g. "managed", "" for single-repo).
+  local default_repo="$1"
+  local ws
+  ws=$(mktemp -d -t tmb-guards-ws-XXXX)
+  mkdir -p "$ws/.claude/tmb"
+  sqlite3 "$ws/.claude/tmb/trajectory.db" < "$PLUGIN_ROOT/mcp/trajectory-server/src/schema.sql" >/dev/null
+  # Managed repo on protected main.
+  (
+    cd "$ws" && git init -q -b main managed
+    cd "$ws/managed" || exit 1
+    git config user.email t@t.t
+    git config user.name T
+    echo init > README.md
+    git add . && git commit -qm init
+  )
+  # Sibling repo (e.g. marketplace-rc): also on main, also registered.
+  (
+    cd "$ws" && git init -q -b main sibling
+    cd "$ws/sibling" || exit 1
+    git config user.email t@t.t
+    git config user.name T
+    echo init > README.md
+    git add . && git commit -qm init
+  )
+  # Register repos with git's canonical toplevel path (handles /tmp →
+  # /private/tmp on macOS) so tmb_repo_is_registered matches the hook's _GIT_ROOT.
+  local managed_root sibling_root
+  managed_root=$(git -C "$ws/managed" rev-parse --show-toplevel)
+  sibling_root=$(git -C "$ws/sibling" rev-parse --show-toplevel)
+  sqlite3 "$ws/.claude/tmb/trajectory.db" \
+    "INSERT INTO repos (name, path) VALUES ('managed', '$managed_root');
+     INSERT INTO repos (name, path) VALUES ('sibling', '$sibling_root');" >/dev/null
+  if [ -n "$default_repo" ]; then
+    sqlite3 "$ws/.claude/tmb/trajectory.db" \
+      "INSERT OR REPLACE INTO plugin_config (key, value_json) VALUES ('tmb_default_repo', '\"${default_repo}\"');" >/dev/null
+  fi
+  WS_PATH="$ws"
+}
+
+run_hook_in_ws() {
+  # $1 = absolute repo dir to cd into, $2 = git command.
+  local repo_dir="$1" cmd="$2" payload
+  payload=$(jq -cn --arg c "cd $repo_dir && $cmd" '{tool_input:{command:$c}}')
+  (cd "$WS_PATH" && echo "$payload" \
+    | TRAJECTORY_DB_PATH="$WS_PATH/.claude/tmb/trajectory.db" \
+      bash "$HOOK" 2>&1 || true)
+}
+
+cleanup_ws() {
+  [ -n "${WS_PATH:-}" ] && [ -d "${WS_PATH:-}" ] && rm -rf "$WS_PATH"
+  WS_PATH=""
+}
+
+test_case "#631: managed-repo direct commit to main IS still blocked (tmb_default_repo=managed)"
+setup_multirepo_workspace "managed"
+out=$(run_hook_in_ws "$WS_PATH/managed" "git commit -m broken")
+assert_contains "$out" '"permissionDecision":"deny"' "commit on managed repo's protected main must still block"
+cleanup_ws
+
+test_case "#631: sibling-repo direct commit to main is ALLOWED (outside managed scope)"
+setup_multirepo_workspace "managed"
+out=$(run_hook_in_ws "$WS_PATH/sibling" "git commit -m wip")
+assert_not_contains "$out" '"permissionDecision":"deny"' "commit on sibling repo must be exempt from git-guards"
+cleanup_ws
+
+test_case "#631: sibling-repo branch-from-main is ALLOWED (Rule 4 exempt outside managed scope)"
+setup_multirepo_workspace "managed"
+out=$(run_hook_in_ws "$WS_PATH/sibling" "git checkout -b feat/x")
+assert_not_contains "$out" '"permissionDecision":"deny"' "branch creation in sibling repo must be exempt"
+cleanup_ws
+
+test_case "#631: single-repo (empty tmb_default_repo) commit to main STILL blocked (unchanged)"
+setup_multirepo_workspace ""
+out=$(run_hook_in_ws "$WS_PATH/managed" "git commit -m broken")
+assert_contains "$out" '"permissionDecision":"deny"' "empty tmb_default_repo must guard the whole tree as before"
+cleanup_ws
+
+test_case "#631: single-repo sibling commit also blocked when tmb_default_repo empty (no scoping)"
+setup_multirepo_workspace ""
+out=$(run_hook_in_ws "$WS_PATH/sibling" "git commit -m broken")
+assert_contains "$out" '"permissionDecision":"deny"' "with no managed scope, every registered repo is guarded (status quo)"
+cleanup_ws
+
 summarize


### PR DESCRIPTION
Promotion of v0.8.5 to stable: release-gate rc-only trigger (#630) + git-guards managed-repo scoping (#631). Per Human directive, v0.8.5 skipped the rc cycle + L6 + CI gate; cheap sanity green (pr-reviewer, L3 git-guards 98/98, shellcheck, L1 lints).