### PR TITLE
🔖 chore(release): bump to v0.8.6 (#636)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.8.6 — 2026-06-14
+
+### Fixed
+- **install-smoke semantic step no longer flakes (#636):** the L0 install-smoke's `discussion_search(mode=semantic)` check gives the embeddings model cold-load headroom (timeout 8→60) and treats a slow/cold model as the graceful `semantic_unavailable` path, failing only on a genuine MCP error payload. Removes a false-red release canary (hit during the v0.8.5 cut).
+
 ## v0.8.5 — 2026-06-14
 
 Release-process + multi-repo guard follow-ups to v0.8.4.

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
v0.8.6: de-flake install-smoke semantic step (#636). Bump + CHANGELOG. Skip-L6 (test-harness only).