### PR TITLE
📝 Typed Rails: tmb_planning emits typed files[]/verification[] (#673)

### DIFF
--- a/skills/tmb_planning/SKILL.md
+++ b/skills/tmb_planning/SKILL.md
@@ -30,14 +30,23 @@ Pick conservative defaults; name them in `## Description` Assumptions bullets. I
 | File layout | single file until ~200 LOC |
 | Python / concurrency | `python3`; single-user, single-process |
 
+Two surfaces carry the spec. **Typed args** on `task_create_batch` carry the machine-read contract; **spec_body markdown** carries the prose bro and swe reason from.
+
+Pass on each swe-executed task:
+
+- `files: string[]` — the paths the task touches (the list formerly written under `## Files`). The scope fence reads this typed field.
+- `verification: string[]` — runnable bash commands, one per entry, commands only. Each entry is executed verbatim by the verification gate, so it holds a command and nothing else — reasoning about what the command proves lives in `## Description`.
+
 Spec body sections — when the scope outgrows one spec, split into multiple tasks linked by `parent_branch_id`:
 
 - `## Description` — ≤3 sentences, file paths with line refs, Assumptions bullets
-- `## Files` — path — action
+- `## Files` — path — action (mirrors the typed `files[]` for the reader)
 - `## Success Criteria` — 2–5 testable assertions
-- `## Verification` — exact bash commands
+- `## Verification` — the same commands as typed `verification[]`, for the reader
 - `## Out of Scope`
 - `## Commit` — `<emoji> <type>(<scope>): <msg>`
+
+The typed `files[]`/`verification[]` args are what the scope fence and verification gate enforce; the matching markdown sections are reader-facing mirrors, not the source of enforcement.
 
 Before `task_create_batch`: `discussion_append(issue_id, author='bro', kind='decision', body='<chosen approach>')`.
 
@@ -56,7 +65,7 @@ Blast-radius (external side effects only): default config is the safe state (opt
 
 ## 4. Spawn SWE
 
-Create the tasks with `task_create_batch`, asking it to emit the planning-complete event in the same transaction. `waive_scope_gate` is valid for truly trivial work (`'trivial: <what>'`) or headless mode (`'headless mode, defaults applied; <one-line scope summary>'`).
+Create the tasks with `task_create_batch`, passing the typed `files[]` and `verification[]` for each swe-executed task and asking it to emit the planning-complete event in the same transaction. `waive_scope_gate` is valid for truly trivial work (`'trivial: <what>'`) or headless mode (`'headless mode, defaults applied; <one-line scope summary>'`).
 
 Then run the worktree hook per branch and spawn SWE per task — the post-create hint carries the exact spawn recipe.
 


### PR DESCRIPTION
Prompt-surface half of **#673 Typed Rails**: `tmb_planning` now directs bro to emit typed `files[]` / `verification[]` args on `task_create_batch` (commands-only verification; reasoning prose stays in `## Description`). The `## Files` / `## Verification` markdown sections become reader-facing mirrors, not the enforcement source.

⚠️ **Merge after the code PR** (`feat/typed-rails-hook-path-fix`) — this skill assumes the typed-field schema/hooks exist.

Prompt-surface change → human review, no auto-merge. pr-reviewer: PASS (task #140).

🤖 Generated with [Claude Code](https://claude.com/claude-code)