### PR TITLE
🔖 chore(release): bump dev to 0.10.0-alpha (#76)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.9.2-rc.2",
+  "version": "0.10.0-alpha",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.10.0-alpha — 2026-06-16
+
+### Changed
+- **Dev channel version bumped to 0.10.0-alpha** (#76): the `dev` channel ships commits without an rc/stable version bump, but Claude Code keys its plugin cache by `plugin.json` version — so dev updates landed as no-ops once the cache dir for `0.9.2-rc.2` existed. Bumping dev to a distinct pre-release version restores cache-busting on update. Includes the Typed Rails work (#673/#681/#682). dev-only: no marketplace-repo, rc, or stable changes.
+
 ## v0.9.2-rc.2 — 2026-06-15
 
 ### Fixed

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.9.2-rc.2",
+  "version": "0.10.0-alpha",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.9.2-rc.2",
+  "version": "0.10.0-alpha",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## What

Bump the **dev-channel** plugin version `0.9.2-rc.2` → `0.10.0-alpha`.

## Why

Claude Code keys its plugin cache directory by `plugin.json` version. The `dev` channel (`marketplace-dev` → `ref: dev`) shipped #681/#682 (Typed Rails) **without** a version bump, so once the `0.9.2-rc.2` cache dir existed, `/plugin update` + restart became a content no-op — CC saw the same version and skipped the refetch. Users on dev were silently stuck pre-#681 (still on the markdown `## Files` task contract instead of the typed `files[]`/`verification[]` columns).

Bumping dev to a distinct pre-release version (`0.10.0-alpha` — sorts above `0.9.2-rc.2`, below stable `0.10.0`) restores cache-busting on update.

## Scope (dev only)

- ✅ `.claude-plugin/plugin.json`, `package.json`, `mcp/trajectory-server/package.json` — via `scripts/maintenance/bump-version.sh` (atomic, no hand-edits)
- ✅ `CHANGELOG.md` — new `## v0.10.0-alpha — 2026-06-16` section
- ❌ No marketplace-* repo edits (they carry no version, only `ref`)
- ❌ No rc tag, no stable `0.10.0`, no release-gate dispatch
- ❌ No MCP dist rebuild (version read from `package.json` at runtime)

## Verification

- `tests/l1-lint/version-sync.sh` → PASS
- `tests/l1-lint/changelog-current.sh` → PASS
- pr-reviewer push gate: PASS (validation row #124)

Closes #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)