### PR TITLE
🧪 test(l6): wire cheatcode install/uninstall into the chain manifest (#778)

### DIFF
--- a/tests/EVALUATION.md
+++ b/tests/EVALUATION.md
@@ -113,6 +113,8 @@ Reading the dotted edges:
 
 **Note on retired step 14:** the `skill_invocations` hook-attribution assertion that step 14 used to own is now folded into step 04's outcome.sql — `skill_invocations` rows accumulate naturally on any chain step that invokes tmb skills, and step 04 is the first such step. The standalone row was redundant.
 
+**Note on the cheatcode steps (chain steps 4 and 9):** the chain now runs the cheatcode pipeline end-to-end via two rows wired into `chain-manifest.json` (dir names `rows/44-cheatcode-install-plugins` and `rows/45-cheatcode-uninstall-plugins`, pending the cosmetic 1–15 dir renumber). **Chain step 4** (`44-cheatcode-install-plugins`) installs two marketplace plugins via cheatcode — `feature-dev` attaches to `swe`, `code-review` attaches to `pr-reviewer` — so the install state is cumulative for the rest of the journey. **Chain step 9** (`45-cheatcode-uninstall-plugins`) reverses it, tearing the installed cheatcodes + attachments back down. Both steps stage their deterministic, no-network fixture via a `chain_setup_command` that reuses the row's own `setup-l5.sh` (the same script L5 isolation sources directly). The existing rows shift down accordingly: `04-first-task-hits-gate` runs at chain step 5, `09-concerns-protocol` at step 11, `13-search-grounding` at step 15.
+
 **Reading the S13 dotted edge:** S8 → S13: step 08 records the `kind='decision'` discussion that step 13 searches for. In L6, the organic DB carry means the row is already present when step 13 fires. In L5 isolation, `setup-l5.sh` seeds the same decision body so the same prompt + assertion work unchanged.
 
 ---

--- a/tests/l5-l6/l6-chain/chain-manifest.json
+++ b/tests/l5-l6/l6-chain/chain-manifest.json
@@ -1,5 +1,5 @@
 {
-  "description": "Single chained L6 integration test. 13 sequential rows fired via fresh `claude -p` each, against a cumulative trajectory DB. State carries across rows via the trajectory DB. See tests/EVALUATION.md for the journey spec.",
+  "description": "Single chained L6 integration test. 15 sequential rows fired via fresh `claude -p` each, against a cumulative trajectory DB. State carries across rows via the trajectory DB. See tests/EVALUATION.md for the journey spec.",
   "initial_fixture": "empty",
   "initial_setup": null,
   "steps": [
@@ -36,6 +36,18 @@
     {
       "step": 4,
       "id": 4,
+      "name": "44-cheatcode-install-plugins",
+      "row_dir": "rows/44-cheatcode-install-plugins",
+      "partial_test": false,
+      "seed_before": null,
+      "chain_setup_command": "bash \"$PLUGIN_ROOT/tests/l5-l6/rows/44-cheatcode-install-plugins/setup-l5.sh\" \"$PWD\" \"$PLUGIN_ROOT\"",
+      "chain_setup_note": "Stage the cheatcode-install fixture exactly as the row's setup-l5.sh does (deterministic marketplace stub, no network): writes $PROJECT/.tmb-cheatcode-install-fixture.json with per-candidate attachment targets (feature-dev→swe, code-review→pr-reviewer). L5 standalone sources the same setup directly.",
+      "seed_after": null,
+      "halt_on_fail": true
+    },
+    {
+      "step": 5,
+      "id": 5,
       "name": "04-first-task-hits-gate",
       "row_dir": "rows/04-first-task-hits-gate",
       "partial_test": false,
@@ -44,8 +56,8 @@
       "halt_on_fail": true
     },
     {
-      "step": 5,
-      "id": 5,
+      "step": 6,
+      "id": 6,
       "name": "05-swe-atomic-close",
       "row_dir": "rows/05-swe-atomic-close",
       "partial_test": false,
@@ -54,8 +66,8 @@
       "halt_on_fail": true
     },
     {
-      "step": 6,
-      "id": 6,
+      "step": 7,
+      "id": 7,
       "name": "06-post-close-cleanup",
       "row_dir": "rows/06-post-close-cleanup",
       "partial_test": false,
@@ -66,8 +78,8 @@
       "chain_setup_note": "Expose the implemented-but-unmerged CLI: prior steps leave src/cli.py on its task branch (the checkout rests on the base per stay-on-base doctrine); the Human inspecting in-flight work checks the branch out. L5 standalone seeds the file directly."
     },
     {
-      "step": 7,
-      "id": 7,
+      "step": 8,
+      "id": 8,
       "name": "07-push-gate",
       "row_dir": "rows/07-push-gate",
       "partial_test": false,
@@ -77,8 +89,20 @@
       "chain_post_command": "LATEST=$(git for-each-ref --sort=-committerdate --format=\"%(refname:short)\" refs/heads/ | grep -E \"^(feat|fix|chore|refactor)/\" | head -1); [ -n \"$LATEST\" ] && git checkout dev 2>/dev/null && git merge --ff-only \"$LATEST\" 2>/dev/null || true"
     },
     {
-      "step": 8,
-      "id": 8,
+      "step": 9,
+      "id": 9,
+      "name": "45-cheatcode-uninstall-plugins",
+      "row_dir": "rows/45-cheatcode-uninstall-plugins",
+      "partial_test": false,
+      "seed_before": null,
+      "chain_setup_command": "bash \"$PLUGIN_ROOT/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/setup-l5.sh\" \"$PWD\" \"$PLUGIN_ROOT\"",
+      "chain_setup_note": "Stage the cheatcode-uninstall fixture exactly as the row's setup-l5.sh does (deterministic teardown stub, no network): seeds the INSTALLED state (cheatcodes + attachments + install audit rows for feature-dev→swe, code-review→pr-reviewer) and writes $PROJECT/.tmb-cheatcode-uninstall-fixture.json so the uninstall has concrete state to reverse. L5 standalone sources the same setup directly.",
+      "seed_after": null,
+      "halt_on_fail": true
+    },
+    {
+      "step": 10,
+      "id": 10,
       "name": "08-architectural-change",
       "row_dir": "rows/08-architectural-change",
       "partial_test": false,
@@ -87,8 +111,8 @@
       "halt_on_fail": true
     },
     {
-      "step": 9,
-      "id": 9,
+      "step": 11,
+      "id": 11,
       "name": "09-concerns-protocol",
       "row_dir": "rows/09-concerns-protocol",
       "partial_test": false,
@@ -96,11 +120,11 @@
       "seed_after": null,
       "halt_on_fail": true,
       "chain_setup_command": "b=$(git for-each-ref --format='%(refname:short)' refs/heads | while read -r br; do git ls-tree -r --name-only \"$br\" | grep -qx 'tests/test_cli.py' && { echo \"$br\"; break; }; done); [ -n \"$b\" ] && git checkout -q \"$b\"",
-      "chain_setup_note": "Expose tests/test_cli.py (created on the step-04/05 task branch, unmerged until push-gate): the row's bait is its exact-equality-on-integers content, which must be visible for the concern to register. Same pattern as step 6. L5 standalone seeds the files directly."
+      "chain_setup_note": "Expose tests/test_cli.py (created on the step-04/05 task branch, unmerged until push-gate): the row's bait is its exact-equality-on-integers content, which must be visible for the concern to register. Same pattern as step 7. L5 standalone seeds the files directly."
     },
     {
-      "step": 10,
-      "id": 10,
+      "step": 12,
+      "id": 12,
       "name": "10-consultant",
       "row_dir": "rows/10-consultant",
       "partial_test": false,
@@ -109,8 +133,8 @@
       "halt_on_fail": true
     },
     {
-      "step": 11,
-      "id": 11,
+      "step": 13,
+      "id": 13,
       "name": "11-roundtable",
       "row_dir": "rows/11-roundtable",
       "partial_test": true,
@@ -120,8 +144,8 @@
       "halt_on_fail": true
     },
     {
-      "step": 12,
-      "id": 12,
+      "step": 14,
+      "id": 14,
       "name": "12-issue-resume",
       "row_dir": "rows/12-issue-resume",
       "partial_test": false,
@@ -131,8 +155,8 @@
       "chain_setup_command": "base=$(git for-each-ref --format='%(refname:short)' refs/heads | while read -r br; do git ls-tree -r --name-only \"$br\" | grep -qx 'src/cli.py' && { echo \"$br\"; break; }; done); git branch feat/add-count-subcommand \"${base:-HEAD}\" 2>/dev/null || true"
     },
     {
-      "step": 13,
-      "id": 13,
+      "step": 15,
+      "id": 15,
       "name": "13-search-grounding",
       "row_dir": "rows/13-search-grounding",
       "partial_test": false,


### PR DESCRIPTION
Reorders chain-manifest.json to 15 steps with cheatcode install at step 4 / uninstall at step 9 (+ EVALUATION.md note). All existing steps' seeds/commands preserved verbatim. pr-reviewer PASS (validation attempt 1). Refs #778.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)