### PR TITLE
🔖 chore(release): bump to v0.9.2-rc.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.9.2-rc.1",
+  "version": "0.9.2-rc.2",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.9.2-rc.2 — 2026-06-15
+
+### Fixed
+- **Headless enforcement shim now actually enforces** (#661): rc.1 wrote the PreToolUse hooks to `~/.claude/settings.json` but they didn't fire — `swe-brief-gate` ran first in the chain and short-circuited before `no-source-edit-from-main`. The shim now excludes advisory/short-circuiting hooks so `no-source-edit-from-main` runs first and denies (end-to-end verified: a direct source edit is blocked under headless `claude -p`). Idempotency now keys on a `_tmb_managed` sentinel (not a `/tmb/` path substring, which missed dev/worktree paths and could accumulate entries), and the shim refuses to write when the plugin root is a dev worktree.
+
 ## v0.9.2-rc.1 — 2026-06-15
 
 Headless enforcement for marketplace installs.

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.9.2-rc.1",
+  "version": "0.9.2-rc.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.9.2-rc.1",
+  "version": "0.9.2-rc.2",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Phase A bump for rc.2 (headless shim now enforces, #661). Manifests + CHANGELOG; dist unchanged. Next: L6 13/13 licenses the rc.2 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)