### PR TITLE
🔖 chore(release): bump to v0.9.2-rc.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.9.1",
+  "version": "0.9.2-rc.1",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.9.2-rc.1 — 2026-06-15
+
+Headless enforcement for marketplace installs.
+
+### Fixed
+- **Headless hook enforcement** (#661): marketplace-installed plugin hooks don't fire in headless `claude -p` (Claude Code activates plugin hooks via the interactive trust dialog, which `-p` skips). TMB's doctrine enforcement is its PreToolUse hooks (the no-source-edit hook forces bro to dispatch swe), so headless/CI users on a marketplace install previously got no enforcement and bro could edit source directly. `/onboard` (`onboard_apply`) now writes a TMB-managed PreToolUse hooks block into `~/.claude/settings.json` — settings.json hooks DO fire headless. Derived from the plugin's own `hooks/hooks.json` (PreToolUse only, plugin-root resolved to an absolute path), idempotent, preserves user hooks, and never fails onboarding.
+
 ## v0.9.1 — 2026-06-15
 
 Fresh-install reliability. No workflow or enforcement changes.

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.9.1",
+  "version": "0.9.2-rc.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.9.1",
+  "version": "0.9.2-rc.1",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Phase A rc candidate bump for v0.9.2 (headless enforcement shim, #661). Manifests + CHANGELOG only; dist unchanged (version read at runtime). Next: local L6 13/13 licenses the rc tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)