### PR TITLE
🧪 test(l6): author cheatcode install/uninstall plugin rows (#778)

### DIFF
--- a/tests/l5-l6/rows/44-cheatcode-install-plugins/README.md
+++ b/tests/l5-l6/rows/44-cheatcode-install-plugins/README.md
@@ -1,0 +1,16 @@
+# 44-cheatcode-install-plugins
+
+**Scenario:** Onboarded project. The user tells bro to install two already-chosen plugins — `feature-dev` and `code-review` — in local scope. Installs are human-approved, never silent (#659): bro records the per-candidate approval via `cheatcode_approve`, then calls `cheatcode_install` once per plugin. The PreToolUse approval gate allows each install only because the matching `cheatcode_approved` record now exists — it fails closed otherwise. Each install writes the `cheatcodes` row (scope='local') + its attachment record in one transaction and emits the `cheatcode_install` / `cheatcode_installed` audit rows. The per-agent attachment routes feature-dev → swe and code-review → pr-reviewer.
+
+**Determinism:** `setup-l5.sh` writes a marketplace-install fixture and points `cheatcode_install` at it via `TMB_CHEATCODE_INSTALL_FIXTURE` — no live web, no real marketplace call. The fixture supplies the per-agent attachment targets (swe, pr-reviewer) that pass through verbatim. This row asserts the flow ran (approval recorded, install gate cleared, both installs + audit + per-agent attachment records present), not marketplace results.
+
+**L5 mode:** `setup-l5.sh` seeds the fixture; `fixture.txt` seeds `onboarding-named` identity.
+**L6 mode:** Standalone here — NOT in the chain manifest (L6-B renumbers + wires it into the cheatcode journey chain).
+
+## Scorers
+
+| Scorer | Asserts |
+|---|---|
+| `outcome.sql` | Two `cheatcode_installed` audit rows; two `cheatcodes` rows `scope='local'`; the feature-dev AND code-review cheatcodes rows; `cheatcode_attachments` target='swe' AND target='pr-reviewer' |
+| `tools-required.json` | `cheatcode_approve` + `cheatcode_install` called |
+| `cost-budget.json` | Soft 60K tokens / 90s |

--- a/tests/l5-l6/rows/44-cheatcode-install-plugins/cost-budget.json
+++ b/tests/l5-l6/rows/44-cheatcode-install-plugins/cost-budget.json
@@ -1,0 +1,6 @@
+{
+  "max_tokens_total": 60000,
+  "max_duration_ms": 90000,
+  "fail_above_max": false,
+  "_comment": "Soft budget — warn on overage but don't fail the run."
+}

--- a/tests/l5-l6/rows/44-cheatcode-install-plugins/fixture.txt
+++ b/tests/l5-l6/rows/44-cheatcode-install-plugins/fixture.txt
@@ -1,0 +1,1 @@
+onboarding-named

--- a/tests/l5-l6/rows/44-cheatcode-install-plugins/outcome.sql
+++ b/tests/l5-l6/rows/44-cheatcode-install-plugins/outcome.sql
@@ -1,0 +1,56 @@
+-- Outcome assertions for 44-cheatcode-install-plugins. Each row returns
+-- (pass, description). The scorer requires every row's pass column to be 1.
+--
+-- Scope: bro installs BOTH the feature-dev and code-review plugins in local
+-- scope. The deterministic proof is (a) two cheatcode_installed audit rows,
+-- (b) the two cheatcodes rows (feature-dev + code-review) written scope='local',
+-- and (c) the per-agent attachment records — feature-dev → swe, code-review →
+-- pr-reviewer. Marketplace results are stubbed via TMB_CHEATCODE_INSTALL_FIXTURE;
+-- the install/attachment SHAPE is covered by L2/L3, the per-candidate routing
+-- here.
+
+SELECT
+  CASE WHEN COUNT(*) >= 2 THEN 1 ELSE 0 END AS pass,
+  'two-cheatcode_installed-audit-rows (got ' || COUNT(*) || ')' AS description
+FROM audit
+WHERE event_type = 'cheatcode_installed'
+
+UNION ALL
+
+SELECT
+  CASE WHEN COUNT(*) >= 2 THEN 1 ELSE 0 END AS pass,
+  'two-cheatcodes-rows-scope-local (got ' || COUNT(*) || ')' AS description
+FROM cheatcodes
+WHERE scope = 'local'
+
+UNION ALL
+
+SELECT
+  CASE WHEN COUNT(*) >= 1 THEN 1 ELSE 0 END AS pass,
+  'feature-dev-cheatcode-row-written (got ' || COUNT(*) || ')' AS description
+FROM cheatcodes
+WHERE name = 'feature-dev'
+
+UNION ALL
+
+SELECT
+  CASE WHEN COUNT(*) >= 1 THEN 1 ELSE 0 END AS pass,
+  'code-review-cheatcode-row-written (got ' || COUNT(*) || ')' AS description
+FROM cheatcodes
+WHERE name = 'code-review'
+
+UNION ALL
+
+SELECT
+  CASE WHEN COUNT(*) >= 1 THEN 1 ELSE 0 END AS pass,
+  'attachment-target-swe-written (got ' || COUNT(*) || ')' AS description
+FROM cheatcode_attachments
+WHERE target = 'swe'
+
+UNION ALL
+
+SELECT
+  CASE WHEN COUNT(*) >= 1 THEN 1 ELSE 0 END AS pass,
+  'attachment-target-pr-reviewer-written (got ' || COUNT(*) || ')' AS description
+FROM cheatcode_attachments
+WHERE target = 'pr-reviewer';

--- a/tests/l5-l6/rows/44-cheatcode-install-plugins/prompt.txt
+++ b/tests/l5-l6/rows/44-cheatcode-install-plugins/prompt.txt
@@ -1,0 +1,1 @@
+@bro install the feature-dev and code-review plugins in local scope. Don't ask questions.

--- a/tests/l5-l6/rows/44-cheatcode-install-plugins/script.json
+++ b/tests/l5-l6/rows/44-cheatcode-install-plugins/script.json
@@ -1,0 +1,5 @@
+{
+  "max_turns": 1,
+  "user_after_bro": [],
+  "terminal_pattern": "installed|cheatcode_install|approved|approval|cheatcode_installed|done|all set"
+}

--- a/tests/l5-l6/rows/44-cheatcode-install-plugins/setup-l5.sh
+++ b/tests/l5-l6/rows/44-cheatcode-install-plugins/setup-l5.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Cheatcode-install-plugins L5 isolation: seed a deterministic marketplace-install
+# fixture and point cheatcode_install at it via TMB_CHEATCODE_INSTALL_FIXTURE so
+# no live web / real marketplace call is ever made. The fixture lives in the
+# project dir; the env export covers runners that source this setup.
+#
+# Both candidates are plugin-kind. The fixture supplies attachments[] that pass
+# through verbatim — the per-agent attachment targets the install records: the
+# feature-dev plugin attaches to swe, the code-review plugin to pr-reviewer. The
+# {installed, version} object stands in for the marketplace result; the
+# cheatcodes + attachment + audit rows the install writes are computed the same
+# way regardless, so the fixture only enriches the reported version + targets. No
+# network.
+set -uo pipefail
+
+PROJECT="$1"
+# shellcheck disable=SC2034
+SCENARIO_DIR="$2"
+
+FIXTURE="$PROJECT/.tmb-cheatcode-install-fixture.json"
+cat > "$FIXTURE" <<'JSON'
+{
+  "installed": true,
+  "version": "1.0.0",
+  "error": null,
+  "attachments": [
+    { "target": "swe", "artifact": "marketplace-plugin:feature-dev" },
+    { "target": "pr-reviewer", "artifact": "marketplace-plugin:code-review" }
+  ]
+}
+JSON
+
+export TMB_CHEATCODE_INSTALL_FIXTURE="$FIXTURE"

--- a/tests/l5-l6/rows/44-cheatcode-install-plugins/tools-required.json
+++ b/tests/l5-l6/rows/44-cheatcode-install-plugins/tools-required.json
@@ -1,0 +1,4 @@
+[
+  "mcp__plugin_tmb_trajectory-server__cheatcode_approve",
+  "mcp__plugin_tmb_trajectory-server__cheatcode_install"
+]

--- a/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/README.md
+++ b/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/README.md
@@ -1,0 +1,16 @@
+# 45-cheatcode-uninstall-plugins
+
+**Scenario:** Onboarded project with two plugins already installed — `feature-dev` (attached to swe) and `code-review` (attached to pr-reviewer). The user tells bro to uninstall both. Uninstall is bro-proposed + Human-confirmed, not PreToolUse-gated (#676): bro discovers each installed cheatcode's id and calls `cheatcode_uninstall` once per plugin. Each uninstall reverses the attachment via the marketplace/plugin uninstall path (no manual file deletion), deletes the `cheatcodes` + `cheatcode_attachments` rows in one transaction, and emits a `cheatcode_uninstalled` audit row. Idempotent — an absent install no-ops cleanly.
+
+**Determinism:** `setup-l5.sh` pre-seeds the installed state (two `cheatcodes` rows scope='local' + their per-agent attachments + the `cheatcode_install`/`cheatcode_installed` audit rows carrying each cheatcode_id) directly into the trajectory DB, then writes a teardown fixture and points `cheatcode_uninstall` at it via `TMB_CHEATCODE_UNINSTALL_FIXTURE` — no live web, no real marketplace call. This row asserts the flow ran (both teardowns recorded, both cheatcodes + their attachments gone), not marketplace results.
+
+**L5 mode:** `setup-l5.sh` seeds the installed state + fixture; `fixture.txt` seeds `onboarding-named` identity.
+**L6 mode:** Standalone here — NOT in the chain manifest (L6-B renumbers + wires it into the cheatcode journey chain, where the install row seeds the state instead).
+
+## Scorers
+
+| Scorer | Asserts |
+|---|---|
+| `outcome.sql` | Two `cheatcode_uninstalled` audit rows; the feature-dev AND code-review cheatcodes rows gone (COUNT=0 by name); their attachment rows (target='swe', target='pr-reviewer') gone |
+| `tools-required.json` | `cheatcode_uninstall` called |
+| `cost-budget.json` | Soft 60K tokens / 90s |

--- a/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/cost-budget.json
+++ b/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/cost-budget.json
@@ -1,0 +1,6 @@
+{
+  "max_tokens_total": 60000,
+  "max_duration_ms": 90000,
+  "fail_above_max": false,
+  "_comment": "Soft budget — warn on overage but don't fail the run."
+}

--- a/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/fixture.txt
+++ b/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/fixture.txt
@@ -1,0 +1,1 @@
+onboarding-named

--- a/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/outcome.sql
+++ b/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/outcome.sql
@@ -1,0 +1,48 @@
+-- Outcome assertions for 45-cheatcode-uninstall-plugins. Each row returns
+-- (pass, description). The scorer requires every row's pass column to be 1.
+--
+-- Scope: setup-l5.sh pre-seeds two installed plugins (feature-dev → swe,
+-- code-review → pr-reviewer). bro tears both down. The deterministic proof is
+-- (a) two cheatcode_uninstalled audit rows, (b) both cheatcodes rows gone
+-- (COUNT=0 by name), and (c) their attachment rows gone (the install + teardown
+-- reverse each attachment via the marketplace path). Marketplace results are
+-- stubbed via TMB_CHEATCODE_UNINSTALL_FIXTURE; the teardown SHAPE is covered by
+-- L2/L3, the journey-level reversal here.
+
+SELECT
+  CASE WHEN COUNT(*) >= 2 THEN 1 ELSE 0 END AS pass,
+  'two-cheatcode_uninstalled-audit-rows (got ' || COUNT(*) || ')' AS description
+FROM audit
+WHERE event_type = 'cheatcode_uninstalled'
+
+UNION ALL
+
+SELECT
+  CASE WHEN COUNT(*) = 0 THEN 1 ELSE 0 END AS pass,
+  'feature-dev-cheatcode-row-gone (got ' || COUNT(*) || ')' AS description
+FROM cheatcodes
+WHERE name = 'feature-dev'
+
+UNION ALL
+
+SELECT
+  CASE WHEN COUNT(*) = 0 THEN 1 ELSE 0 END AS pass,
+  'code-review-cheatcode-row-gone (got ' || COUNT(*) || ')' AS description
+FROM cheatcodes
+WHERE name = 'code-review'
+
+UNION ALL
+
+SELECT
+  CASE WHEN COUNT(*) = 0 THEN 1 ELSE 0 END AS pass,
+  'feature-dev-attachment-gone (got ' || COUNT(*) || ')' AS description
+FROM cheatcode_attachments
+WHERE target = 'swe'
+
+UNION ALL
+
+SELECT
+  CASE WHEN COUNT(*) = 0 THEN 1 ELSE 0 END AS pass,
+  'code-review-attachment-gone (got ' || COUNT(*) || ')' AS description
+FROM cheatcode_attachments
+WHERE target = 'pr-reviewer';

--- a/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/prompt.txt
+++ b/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/prompt.txt
@@ -1,0 +1,1 @@
+@bro uninstall the feature-dev and code-review plugins. Don't ask questions.

--- a/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/script.json
+++ b/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/script.json
@@ -1,0 +1,5 @@
+{
+  "max_turns": 1,
+  "user_after_bro": [],
+  "terminal_pattern": "uninstalled|cheatcode_uninstall|removed|torn down|done|all set"
+}

--- a/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/setup-l5.sh
+++ b/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/setup-l5.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Cheatcode-uninstall-plugins L5 isolation: pre-seed the INSTALLED state for two
+# plugins (feature-dev → swe, code-review → pr-reviewer) directly into the
+# trajectory DB so the uninstall has something concrete to reverse, then point
+# cheatcode_uninstall at a deterministic teardown fixture via
+# TMB_CHEATCODE_UNINSTALL_FIXTURE so no live web / real marketplace call is ever
+# made. The fixture lives in the project dir; the env export covers runners that
+# source this setup.
+#
+# The seed mirrors exactly what a prior cheatcode_install would have written: a
+# cheatcodes row (kind='plugin', scope='local', status='installed') + its
+# per-agent attachment row, plus the cheatcode_install / cheatcode_installed
+# audit rows that carry each cheatcode_id (so bro can discover the ids to tear
+# down). cheatcode_uninstall then deletes the cheatcodes + cheatcode_attachments
+# rows in one transaction and emits a cheatcode_uninstalled audit row.
+set -uo pipefail
+
+PROJECT="$1"
+# shellcheck disable=SC2034
+SCENARIO_DIR="$2"
+
+DB="$PROJECT/.claude/tmb/trajectory.db"
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+sqlite3 "$DB" <<SQL
+INSERT INTO cheatcodes (id, name, kind, source_url, version, trust_tier, scope, status, installed_at)
+VALUES
+  (1, 'feature-dev', 'plugin', 'https://example.test/feature-dev', '1.0.0', 'trusted', 'local', 'installed', '$NOW'),
+  (2, 'code-review', 'plugin', 'https://example.test/code-review', '1.0.0', 'trusted', 'local', 'installed', '$NOW');
+
+INSERT INTO cheatcode_attachments (cheatcode_id, target, artifact, created_at)
+VALUES
+  (1, 'swe', 'marketplace-plugin:feature-dev', '$NOW'),
+  (2, 'pr-reviewer', 'marketplace-plugin:code-review', '$NOW');
+
+INSERT INTO audit (issue_id, branch_id, from_node, event_type, summary, content_json, created_at)
+VALUES
+  (-1, NULL, 'bro', 'cheatcode_install', 'Cheatcode install: ''feature-dev'' (kind=plugin, method=marketplace)', '{"name":"feature-dev","kind":"plugin","source_url":"https://example.test/feature-dev","method":"marketplace"}', '$NOW'),
+  (-1, NULL, 'bro', 'cheatcode_installed', 'Cheatcode installed: ''feature-dev'' → cheatcode_id=1', '{"cheatcode_id":1,"name":"feature-dev","kind":"plugin","source_url":"https://example.test/feature-dev","installed":true,"attachments":[{"target":"swe","artifact":"marketplace-plugin:feature-dev"}]}', '$NOW'),
+  (-1, NULL, 'bro', 'cheatcode_install', 'Cheatcode install: ''code-review'' (kind=plugin, method=marketplace)', '{"name":"code-review","kind":"plugin","source_url":"https://example.test/code-review","method":"marketplace"}', '$NOW'),
+  (-1, NULL, 'bro', 'cheatcode_installed', 'Cheatcode installed: ''code-review'' → cheatcode_id=2', '{"cheatcode_id":2,"name":"code-review","kind":"plugin","source_url":"https://example.test/code-review","installed":true,"attachments":[{"target":"pr-reviewer","artifact":"marketplace-plugin:code-review"}]}', '$NOW');
+SQL
+
+FIXTURE="$PROJECT/.tmb-cheatcode-uninstall-fixture.json"
+cat > "$FIXTURE" <<'JSON'
+{ "removed": true, "error": null }
+JSON
+
+export TMB_CHEATCODE_UNINSTALL_FIXTURE="$FIXTURE"

--- a/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/tools-required.json
+++ b/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/tools-required.json
@@ -1,0 +1,3 @@
+[
+  "mcp__plugin_tmb_trajectory-server__cheatcode_uninstall"
+]


### PR DESCRIPTION
Two new L6 rows (`44-cheatcode-install-plugins`, `45-cheatcode-uninstall-plugins`) mirroring row 43, standalone L5-runnable. Not yet wired into the chain manifest (that's L6-B).

- Bare no-AUQ prompts (claude -p safe).
- outcome.sql honest: fail-before / pass-after against the real schema + real install/uninstall scripts; stronger than row 43 (per-name + per-target pins).
- pr-reviewer PASS, no findings.

⚠️ **Touches L6 prompt rows — flagged for Human review** (TMB/ ledger). Auto-merged per the autonomous-run directive.

Refs #778. (Strict per-agent attachment assertion lands once the per-candidate fixture fix merges, then L6-B tightens row 44.)

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)