### PR TITLE
🔖 chore(release): bump dev to 0.10.0-beta

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.10.0-alpha",
+  "version": "0.10.0-beta",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 ## Unreleased
 
+## v0.10.0-beta — 2026-06-17
+
 ### Added
+- **Cheatcode vet stage** (#658): `cheatcode_vet` gathers reputation + security-surface signals for a candidate and emits a deterministic trust tier (trusted / caution / untrusted / unknown) + one-line rationale + capability list — a reproducible classification of the signal set, never an install verdict. A code-executing candidate (ships hooks / MCP / scripts) is never classified `trusted` on popularity alone; failed or empty signals degrade to `unknown` and never crash. Network stubbed via `TMB_CHEATCODE_VET_FIXTURE` in CI.
 - **Cheatcode install stage + approval gate** (#659): `cheatcode_install` installs a vetted cheatcode (skill / MCP toolkit / plugin) via the marketplace-install path (no seeding), writing one `cheatcodes` row plus its `cheatcode_attachments` record(s) in a single transaction and emitting `cheatcode_install` / `cheatcode_installed` audit rows; re-installing the same candidate no-ops. Installs are human-approved, never silent — a PreToolUse gate (`cheatcode-install-approval.sh`) blocks the install until a per-candidate `cheatcode_approve` record exists and fails closed otherwise. A standalone-skill install never edits agent frontmatter: it returns a proposed-PR payload for the Human-reviewed prompt-surface change. New `cheatcodes` + `cheatcode_attachments` tables (schema v14). Discovery/install fixtures stub the marketplace via `TMB_CHEATCODE_INSTALL_FIXTURE` — no live network in CI.
 
 ### Fixed

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.10.0-alpha",
+  "version": "0.10.0-beta",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.10.0-alpha",
+  "version": "0.10.0-beta",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Bumps dev 0.10.0-alpha → 0.10.0-beta to bust CC's version-keyed plugin cache so `/plugin update` is not a no-op. Delivers the cheatcode vet (#658) + install (#659) stages and the task_stats over-count fix (#685). Version-sync + changelog-current green; dist untouched (version is read from package.json at runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)