### PR TITLE
📝 docs(readme): add code-surface READMEs + skip README.md in command-frontmatter (#807)

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,20 @@
+# agents
+
+The plugin's shipped subagents — the roles bro dispatches a code-touching task to. Each file is a Claude Code agent definition: YAML frontmatter (name, model, tool allow-list, attached skills) followed by the persona prompt. bro itself is defined by the plugin-root `CLAUDE.md`, so it lives outside this directory; only the agents bro spawns are here.
+
+## Agents
+
+| File | Role | Tools / shape |
+|---|---|---|
+| `swe.md` | Executor — implements one task spec in an isolated git worktree, then closes it atomically. Every production code change routes through swe. | Read/Glob/Grep/Bash/Write/Edit plus `task_brief` + `task_update_status`; attached skills `tmb_swe-checklist`, `tmb_docs-conventions`. |
+| `pr-reviewer.md` | Push gate — independently reviews a committed task against its spec and records the `validation_record` verdict that gates the push. Read-only on files by design (no Write/Edit). | Read/Glob/Grep/Bash/Task plus the review + audit MCP tools; attached skill `tmb_review`. |
+
+Both carry `tmb_owner: bro` in frontmatter, marking them plugin-managed.
+
+## Consultants
+
+Domain experts (security, performance, legal, and the like) are not shipped here. The Human creates them on demand with the `/tmb:agent-create` command, which writes the new agent into the project's own `.claude/agents/` directory and registers it. A project may also place a local override of `swe` or `pr-reviewer` at that same path.
+
+## How it fits
+
+These definitions are the executor and gate halves of bro's code-touching flow: bro writes a spec, dispatches `swe` to implement it, then `pr-reviewer` signs off before anything is pushed. The frontmatter tool allow-lists keep each role scoped to what it needs, and the attached skills carry the step-by-step procedures so the persona prompts stay short. Behavior is exercised by the L5/L6 chain under `tests/l5-l6/`.

--- a/commands/README.md
+++ b/commands/README.md
@@ -1,0 +1,17 @@
+# commands
+
+The plugin's slash commands — the Human-triggered entry points into TMB's workflow. Each file is a Claude Code command: YAML frontmatter (`description`, `argument-hint`, optional `allowed-tools`) followed by the body bro runs when the command fires. Most commands are thin orchestration layers — the deterministic logic lives in the `onboard_*`, `scan_run`, `agent_*`, and `roundtable_*` MCP tools, so each body mostly passes data between AskUserQuestion and the server.
+
+## Commands
+
+| Command | Purpose | Argument |
+|---|---|---|
+| `onboard.md` | Configure or change identity, branching model, PR target, remotes, and issue-sync via a short AskUserQuestion ceremony. Auto-fires on bro's first turn when the project is not yet onboarded. | (none) |
+| `scan.md` | Refresh the world model — walk the session dir for git repos and pull each directory's `README.md` into a summary node in the kuzu graph. Idempotent and summary-preserving. | (none) |
+| `agent-create.md` | Create or copy an agent into the project's `.claude/agents/` directory and optionally spawn it on a consultant question. User-created agents default to `kind='consultant'`. | `<kebab-case name>` plus optional question |
+| `roundtable.md` | Run a structured multi-agent deliberation: collect parallel positions, synthesize agreements and disagreements, ratify with the Human via AUQ, then close with decisions. | `<topic>` |
+| `monitor.md` | Pull review comments from a GitHub PR or GitLab MR and plan/dispatch SWE work to address them, via the `tmb_review` skill's triage section. | `<PR or MR number>` |
+
+## How it fits
+
+Commands are how a Human steers the workflow that bro otherwise drives autonomously. Policy changes (`/onboard`), world-model refreshes (`/scan`), specialist creation (`/tmb:agent-create`), group decisions (`/roundtable`), and review triage (`/monitor`) each have a dedicated entry point so the same ceremony runs the same way every time. Frontmatter is checked at L1 (`tests/l1-lint/command-frontmatter.sh`); the interactive flows are exercised by the L5/L6 chain.

--- a/mcp/trajectory-server/src/tools/README.md
+++ b/mcp/trajectory-server/src/tools/README.md
@@ -1,0 +1,32 @@
+# src/tools
+
+The MCP tool modules for the trajectory server — one TypeScript file per domain. Each module exports a factory (e.g. `issueTools(db)`) returning `{ definitions, handlers }`: the JSON-Schema tool definitions Claude sees and the handlers that run against the SQLite trajectory DB (and, for some, the kuzu world-model graph). `index.ts` wires every module's definitions + handlers together and decorates each with the `agent` param used for role-gating.
+
+## Grouped by domain
+
+| Domain | File | Tools |
+|---|---|---|
+| Issues | `issues.ts` | `issue_create`, `issue_get`, `issue_list`, `issue_resume`, `issue_close`, `issue_link`, `issue_update_description`, `issue_get_phase`, `issue_sync_retry` |
+| Tasks | `tasks.ts` | `task_create_batch`, `task_get`, `task_update_status`, `task_first_actionable` |
+| Discussions | `discussions.ts` | `discussion_append`, `discussion_list`, `discussion_search`, `issue_get_with_discussions` |
+| Audit | `audit.ts` | `audit_log`, `audit_log_list`, `audit_search` |
+| Validation | `validation.ts` | `validation_record`, `validation_history` |
+| Composites | `composites.ts` | multi-step orchestration helpers: `task_brief`, `intent_start`, `branch_id_propose`, `bro_atomic_close`, `bro_verification_fail_record`, `pr_review_worktree`, `reap_and_review_prep`, `task_retry_batch`, `headless_intent_start`, `headless_fallback_record` |
+| Agents | `agents.ts` | `agent_register`, `agent_list`, `agent_resolve` |
+| Skills | `skills.ts` | `skill_register`, `skill_promote`, `skill_invocations_list` |
+| Cheatcodes | `cheatcode.ts` | `cheatcode_search`, `cheatcode_vet`, `cheatcode_approve`, `cheatcode_install`, `cheatcode_activate`, `cheatcode_uninstall` |
+| Roundtable | `roundtable.ts` | `roundtable_create`, `roundtable_vote`, `roundtable_summarize`, `roundtable_finalize_decisions`, `roundtable_close`, `roundtable_close_with_decisions` |
+| PR comments | `pr_comments.ts` | `pr_comments_get`, `pr_review_runs_list` |
+| Reports | `reports.ts` | `issue_report_md`, `issue_snapshot_md` |
+| Branch report | `branch_report_md.ts` | `branch_report_md` |
+| Stats | `stats.ts` | `task_stats` |
+| Config | `config.ts` | `config_get`, `config_set`, `config_list` |
+| Onboard | `onboard.ts` | `onboard_state_get`, `onboard_get_questions`, `onboard_apply` (+ `origin` helper) |
+| Scan | `scan.ts` | `scan_run` (forks `scripts/scan.sh`), `repos_list` |
+| World model | `world-model.ts` | `world_model_get`, `world_model_search` (kuzu graph) |
+
+`onboard-hooks-shim.ts` is a non-tool helper: it writes the plugin's PreToolUse hooks into the user's `settings.json` so they fire in headless `claude -p`, where marketplace plugin hooks are absent.
+
+## How it fits
+
+These modules are the entire MCP surface bro and the subagents call. `index.ts` is the registration point; role-gating per tool is enforced by `requireRoles()` in `../middleware/agent-scope.ts`. See `../../README.md` for the tool-family overview, environment, and schema notes. Handlers are unit-tested at L2 (`../test/`).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,25 @@
+# scripts
+
+Top-level shell + Node entry scripts that the plugin's hooks, MCP tools, and Human-run release flow shell out to. These are the deterministic, language-agnostic side of TMB — work that must run identically whether triggered by a hook, an MCP tool, or a person at a terminal, with no LLM in the loop.
+
+## Key files
+
+| Script | Purpose |
+|---|---|
+| `scan.sh` | Deterministic project scanner. Walks the session dir for git repos, enumerates each repo's tracked files, computes md5 + size + last-commit SHA per file, and emits a single JSON document. Forked by the `scan_run` MCP tool to feed the world model. |
+| `cheatcode-search.sh` | Discovers + ranks candidate Claude Code cheatcodes (skills, MCP/toolkits, plugins) for a capability query from reputable registries. |
+| `cheatcode-vet.sh` | Gathers reputation + security-surface signals for one candidate and emits a deterministic trust-tier classification. |
+| `cheatcode-install.sh` | Installs one approved cheatcode via the marketplace path and reports what was wired. |
+| `cheatcode-uninstall.sh` | Reverses one installed cheatcode and reports what was torn down. |
+| `release.sh` | Cuts a release from `main` after `dev` is merged and the version bump has landed. |
+| `prompt-author-lint.sh` | Pre-write lint for agent + skill files — flags pink-elephant negations and other prompt anti-patterns before a prompt file is written. |
+
+## Subdirectories
+
+- `hooks/` — the Claude Code lifecycle hook engine (PreToolUse gates, PostToolUse reactions, SessionStart preflight, etc.).
+- `lib/` — shared shell helpers sourced by the scripts and hooks above.
+- `maintenance/` — operational / one-off scripts (version bump, cache healing, stale-worktree cleanup, standalone scan invokers).
+
+## How it fits
+
+The `cheatcode-*` scripts back the `cheatcode_*` MCP tools; `scan.sh` backs `scan_run`; `release.sh` is Human-run release tooling. Keeping this logic in deterministic scripts lets the same behavior be exercised from a hook, an MCP tool, and the test suite without re-implementation.

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -1,0 +1,34 @@
+# scripts/hooks
+
+The Claude Code lifecycle hook engine — the deterministic enforcement layer that gates, nudges, and reacts to what bro and the subagents do each session. Every script reads a hook JSON payload on stdin and either exits silently, emits `additionalContext`, or returns a `permissionDecision: deny`. The wiring (which script runs on which event) lives in the plugin-root `hooks/hooks.json`; the scripts here are the implementations.
+
+## Grouped by lifecycle
+
+### SessionStart — preflight
+`ensure-gitignore.sh`, `mcp-health-check.sh`, `deferred-tools-drift-warn.sh`, `write-active-workspace-sentinel.sh`, `session-start-prescan.sh`, `ensure-kuzu-installed.sh`, `substrate-preflight.sh` — make sure the gitignore, MCP server, kuzu native binary, workspace sentinel, and required host binaries are in place before a session does real work.
+
+### UserPromptSubmit — per-turn setup + routing
+`activation-routine.sh`, `mcp-health-check.sh`, `session-log-capture.sh`, `prompt-intent-hints.sh`, `roundtable-slash-detect.sh` — inject identity/context, log the turn, and route phrasing hints (onboarding nudges, roundtable detection).
+
+### PreToolUse — gates (deny on violation)
+Git: `git-guards.sh`, `git-push-guard.sh`, `no-remote-auth-guard.sh`, `stay-on-base-guard.sh`, `no-source-edit-from-main.sh`, `no-worktree-branch-create.sh`, `branch-up-to-date-with-remote.sh`, `commit-msg-lint.sh`.
+Agent dispatch: `agent-spawn-dispatch.sh`, `swe-brief-gate.sh`, `swe-verification-gate.sh`, `swe-boundary.sh`, `swe-scope-fence.sh`.
+AUQ / roundtable / cheatcode: `askuserquestion-length-lint.sh`, `auq-headless-deny.sh`, `roundtable-auq-shape.sh`, `cheatcode-install-approval.sh`.
+Lint: `naming-lint.sh`, `code-quality-lint.sh`, `debug-trajectory.sh`.
+
+### PostToolUse — reactions after a tool succeeds
+`cleanup-worktree-on-task-close.sh`, `post-task-close-rescan.sh`, `post-atomic-close-readme.sh`, `post-task-create-spawn-hint.sh`, `skill-invocation-record.sh`, `post-pr-comments-persist.sh`, `roundtable-cleanup-postcheck.sh`, `attribution-footer.sh`.
+
+### Stop / SubagentStop / WorktreeCreate
+`bro-turn-usage.sh` (Stop), `swe-atomic-close.sh` + `consultant-persistence-gate.sh` (SubagentStop), `worktree-create.sh` (WorktreeCreate).
+
+### Not wired in hooks.json
+`require-task-spec.sh`, `require-feature-branch-active.sh`, `pr-reviewer-after-atomic-close.sh`, `pr-reviewer-no-worktree.sh`, `pr-reviewer-spawn-prompt-shape.sh` — PreToolUse-on-Agent guards (spawn-shape / spec / branch checks) not currently referenced by `hooks.json`.
+
+## Subdirectory
+
+- `lib/` — shared helpers sourced by the hook scripts (`normalize-role.sh`, `query-task.sh`, `resolve-repo.sh`, `resolve-toolchain-path.sh`, `resolve-workspace.sh`).
+
+## How it fits
+
+Hooks are TMB's enforcement substrate: they make the workflow doctrine mechanical instead of advisory. A PreToolUse deny is a hard stop for the agent that tripped it. Hook behavior is covered by L3 (`tests/l3-integration/hooks/`).

--- a/scripts/lib/README.md
+++ b/scripts/lib/README.md
@@ -1,0 +1,15 @@
+# scripts/lib
+
+Shared shell helpers sourced by the top-level `scripts/` and by the hook engine. These are small, single-responsibility functions that several call sites need to resolve identically — keeping them here avoids each script re-implementing plugin-name resolution, a headless-hook path, or an MCP-write fallback.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `resolve-plugin-name.sh` | Single source of truth for plugin-name resolution. Source it, then call `tmb_resolve_plugin_name` (reads the `name` field from `plugin.json`). |
+| `resolve-headless-hook.sh` | Version-agnostic headless-hook resolver. Lets `/onboard` materialize a stable copy of a hook at a fixed path so version-pinned cache paths don't orphan it. |
+| `sqlite3-fallback.sh` | `sqlite3` wrappers for the MCP write path, used when the MCP server is unavailable. Each wrapper validates the caller's role against the underlying MCP tool before writing. |
+
+## How it fits
+
+These helpers are sourced, not executed standalone. They underpin path resolution and the MCP-down recovery tier, so the same plugin-name lookup and write-fallback behavior holds whether a hook, a script, or a recovery flow invokes them.

--- a/scripts/maintenance/README.md
+++ b/scripts/maintenance/README.md
@@ -1,0 +1,17 @@
+# scripts/maintenance
+
+Operational and one-off scripts that keep a TMB install healthy: version bumps, cache remediation, stale-worktree cleanup, and the standalone scan invokers fired by hooks. These are not part of the per-turn hot path — they run on demand (a person, a release flow) or as the body a hook shells out to.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `bump-version.sh` | Atomic plugin-version bump — updates the three manifests that must stay in sync, or fails leaving every file unchanged. Idempotent. |
+| `heal-mcp-cache.sh` | Interactive remediation for the Claude Code plugin MCP-config cache bug — clears stale `disabledMcpServers` entries and other recovery steps. |
+| `cleanup-stale-worktrees.sh` | One-time cleanup of repo-rooted SWE worktrees left over before worktrees moved to workspace-rooted paths. Idempotent. |
+| `run-scan.mjs` | Standalone scan invoker used by the `post-task-close-rescan.sh` hook to re-run the scan against the current commit after an atomic close. Reuses the same `scan_run` logic as the MCP tool; silent on failure. |
+| `run-scan-initial.mjs` | Mirror of `run-scan.mjs` for the cold-world-model SessionStart prescan, tagged with a distinct audit source. Silent on failure. |
+
+## How it fits
+
+`bump-version.sh` backs the release/version-sync flow; `heal-mcp-cache.sh` and `cleanup-stale-worktrees.sh` are recovery tooling; the two `run-scan*.mjs` invokers let hooks refresh the world model without duplicating the MCP tool's scan logic.

--- a/tests/l1-lint/command-frontmatter.sh
+++ b/tests/l1-lint/command-frontmatter.sh
@@ -12,7 +12,7 @@ cd "$ROOT"
 
 failed=0
 
-for cmd in $(find commands -maxdepth 1 -type f -name '*.md' 2>/dev/null | sort); do
+for cmd in $(find commands -maxdepth 1 -type f -name '*.md' ! -name 'README.md' 2>/dev/null | sort); do
   filename=$(basename "$cmd")
 
   # Filename must match ^[a-z][a-z0-9-]*\.md$


### PR DESCRIPTION
World-model coverage (#807): READMEs for agents/, commands/, scripts/, scripts/hooks/, scripts/lib/, scripts/maintenance/, mcp/trajectory-server/src/tools/ + a one-line command-frontmatter.sh fix to skip README.md (it previously rejected commands/README.md). All content verified vs real dirs; L1 + link-check green. pr-reviewer PASS (151). (Empty stray init commits squash away.) ⚠️ touches agents/ + commands/ prompt surfaces — logged in TMB ledger. Closes #807.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)