### PR TITLE
⚡ perf(agents): per-role MCP tool allowlists for pr-reviewer + consultants (#637)

### DIFF
--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -3,7 +3,7 @@ name: pr-reviewer
 tmb_owner: bro
 description: Push gate. Reviews committed work not yet signed off at this gate (no passing validation row) and records the validation_record verdict. Read-only on files; no Edit/Write tool by design.
 model: opus
-tools: Read, Glob, Grep, Bash, Task, mcp__plugin_tmb_trajectory-server
+tools: Read, Glob, Grep, Bash, Task, mcp__plugin_tmb_trajectory-server__task_brief, mcp__plugin_tmb_trajectory-server__validation_record, mcp__plugin_tmb_trajectory-server__discussion_search, mcp__plugin_tmb_trajectory-server__audit_search, mcp__plugin_tmb_trajectory-server__validation_history, mcp__plugin_tmb_trajectory-server__issue_get_with_discussions, mcp__plugin_tmb_trajectory-server__task_get, mcp__plugin_tmb_trajectory-server__discussion_list, mcp__plugin_tmb_trajectory-server__audit_log_list, mcp__plugin_tmb_trajectory-server__pr_review_worktree, mcp__plugin_tmb_trajectory-server__pr_comments_get
 skills: [tmb_review]
 ---
 

--- a/templates/agents/architect.md
+++ b/templates/agents/architect.md
@@ -3,7 +3,7 @@ name: architect
 tmb_owner: bro
 description: Consultant. Analysis-only system-design read. Surfaces load-bearing assumptions, simpler alternatives, trade-offs, risks.
 model: opus
-tools: Read, Glob, Grep, Bash, mcp__plugin_tmb_trajectory-server
+tools: Read, Glob, Grep, Bash, mcp__plugin_tmb_trajectory-server__issue_get_with_discussions, mcp__plugin_tmb_trajectory-server__discussion_search, mcp__plugin_tmb_trajectory-server__audit_search, mcp__plugin_tmb_trajectory-server__discussion_append, mcp__plugin_tmb_trajectory-server__world_model_get, mcp__plugin_tmb_trajectory-server__world_model_search, mcp__plugin_tmb_trajectory-server__discussion_list, mcp__plugin_tmb_trajectory-server__audit_log_list, mcp__plugin_tmb_trajectory-server__issue_get
 skills: []
 ---
 

--- a/templates/agents/ceo.md
+++ b/templates/agents/ceo.md
@@ -3,7 +3,7 @@ name: ceo
 tmb_owner: bro
 description: Consultant. Product scope and prioritization. Frames "what to build vs not build now" with business reasoning.
 model: opus
-tools: Read, Glob, Grep, Bash, mcp__plugin_tmb_trajectory-server
+tools: Read, Glob, Grep, Bash, mcp__plugin_tmb_trajectory-server__issue_get_with_discussions, mcp__plugin_tmb_trajectory-server__discussion_search, mcp__plugin_tmb_trajectory-server__audit_search, mcp__plugin_tmb_trajectory-server__discussion_append, mcp__plugin_tmb_trajectory-server__world_model_get, mcp__plugin_tmb_trajectory-server__world_model_search, mcp__plugin_tmb_trajectory-server__discussion_list, mcp__plugin_tmb_trajectory-server__audit_log_list, mcp__plugin_tmb_trajectory-server__issue_get
 skills: []
 ---
 

--- a/templates/agents/cto.md
+++ b/templates/agents/cto.md
@@ -3,7 +3,7 @@ name: cto
 tmb_owner: bro
 description: Consultant. Technical strategy + tech-stack trade-offs. Scaling, dependency posture, build/CI direction.
 model: opus
-tools: Read, Glob, Grep, Bash, mcp__plugin_tmb_trajectory-server
+tools: Read, Glob, Grep, Bash, mcp__plugin_tmb_trajectory-server__issue_get_with_discussions, mcp__plugin_tmb_trajectory-server__discussion_search, mcp__plugin_tmb_trajectory-server__audit_search, mcp__plugin_tmb_trajectory-server__discussion_append, mcp__plugin_tmb_trajectory-server__world_model_get, mcp__plugin_tmb_trajectory-server__world_model_search, mcp__plugin_tmb_trajectory-server__discussion_list, mcp__plugin_tmb_trajectory-server__audit_log_list, mcp__plugin_tmb_trajectory-server__issue_get
 skills: []
 ---
 

--- a/templates/agents/pm.md
+++ b/templates/agents/pm.md
@@ -3,7 +3,7 @@ name: pm
 tmb_owner: bro
 description: Consultant. Product strategy + user research framing. Connects user need → feature shape, surfaces evidence gaps.
 model: opus
-tools: Read, Glob, Grep, Bash, mcp__plugin_tmb_trajectory-server
+tools: Read, Glob, Grep, Bash, mcp__plugin_tmb_trajectory-server__issue_get_with_discussions, mcp__plugin_tmb_trajectory-server__discussion_search, mcp__plugin_tmb_trajectory-server__audit_search, mcp__plugin_tmb_trajectory-server__discussion_append, mcp__plugin_tmb_trajectory-server__world_model_get, mcp__plugin_tmb_trajectory-server__world_model_search, mcp__plugin_tmb_trajectory-server__discussion_list, mcp__plugin_tmb_trajectory-server__audit_log_list, mcp__plugin_tmb_trajectory-server__issue_get
 skills: []
 ---
 

--- a/templates/agents/template.md
+++ b/templates/agents/template.md
@@ -3,7 +3,7 @@ name: <kebab-case>
 description: <one sentence>
 tmb_owner: bro
 model: opus
-tools: Read, Glob, Grep, Bash, mcp__plugin_tmb_trajectory-server
+tools: Read, Glob, Grep, Bash, mcp__plugin_tmb_trajectory-server__issue_get_with_discussions, mcp__plugin_tmb_trajectory-server__discussion_search, mcp__plugin_tmb_trajectory-server__audit_search, mcp__plugin_tmb_trajectory-server__discussion_append, mcp__plugin_tmb_trajectory-server__world_model_get, mcp__plugin_tmb_trajectory-server__world_model_search, mcp__plugin_tmb_trajectory-server__discussion_list, mcp__plugin_tmb_trajectory-server__audit_log_list, mcp__plugin_tmb_trajectory-server__issue_get
 skills: []
 ---
 


### PR DESCRIPTION
**v0.9.0 lever #1 — PROMPT-SURFACE, held for Human review (no auto-merge).**

Replaces the broad `mcp__plugin_tmb_trajectory-server` bundle grant (all 68 tool schemas/spawn) with explicit per-tool allowlists in 6 files (tools: frontmatter only, +6/-6):
- agents/pr-reviewer.md → 11 MCP tools
- templates/agents/{cto,architect,pm,ceo,template}.md → 9 MCP tools each

Non-MCP tools (Read/Glob/Grep/Bash/Task) unchanged. Implements cto discussion #184's authoritative lists. Saves ~12–14K tok per pr-reviewer / consultant spawn. pr-reviewer PASS; L1 + run-all L1–L4 green.

### ⚠️ One reviewer heads-up (your call)
The `tmb_review` skill §A Phase 3 names an **optional** `world_model_get(path=…)` sibling-pattern drill-down for pr-reviewer, and that tool is **not** in the new 11-tool list. pr-reviewer normally gets world-model context via `task_brief`'s bundled `scope_world_model` field (granted), so the common path works — the reviewer judged it non-functional. But by the conservative under-grant principle, I'd lean toward **adding `world_model_get` + `world_model_search` to pr-reviewer** so the skill and the grant stay consistent. Say the word and I'll amend before merge; otherwise the rc.1 L6 chain exercises the grants live.

(swe 117 implemented #184's 11/9 lists; the epic's '12/10' was a bro miscount.)

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)