### PR TITLE
📝 docs(readme): add READMEs for docs/* and tests/* dirs (#807)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,14 @@
+# docs/architecture/
+
+Design rationale for how the TMB plugin is built — the schema, the workflow gates, the role boundaries, and the substrates bro reasons from. Read these when you need the "why" behind a structure, not just the "what."
+
+| File | Purpose |
+|---|---|
+| [`ERD.md`](./ERD.md) | Trajectory DB entity-relationship diagram — the SQLite schema, table groups, and where the DB lives on disk |
+| [`FLOWS.md`](./FLOWS.md) | The Human → bro → SWE decision chain and the two gates (bro = task gate, pr-reviewer = push gate) |
+| [`RESPONSIBILITIES.md`](./RESPONSIBILITIES.md) | The role × tool matrix — what each shipped agent is actually instructed to do, plus server-enforced boundaries |
+| [`GIT.md`](./GIT.md) | Where each actor's git state lives across a task lifecycle; the local-is-canonical invariant |
+| [`WORLD_MODEL.md`](./WORLD_MODEL.md) | The kuzu world-model graph — bro's queryable project map, built by `scan_run` |
+| [`TYPED_RAILS.md`](./TYPED_RAILS.md) | Promoting enforced fields (`files`, `verification`) from markdown to typed schema columns |
+| [`CHEATCODES.md`](./CHEATCODES.md) | The discover → vet → install → hot-load pipeline for acquiring skills, MCP toolkits, and plugins on demand |
+| [`UI.md`](./UI.md) | The interactive UI primitives Claude Code exposes and how bro renders them |

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,0 +1,9 @@
+# docs/contributing/
+
+Controlled-vocabulary registries — the source-of-truth names that hooks branch on, skills assert on, and bro routes by. Consult these before adding or renaming an enum value, a label, or a feature stem; a silent rename here breaks downstream code without a compile error.
+
+| File | Purpose |
+|---|---|
+| [`ENUMS.md`](./ENUMS.md) | Source of truth for every controlled vocabulary (status, kind, role, …) in the trajectory DB |
+| [`LABELS.md`](./LABELS.md) | The shared issue-label set used by GitHub, Linear, and the local `issue_labels` table |
+| [`NAMING.md`](./NAMING.md) | The one-stem-per-feature rule — every surface implementing/testing/documenting a feature uses the same name |

--- a/docs/prompt-engineering/README.md
+++ b/docs/prompt-engineering/README.md
@@ -1,0 +1,9 @@
+# docs/prompt-engineering/
+
+How TMB writes and enforces the prompts that drive its agents. The central rule: anything load-bearing belongs on a deterministic layer (hook, tool, schema), not in prose; prompts carry only the irreducibly judgment-bound parts.
+
+| File | Purpose |
+|---|---|
+| [`DETERMINISM.md`](./DETERMINISM.md) | The determinism-vs-judgment layering rules — what migrates out of a prompt into a deterministic layer |
+| [`ENFORCEMENT.md`](./ENFORCEMENT.md) | The 6 enforcement layers (hardest → softest) and which mechanism covers which interaction |
+| [`PROMPT_ENGINEERING.md`](./PROMPT_ENGINEERING.md) | How we author agent personas, skills, and commands — mainstream prompt-engineering technique adapted for tool-using agents |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,9 @@
+# docs/reference/
+
+Operational lookups bro and contributors hit occasionally — kept here so they don't bloat `CLAUDE.md`. Where state lives, what platforms are supported, and what to expect on upgrade.
+
+| File | Purpose |
+|---|---|
+| [`REFERENCE.md`](./REFERENCE.md) | Where workflow state lives — trajectory DB, kuzu world model, and CC config paths |
+| [`MULTI_PLATFORM.md`](./MULTI_PLATFORM.md) | OS-compatibility notes and the Claude-Code-only platform posture |
+| [`UPGRADE.md`](./UPGRADE.md) | Plugin + trajectory-DB version migration — what to expect, recover, and roll back |

--- a/tests/l0-install/README.md
+++ b/tests/l0-install/README.md
@@ -1,0 +1,10 @@
+# L0 — Install-smoke + Release canary
+
+Docker-based install verification. L0 simulates what a fresh marketplace install does (clone → `bun install` → cold-spawn the MCP server) so distribution regressions — missing `dist/`, absent postinstall build, server failing to boot — are caught before they reach a user. The Release canary builds on the same image, then also runs the L5 doctrine flows against the marketplace-installed plugin (RC-only, token-heavy).
+
+| File | Purpose |
+|---|---|
+| [`install-smoke.Dockerfile`](./install-smoke.Dockerfile) | L0 image — each `RUN test` line is a fail-fast assertion that a cold install boots cleanly |
+| [`run-install-smoke.sh`](./run-install-smoke.sh) | Local convenience wrapper that builds the install-smoke image from the plugin root |
+| [`release-canary.Dockerfile`](./release-canary.Dockerfile) | Install-smoke + full L5 doctrine flows against the marketplace artifact in one image |
+| [`run-release-canary.sh`](./run-release-canary.sh) | Local wrapper for the canary — builds image only without a token, full L0+L5 run with `CLAUDE_CODE_OAUTH_TOKEN` |

--- a/tests/l1-lint/README.md
+++ b/tests/l1-lint/README.md
@@ -1,0 +1,71 @@
+# L1 — Lint
+
+Fast, free, deterministic guards run before any heavier layer. Each script is a single-purpose check that catches a class of drift — stale versions, broken links, doctrine-doc parity, prompt-surface regressions — in milliseconds. They run together via the L1 step of `tests/run-all.sh`; each is also runnable standalone. `fixtures/` holds sample inputs some checks lint against.
+
+Run one directly:
+
+```bash
+bash tests/l1-lint/link-check.sh
+```
+
+## Checks by theme
+
+### Version & release integrity
+| Script | Catches |
+|---|---|
+| [`version-sync.sh`](./version-sync.sh) | Version drift across manifest/package files |
+| [`changelog-current.sh`](./changelog-current.sh) | CHANGELOG missing the current version |
+| [`dist-fresh.sh`](./dist-fresh.sh) | Committed `dist/` out of sync with source |
+| [`tsc-noemit.sh`](./tsc-noemit.sh) | TypeScript type errors (no emit) |
+| [`release-script-safety.sh`](./release-script-safety.sh) | Unsafe patterns in release scripts |
+| [`ci-workflow-refs-exist.sh`](./ci-workflow-refs-exist.sh) | CI workflow references that don't resolve |
+
+### Docs & doctrine parity
+| Script | Catches |
+|---|---|
+| [`link-check.sh`](./link-check.sh) | Broken relative markdown links |
+| [`enums-stable.sh`](./enums-stable.sh) | Enum values drifting from `docs/contributing/ENUMS.md` |
+| [`labels-stable.sh`](./labels-stable.sh) | Labels drifting from `docs/contributing/LABELS.md` |
+| [`stale-framing-prose.sh`](./stale-framing-prose.sh) | Outdated framing prose in docs |
+
+### Prompt-surface hygiene (agents, skills, commands)
+| Script | Catches |
+|---|---|
+| [`agent-line-budget.sh`](./agent-line-budget.sh) | Agent prompt files over their line cap |
+| [`agent-task-brief-contract.sh`](./agent-task-brief-contract.sh) | Agent/task-brief contract drift |
+| [`agent-template-byte-identity.sh`](./agent-template-byte-identity.sh) | Shipped vs template agent byte mismatch |
+| [`command-frontmatter.sh`](./command-frontmatter.sh) | Malformed command frontmatter |
+| [`skill-frontmatter.sh`](./skill-frontmatter.sh) | Malformed skill frontmatter |
+| [`skill-catalog-sync.sh`](./skill-catalog-sync.sh) | Skill catalog out of sync with skill dirs |
+| [`tool-description-budget.sh`](./tool-description-budget.sh) | MCP tool descriptions over budget |
+| [`no-citations-in-prompts.sh`](./no-citations-in-prompts.sh) | Issue #s / PR URLs leaking into prompt files |
+| [`no-negative-directives.sh`](./no-negative-directives.sh) | Negative ("never…") directives in prompts |
+| [`local-agent-primitives.sh`](./local-agent-primitives.sh) | Local-agent primitive usage |
+
+### Source & schema invariants
+| Script | Catches |
+|---|---|
+| [`no-bare-role-compare.sh`](./no-bare-role-compare.sh) | Bare role-string comparisons instead of requireRoles |
+| [`no-raw-sql-interpolation.sh`](./no-raw-sql-interpolation.sh) | Raw SQL string interpolation (allowlist: `no-raw-sql-interpolation.allowlist`) |
+| [`no-destructive-sql.sh`](./no-destructive-sql.sh) | Destructive SQL statements |
+| [`no-audit-log-kind.sh`](./no-audit-log-kind.sh) | Disallowed audit-log `kind` usage |
+| [`no-audit-log-without-from-node.sh`](./no-audit-log-without-from-node.sh) | Audit-log writes missing `from_node` |
+| [`no-directories-table-refs.sh`](./no-directories-table-refs.sh) | References to the retired directories table |
+| [`no-file-registry-refs.sh`](./no-file-registry-refs.sh) | References to the retired file registry |
+| [`rag-schema-invariants.sh`](./rag-schema-invariants.sh) | RAG/embedding schema invariants |
+| [`manifest-shape.sh`](./manifest-shape.sh) | Plugin manifest shape |
+| [`valid-permission-decisions.sh`](./valid-permission-decisions.sh) | Invalid hook permission decisions |
+
+### Hooks, toolchain & secrets
+| Script | Catches |
+|---|---|
+| [`hooks-executable.sh`](./hooks-executable.sh) | Hook scripts missing the executable bit |
+| [`shellcheck-hooks.sh`](./shellcheck-hooks.sh) | Shellcheck violations in hook scripts |
+| [`dir-toolchain.sh`](./dir-toolchain.sh) | Per-directory toolchain expectations |
+| [`kuzu-trusted-dep.sh`](./kuzu-trusted-dep.sh) | kuzu trusted-dependency declaration |
+| [`symlink-targets.sh`](./symlink-targets.sh) | Symlinks pointing at missing targets |
+| [`main-guard-files-present.sh`](./main-guard-files-present.sh) | Required main-guard files present |
+| [`no-secrets-in-source.sh`](./no-secrets-in-source.sh) | Secrets committed to source |
+| [`no-developer-paths.sh`](./no-developer-paths.sh) | Hardcoded developer/local paths |
+| [`no-hardcoded-plugin-name.sh`](./no-hardcoded-plugin-name.sh) | Hardcoded plugin name instead of resolution |
+| [`issue-sync-test-isolation.sh`](./issue-sync-test-isolation.sh) | Tests not isolating issue-sync side effects |

--- a/tests/l3-integration/README.md
+++ b/tests/l3-integration/README.md
@@ -1,0 +1,8 @@
+# L3 — Integration
+
+Deterministic integration tests that exercise the real wiring — the MCP server as a subprocess over JSON-RPC stdio, and the hook scripts against synthetic events. L3 catches what L2 cannot: schema drift, a missing `agent` param, role-enforcement plumbing, and hook deny/inject behavior at the wire level. Each subdir has its own `run.sh`; both run as part of `tests/run-all.sh`.
+
+| Subdir | Purpose |
+|---|---|
+| [`mcp/`](./mcp/) | Real server subprocess + JSON-RPC tests — role matrix, schema contract, scope gate, search tools, and per-agent workflow sequences. Shared harness in `harness.mjs`; run via `mcp/run.sh` |
+| [`hooks/`](./hooks/) | Hook-script tests — one `*.test.sh` per hook asserting deny/inject/pass-through behavior (git guards, swe gates, sandbox isolation, cheatcode flow, …). Run via `hooks/run.sh`; shared fixtures in `hooks/fixtures/` |

--- a/tests/l5-l6/README.md
+++ b/tests/l5-l6/README.md
@@ -1,0 +1,21 @@
+# L5 + L6 — Row-based real-Claude harness
+
+The heaviest, non-deterministic layers: they drive real Claude Code (`claude -p`) through user-language prompts and score the resulting MCP/tool sequence and DB state against doctrine. Both layers share one canonical row tree under [`rows/`](./rows/) — **L5** runs a row in isolation (applies its `setup-l5.sh` to pre-seed prior state), **L6** walks the rows as a cumulative chain where state inherits from the prior step. See [`../README.md`](../README.md) for the testing philosophy and [`../EVALUATION.md`](../EVALUATION.md) for the scorer model.
+
+> Test prompts (`rows/*/prompt.txt`) are Human-authored. Do not edit them to make a chain pass — fix the assertion, `setup-l5.sh`, hook, or doctrine instead.
+
+```bash
+bash tests/l5-l6/run-l5.sh                 # all rows in isolation
+bash tests/l5-l6/run-l5.sh onboarding      # one row by name substring
+bash tests/l5-l6/run-l6-chain.sh           # full cumulative chain
+```
+
+| File / folder | Purpose |
+|---|---|
+| [`run-l5.sh`](./run-l5.sh) | Per-row isolated runner — applies `setup-l5.sh`, drives the prompt, runs scorers |
+| [`run-l6-chain.sh`](./run-l6-chain.sh) | Multi-turn chain runner — walks the manifest rows against one cumulative trajectory DB |
+| [`rows/`](./rows/) | The canonical row tree — each `<NN>-<name>/` holds `prompt.txt`, `script.json`, `fixture.txt`, `setup-l5.sh`, `outcome.sql`, `tools-required.json`, `tools-forbidden.json`, `cost-budget.json`, and optional outcome bundles |
+| [`l6-chain/`](./l6-chain/) | Chain configuration — `chain-manifest.json` (ordered steps) + `seeds/` (between-row SQL bridges). See its [`README.md`](./l6-chain/README.md) |
+| [`lib/`](./lib/) | Shared shell helpers — flow/chain helpers, scorers, sandbox, stubs, timeout shim |
+| [`fixtures/`](./fixtures/) | SQL fixtures (`empty`, `onboarding-named`, `onboarding-anonymous`) that pre-seed the world-model-cold gate |
+| [`inspect-trajectory.sh`](./inspect-trajectory.sh) | Helper to inspect a run's trajectory DB |


### PR DESCRIPTION
World-model coverage (#807): adds READMEs to 8 docs/tests dirs that lacked them — docs/{architecture,contributing,prompt-engineering,reference}, tests/{l0-install,l1-lint,l3-integration,l5-l6}. All content verified accurate vs real dir contents (40 lint scripts indexed, none invented); link-check 157 links. pr-reviewer PASS (150). (3 empty stray 'init' commits on the branch squash away.) Part of #807.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)