### PR TITLE
🔧 fix(hooks): resolve bun in resolve-toolchain-path.sh so the verification gate stops false-denying bun verification[] (#812)

### DIFF
--- a/scripts/hooks/lib/resolve-toolchain-path.sh
+++ b/scripts/hooks/lib/resolve-toolchain-path.sh
@@ -76,6 +76,18 @@ tmb_user_toolchain_dirs() {
   # 4. ~/.local/bin.
   [ -n "$home" ] && [ -d "$home/.local/bin" ] && printf '%s\n' "$home/.local/bin"
 
+  # 5. bun — installed by reflex (Library/Application Support/reflex/bun/bin)
+  #    or via the official installer (~/.bun/bin); neither is on the minimal
+  #    PATH, so a bun-using verification[] exits 127 → false DENY. Probe the
+  #    well-known install dirs directly (mirrors the node/npm resolution above).
+  if [ -n "$home" ]; then
+    for cand in \
+      "$home/Library/Application Support/reflex/bun/bin" \
+      "$home/.bun/bin"; do
+      [ -d "$cand" ] && [ -x "$cand/bun" ] && printf '%s\n' "$cand"
+    done
+  fi
+
   return 0
 }
 


### PR DESCRIPTION
The verification gate's stripped PATH couldn't resolve bun (reflex install dir) → exit 127 false-DENY on any bun-using verification[], forcing waives all session. Adds a bun probe (reflex dir + ~/.bun/bin) to tmb_user_toolchain_dirs, mirroring node/npm. Verified via the gate's real apply fn (tmb_resolve_toolchain_path) under PATH=/usr/bin:/bin: bun 1.3.4 + node + npm resolve, no regression. shellcheck-hooks PASS. pr-reviewer PASS (153). Closes #812.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)