### PR TITLE
🐛 fix(hooks): no-source-edit guards single-repo-at-root via repos.path (#59)

### DIFF
--- a/scripts/hooks/no-source-edit-from-main.sh
+++ b/scripts/hooks/no-source-edit-from-main.sh
@@ -213,11 +213,26 @@ esac
 
 # Managed-repo scope (#592): in a multi-repo workspace, Rule 1 must only guard
 # the managed product repo (plugin_config tmb_default_repo), not its siblings.
-# The DB lives at <workspace_root>/.claude/<plugin>/trajectory.db, so the
-# workspace root is three levels above DB_PATH and the managed repo is
-# <workspace_root>/<tmb_default_repo>. An absolute target outside that subtree
-# belongs to a sibling repo and is allowed. When tmb_default_repo is empty or
-# '.' (the normal single-repo user project), the whole tree is guarded as before.
+# tmb_default_repo is the repo NAME, so the managed root is resolved by a
+# path-keyed lookup against repos.path (the canonical absolute path set by scan)
+# rather than string-joining the workspace root with the name — that join
+# mis-scopes single-repo-at-root layouts (where the git repo IS the workspace
+# root) one level too deep, leaking the whole tree as a "sibling". Both the
+# resolved MANAGED_ROOT and the absolute target are realpath-normalized before
+# the enclosure test (handles /tmp->/private/tmp symlinks and trailing slashes).
+# Fail-closed: if the repos.path lookup is empty (repo name not found), the whole
+# tree is guarded — the same as an empty/'.' tmb_default_repo (single-repo user
+# project). Only a resolved MANAGED_ROOT plus a target outside it allows a
+# sibling-repo edit.
+_realpath() {
+  if command -v realpath >/dev/null 2>&1; then
+    realpath -m "$1" 2>/dev/null || printf '%s' "$1"
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' "$1" 2>/dev/null || printf '%s' "$1"
+  else
+    printf '%s' "$1"
+  fi
+}
 DEFAULT_REPO=""
 if command -v sqlite3 >/dev/null 2>&1; then
   DEFAULT_REPO=$(sqlite3 -readonly -cmd '.timeout 500' "$DB_PATH" \
@@ -227,12 +242,20 @@ fi
 if [ -n "$DEFAULT_REPO" ] && [ "$DEFAULT_REPO" != "." ]; then
   case "$TARGET" in
     /*)
-      WORKSPACE_ROOT=$(dirname "$(dirname "$(dirname "$DB_PATH")")")
-      MANAGED_ROOT="$WORKSPACE_ROOT/$DEFAULT_REPO"
-      case "$TARGET" in
-        "$MANAGED_ROOT"/*) : ;;       # inside the managed repo — keep guarding
-        *) exit 0 ;;                  # sibling repo — outside Rule 1 scope
-      esac
+      MANAGED_ROOT=""
+      if command -v sqlite3 >/dev/null 2>&1; then
+        MANAGED_ROOT=$(sqlite3 -readonly -cmd '.timeout 500' "$DB_PATH" \
+          "SELECT path FROM repos WHERE name='$(printf '%s' "$DEFAULT_REPO" | sed "s/'/''/g")' LIMIT 1;" \
+          2>/dev/null || true)
+      fi
+      if [ -n "$MANAGED_ROOT" ]; then
+        MANAGED_ROOT=$(_realpath "$MANAGED_ROOT")
+        TARGET_REAL=$(_realpath "$TARGET")
+        case "$TARGET_REAL" in
+          "$MANAGED_ROOT"/*) : ;;       # inside the managed repo — keep guarding
+          *) exit 0 ;;                  # sibling repo — outside Rule 1 scope
+        esac
+      fi
       ;;
   esac
 fi

--- a/tests/l3-integration/hooks/no-source-edit-from-main.test.sh
+++ b/tests/l3-integration/hooks/no-source-edit-from-main.test.sh
@@ -348,15 +348,16 @@ assert_not_contains "$out" 'bashrc' "deny message must not mention bashrc"
 assert_contains "$out" 'non-isolated' "deny message mentions non-isolated mode"
 
 # ---- Managed-repo scope (#592): multi-repo workspace ----
-# DB lives at <workspace_root>/.claude/<plugin>/trajectory.db, so the hook
-# derives the workspace root three levels above DB_PATH and the managed repo as
-# <workspace_root>/<tmb_default_repo>. Build that exact layout so MANAGED_ROOT
-# is deterministic.
+# The hook resolves the managed root from repos.path (path-keyed), so build a
+# repos row whose path is the managed repo's absolute location. tmb_default_repo
+# carries the repo NAME; repos.path carries the canonical absolute path.
 WS_ROOT="$TMPDIR/ws"
 MANAGED_DB="$WS_ROOT/.claude/tmb/trajectory.db"
 mkdir -p "$WS_ROOT/.claude/tmb"
 sqlite3 "$MANAGED_DB" "CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT);"
 sqlite3 "$MANAGED_DB" "INSERT INTO plugin_config (key, value_json) VALUES ('tmb_default_repo', '\"plugin\"');"
+sqlite3 "$MANAGED_DB" "CREATE TABLE repos(name TEXT PRIMARY KEY, path TEXT NOT NULL, file_count INTEGER NOT NULL DEFAULT 0, last_scanned_at TEXT NOT NULL DEFAULT (datetime('now')), target_branch TEXT, branching_model TEXT, protected_branches TEXT);"
+sqlite3 "$MANAGED_DB" "INSERT INTO repos (name, path) VALUES ('plugin', '$WS_ROOT/plugin');"
 
 run_hook_db() {
   echo "$2" | env TRAJECTORY_DB_PATH="$1" bash "$HOOK" 2>&1 || true
@@ -375,5 +376,23 @@ SINGLE_DB="$TMPDIR/single.db"
 sqlite3 "$SINGLE_DB" "CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT);"
 out=$(run_hook_db "$SINGLE_DB" "$(input 'Edit' '/some/project/src/foo.ts' "$TRANSCRIPT_BRO")")
 assert_contains "$out" '"permissionDecision":"deny"' "empty tmb_default_repo guards the whole tree as before"
+
+# ---- Single-repo-at-root: the git repo IS the workspace root ----
+# repos.path == workspace root, so the managed root resolves to the workspace
+# itself and source under it must be guarded. The old string-join (workspace +
+# name) computed one level too deep and leaked $WS/src/* as a "sibling" — this
+# is the regression the path-keyed lookup closes.
+SR_ROOT="$TMPDIR/repo-at-root"
+SR_DB="$SR_ROOT/.claude/tmb/trajectory.db"
+mkdir -p "$SR_ROOT/.claude/tmb"
+SR_NAME=$(basename "$SR_ROOT")
+sqlite3 "$SR_DB" "CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT);"
+sqlite3 "$SR_DB" "INSERT INTO plugin_config (key, value_json) VALUES ('tmb_default_repo', '\"$SR_NAME\"');"
+sqlite3 "$SR_DB" "CREATE TABLE repos(name TEXT PRIMARY KEY, path TEXT NOT NULL, file_count INTEGER NOT NULL DEFAULT 0, last_scanned_at TEXT NOT NULL DEFAULT (datetime('now')), target_branch TEXT, branching_model TEXT, protected_branches TEXT);"
+sqlite3 "$SR_DB" "INSERT INTO repos (name, path) VALUES ('$SR_NAME', '$SR_ROOT');"
+
+test_case "single-repo-at-root + src/foo.ts from main as bro: BLOCK (regression)"
+out=$(run_hook_db "$SR_DB" "$(input_with_agent 'Edit' "$SR_ROOT/src/foo.ts" 'bro')")
+assert_contains "$out" '"permissionDecision":"deny"' "source under the single repo-at-root is guarded, not leaked as a sibling"
 
 summarize


### PR DESCRIPTION
## What

Fixes `no-source-edit-from-main.sh` so it guards **single-repo-at-root** workspaces (the normal single-repo user project, and every headless benchmark `/workspace`).

The managed-repo scope block (#592) computed the guarded root by string-joining `WORKSPACE_ROOT + tmb_default_repo` (the repo *name*). Correct for the multi-repo dev layout (`TMB/plugin/`), but **one level too deep** when the git repo IS the workspace root (`/workspace` → `/workspace/workspace`) — so source files were judged "sibling repo, out of scope" and silently allowed. This silently disabled no-source-edit enforcement headless and caused the SlopCodeBench bro arm to degenerate.

## Fix

Resolve `MANAGED_ROOT` from `SELECT path FROM repos WHERE name=<default_repo>` (the table already stores the real absolute path; SQL-escaped), realpath-normalize both `MANAGED_ROOT` and `TARGET`, and fail closed (guard whole tree) on empty lookup. Aligns with the path-keyed `resolve-repo.sh` convention.

## Verification

- `tests/l3-integration/hooks/no-source-edit-from-main.test.sh`: **71/71** incl. a new single-repo-at-root BLOCK case. Multi-repo BLOCK / sibling ALLOW / empty-default BLOCK all still green.
- L1 shellcheck + tsc clean; L4 flows green.
- pr-reviewer: **PASS** (no findings).
- End-to-end proof with real `claude -p` (CC 2.1.178) in the docker condition: deny 0→7, bro routes to swe, full doctrine VALID.

## Notes

Interim fix — forward-compatible with #667 (remove `tmb_default_repo` entirely): when that lands, this block is skipped and the hook falls back to guarding the whole tree (fail-closed).

Closes #59. Refs #667.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)