### PR TITLE
🧪 test(l6): verify skill usage from claude stream-json log; re-point row 04 off skill_invocations (#119)

### DIFF
--- a/tests/l5-l6/lib/assert-usage-test.sh
+++ b/tests/l5-l6/lib/assert-usage-test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Self-test for assert-usage.sh (issue #119). Feeds tmb_usage_in_log a small
+# sample stream-json run log and asserts it detects an invoked skill, accepts
+# bare/prefixed name forms, and rejects a skill that never fired.
+# Run: bash tests/l5-l6/lib/assert-usage-test.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/assert-usage.sh"
+
+PASS=0
+FAIL=0
+TMP=$(mktemp -d -t assert-usage-test-XXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+assert_detect() {
+  local label="$1" log="$2" name="$3" want="$4"
+  tmb_usage_in_log "$log" "$name"
+  local got=$?
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL $label — expected exit=$want, got exit=$got"
+  fi
+}
+
+# ---- Sample stream-json run log: bro invokes tmb:tmb_planning -------------
+# Mirrors a real `claude -p --output-format stream-json --verbose` stream:
+# a system/init event listing loaded plugins, then an assistant message whose
+# content carries a Skill tool_use, then the tool_result text.
+SKILL_LOG="$TMP/skill-invoked.jsonl"
+cat > "$SKILL_LOG" <<'EOF'
+{"type":"system","subtype":"init","session_id":"s1","plugins":["tmb@trustmybot"],"tools":["Skill","Bash"]}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Loading the planning skill."},{"type":"tool_use","id":"tu_1","name":"Skill","input":{"skill":"tmb:tmb_planning"}}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_1","content":"Launching skill: tmb:tmb_planning"}]}}
+{"type":"result","subtype":"success","duration_ms":1234}
+EOF
+
+# ---- Sample run log where NO skill fired ----------------------------------
+NO_SKILL_LOG="$TMP/no-skill.jsonl"
+cat > "$NO_SKILL_LOG" <<'EOF'
+{"type":"system","subtype":"init","session_id":"s2","plugins":["tmb@trustmybot"],"tools":["Bash"]}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Just running a command."},{"type":"tool_use","id":"tu_9","name":"Bash","input":{"command":"ls"}}]}}
+{"type":"result","subtype":"success","duration_ms":42}
+EOF
+
+echo "== detect: skill invoked (prefixed query) =="
+assert_detect "tmb:tmb_planning in skill log" "$SKILL_LOG" "tmb:tmb_planning" 0
+
+echo "== detect: skill invoked (bare query matches prefixed log) =="
+assert_detect "tmb_planning (bare) in skill log" "$SKILL_LOG" "tmb_planning" 0
+
+echo "== reject: skill not invoked =="
+assert_detect "tmb_planning absent from no-skill log" "$NO_SKILL_LOG" "tmb_planning" 1
+
+echo "== reject: different skill not invoked =="
+assert_detect "tmb_review absent from skill log" "$SKILL_LOG" "tmb_review" 1
+
+echo "== detect: plugin presence via init plugins[] =="
+assert_detect "tmb@trustmybot plugin loaded" "$SKILL_LOG" "tmb@trustmybot:tmb_planning" 0
+
+echo "== reject: missing run log =="
+assert_detect "nonexistent log → fail" "$TMP/does-not-exist.jsonl" "tmb_planning" 1
+
+echo
+echo "assert-usage-test: $PASS pass / $FAIL fail"
+[ "$FAIL" = "0" ] && exit 0 || exit 1

--- a/tests/l5-l6/lib/assert-usage.sh
+++ b/tests/l5-l6/lib/assert-usage.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Run-log usage detection for L5/L6 (issue #119).
+#
+# The L5/L6 runner invokes `claude -p --output-format stream-json --verbose`
+# and persists the stream to a per-row run log ($project/trajectory.jsonl).
+# This helper reads that log and answers "did bro invoke skill/plugin X?" —
+# the signal that previously came from the skill_invocations table (#118,
+# being retired). Moving it to the run log keeps the assertion alive once the
+# table is gone.
+#
+# Detection signals, in priority order:
+#   1. stream-json tool_use: {"type":"tool_use","name":"Skill",
+#      "input":{"skill":"<plugin>:<name>"}} — the strongest signal. CC
+#      delivers skill names plugin-prefixed (e.g. "tmb:tmb_planning"); a bare
+#      "tmb_planning" also matches.
+#   2. tool_result text "Launching skill: <plugin>:<name>".
+#   3. system/init event plugins[] array — plugin presence (coarse; proves the
+#      plugin loaded, not that a specific skill fired).
+#   4. --debug line: Skill prompt: showing "<plugin>:<skill>".
+#
+# KNOWN LIMITATION — subagent (swe) attribution. When bro spawns swe via the
+# Task tool, swe runs in its own CC session whose stream-json is NOT merged
+# into bro's run log. A skill swe loads therefore leaves no tool_use in this
+# log, so tmb_usage_in_log cannot attribute it. Row 05 (swe dispatch) depends
+# on swe-side skill usage and is intentionally NOT re-pointed onto this helper.
+# Do not attempt swe-via-Task attribution here.
+
+set -uo pipefail
+
+# tmb_usage_in_log <run_log> <name>
+# Returns 0 iff <run_log> shows <name> was invoked as a skill, the plugin was
+# loaded, or the debug line names it. <name> may be bare ("tmb_planning") or
+# plugin-prefixed ("tmb:tmb_planning"); both forms are accepted and the bare
+# form matches a prefixed log entry (and vice versa).
+tmb_usage_in_log() {
+  local run_log="$1" name="$2"
+  [ -n "$run_log" ] || return 1
+  [ -f "$run_log" ] || return 1
+  [ -n "$name" ] || return 1
+
+  # Bare name (strip any plugin prefix) for prefix-agnostic matching.
+  local bare="${name#*:}"
+
+  # ---- Signal 1: stream-json tool_use name=Skill, input.skill matches ----
+  # Match when the recorded skill equals the bare or prefixed name, or ends
+  # in ":<bare>" (log prefixed, query bare), or the query is prefixed and the
+  # log is bare.
+  if command -v jq >/dev/null 2>&1; then
+    if jq -e --arg bare "$bare" '
+          select(.type=="assistant")
+          | .message.content[]?
+          | select(.type=="tool_use" and .name=="Skill")
+          | (.input.skill // "")
+          | (. == $bare) or (sub("^[^:]*:";"") == $bare)
+        ' "$run_log" >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+
+  # ---- Signal 2: "Launching skill: <plugin>:<name>" tool_result text ----
+  if grep -Eq "Launching skill:[^\"]*(^|:|\b)${bare}\b" "$run_log" 2>/dev/null; then
+    return 0
+  fi
+
+  # ---- Signal 4: --debug line: Skill prompt: showing "<plugin>:<skill>" ----
+  if grep -Eq "Skill prompt: showing \"[^\"]*${bare}\"" "$run_log" 2>/dev/null; then
+    return 0
+  fi
+
+  # ---- Signal 3: system/init event plugins[] (plugin presence, coarse) ----
+  # Only consulted when <name> is plugin-prefixed (a plugin id, not a skill);
+  # plugins[] lists plugin ids, not skills, so a bare skill name must not
+  # match here.
+  if [ "$name" != "$bare" ] && command -v jq >/dev/null 2>&1; then
+    local plugin="${name%%:*}"
+    if jq -e --arg plugin "$plugin" '
+          select(.type=="system" and (.subtype=="init"))
+          | (.plugins // [])
+          | any(. == $plugin or (sub("@.*";"") == $plugin))
+        ' "$run_log" >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+
+  return 1
+}

--- a/tests/l5-l6/lib/flow-helpers.sh
+++ b/tests/l5-l6/lib/flow-helpers.sh
@@ -136,6 +136,7 @@ l5_run_claude() {
 #   5. files                — filesystem assertions (opt-in via outcome-files.json)
 #   6. coherence            — table-shape invariants (opt-in via outcome-coherence.json) — catches empty-table doctrine violations
 #   7. git                  — git-state invariants (opt-in via outcome-git.json) — catches base-branch contamination + worktree-on-wrong-branch
+#   8. usage                — skill/plugin usage from the stream-json run log (opt-in via outcome-usage.json) — replaces skill_invocations (#118/#119)
 l5_score_flow() {
   local project="$1" flow="$2" scorer_dir="$3" run_id="$4"
   local total_fail=0
@@ -147,6 +148,7 @@ l5_score_flow() {
   l5_score_files                "$scorer_dir" "$project"                   || total_fail=$((total_fail + 1))
   l5_score_coherence            "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
   l5_score_git                  "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
+  l5_score_usage                "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
 
   return "$total_fail"
 }

--- a/tests/l5-l6/lib/l6-chain-helpers.sh
+++ b/tests/l5-l6/lib/l6-chain-helpers.sh
@@ -157,6 +157,7 @@ l6c_score_step() {
   l5_score_files                "$row_dir" "$project"                   || fails=$((fails + 1))
   l5_score_coherence            "$project" "$step" "$row_dir" "$run_id" || fails=$((fails + 1))
   l5_score_git                  "$project" "$step" "$row_dir" "$run_id" || fails=$((fails + 1))
+  l5_score_usage                "$project" "$step" "$row_dir" "$run_id" || fails=$((fails + 1))
 
   return "$fails"
 }

--- a/tests/l5-l6/lib/scorers.sh
+++ b/tests/l5-l6/lib/scorers.sh
@@ -14,6 +14,9 @@
 
 set -uo pipefail
 
+# shellcheck source=tests/l5-l6/lib/assert-usage.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/assert-usage.sh"
+
 # l5_record_score <db_path> <run_id> <flow> <scorer> <pass:0|1> <value> <explanation>
 l5_record_score() {
   local db="$1" run_id="$2" flow="$3" scorer="$4" pass="$5" value="$6" explanation="$7"
@@ -566,4 +569,61 @@ l5_score_git() {
     "" \
     "$([ "$fail" = "0" ] && echo "$checked check(s) passed" || echo "$fail of $checked check(s) failed")"
   return "$fail"
+}
+
+# l5_score_usage <project_dir> <flow> <scorer_dir> <run_id>
+# Reads scorer_dir/outcome-usage.json: a JSON array of skill/plugin names that
+# bro must have invoked this row. Each name is checked against the per-row
+# stream-json run log ($project/trajectory.jsonl) via tmb_usage_in_log — the
+# log-based replacement for the (retiring, #118) skill_invocations table.
+#
+# Schema:
+#   { "skills_used": ["tmb_planning", "tmb:tmb_review"] }
+#
+# KNOWN LIMITATION — subagent (swe) skills. swe runs in its own CC session
+# whose stream-json is not merged into bro's run log, so a skill swe loads
+# leaves no signal here. Only assert bro-side skills with this scorer (see
+# assert-usage.sh).
+#
+# Opt-in: silently returns 0 when no outcome-usage.json is present.
+l5_score_usage() {
+  local project="$1" flow="$2" scorer_dir="$3" run_id="$4"
+  local cfg="$scorer_dir/outcome-usage.json"
+  local db="$project/.claude/tmb/trajectory.db"
+  local run_log="$project/trajectory.jsonl"
+
+  [ -f "$cfg" ] || return 0
+
+  if [ ! -f "$run_log" ]; then
+    echo "  ✗ usage: $run_log not found (runner must produce stream-json)" >&2
+    l5_record_score "$db" "$run_id" "$flow" "usage" 0 "no-log" "trajectory.jsonl missing"
+    return 1
+  fi
+
+  local names
+  names=$(jq -r '(.skills_used // [])[]' "$cfg" 2>/dev/null)
+
+  local checked=0 missing=""
+  while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    checked=$((checked + 1))
+    if tmb_usage_in_log "$run_log" "$name"; then
+      echo "  ✓ usage: '$name' invoked (run log)"
+    else
+      echo "  ✗ usage: '$name' not found in run log" >&2
+      missing="${missing}; $name"
+    fi
+  done <<< "$names"
+
+  if [ "$checked" = "0" ]; then
+    return 0
+  fi
+
+  if [ -z "$missing" ]; then
+    l5_record_score "$db" "$run_id" "$flow" "usage" 1 "${checked}" "all skills used"
+    return 0
+  else
+    l5_record_score "$db" "$run_id" "$flow" "usage" 0 "missing" "$missing"
+    return 1
+  fi
 }

--- a/tests/l5-l6/rows/04-first-task-hits-gate/README.md
+++ b/tests/l5-l6/rows/04-first-task-hits-gate/README.md
@@ -2,7 +2,7 @@
 
 **Scenario under test:** the user onboarded but `/scan` never ran (no `deep_scan_completed` audit row). User asks for a code change ("make a todo CLI"). Bro must run `/scan` (or `scan_run` directly) BEFORE `task_create_batch` — the world-model-cold gate enforces this server-side, and the test verifies bro responds correctly instead of waiving silently.
 
-The row also asserts the **skill-invocation hook attribution** (`skill_invocations` rows for `tmb_*` skills + at least one `agent_runs` row for `agent_type='bro'`) — folded in from the (now-retired) step 14 since these signals naturally land on any chain step that invokes tmb skills, and step 04 is the first such step.
+The row also asserts **bro's skill usage** (bro invoked `tmb_planning` this turn + at least one `agent_runs` row for `agent_type='bro'`) — folded in from the (now-retired) step 14 since these signals naturally land on any chain step that invokes tmb skills, and step 04 is the first such step. Skill usage is read from the stream-json run log via the `usage` scorer (`outcome-usage.json`), not the retiring `skill_invocations` table (#118/#119).
 
 The prompt is a natural full-feature ask, so bro typically also dispatches SWE + atomic-closes in the same turn — that's not exclusive with step 05 (which adds a feature on top); step 05's assertion just measures its own dispatch + close round trip.
 
@@ -23,11 +23,12 @@ The prompt is a natural full-feature ask, so bro typically also dispatches SWE +
 
 | Scorer | Asserts |
 |---|---|
-| `outcome.sql` | `deep_scan_completed` audit row (proxy for kuzu graph warm); `tasks` ≥1; `repos` ≥1; `skill_invocations` (`tmb_*`) ≥1; `agent_runs` (`agent_type='bro'`) ≥1 |
+| `outcome.sql` | `deep_scan_completed` audit row (proxy for kuzu graph warm); `tasks` ≥1; `repos` ≥1; `agent_runs` (`agent_type='bro'`) ≥1 |
 | `outcome-coherence.json` | matching row counts |
+| `outcome-usage.json` | bro invoked `tmb_planning` (from the stream-json run log) |
 | `outcome-git.json` | `base_branch_unchanged: true` |
 | `tools-required.json` | `scan_run`, `task_create_batch` |
 | `tools-forbidden.json` | (none) |
 | `cost-budget.json` | Soft 200K / 900s |
 
-**Failure modes captured:** (a) bro waives the gate via `waive_registry_gate=true` instead of running `scan_run` → the `deep_scan_completed` audit check fails; (b) the `skill-invocation-record.sh` PostToolUse hook (#2886) regressed and stops attributing tmb skill invocations → `skill_invocations` assertion fails.
+**Failure modes captured:** (a) bro waives the gate via `waive_registry_gate=true` instead of running `scan_run` → the `deep_scan_completed` audit check fails; (b) bro skips the planning chain and never loads `tmb_planning` → the `usage` scorer fails on the run log.

--- a/tests/l5-l6/rows/04-first-task-hits-gate/outcome-coherence.json
+++ b/tests/l5-l6/rows/04-first-task-hits-gate/outcome-coherence.json
@@ -3,7 +3,6 @@
     "audit WHERE event_type='deep_scan_completed'": ">=1",
     "tasks": ">=1",
     "repos": ">=1",
-    "skill_invocations WHERE skill_name LIKE 'tmb_%'": ">=1",
     "agent_runs WHERE agent_type='bro'": ">=1"
   }
 }

--- a/tests/l5-l6/rows/04-first-task-hits-gate/outcome-usage.json
+++ b/tests/l5-l6/rows/04-first-task-hits-gate/outcome-usage.json
@@ -1,0 +1,3 @@
+{
+  "skills_used": ["tmb_planning"]
+}

--- a/tests/l5-l6/rows/04-first-task-hits-gate/outcome.sql
+++ b/tests/l5-l6/rows/04-first-task-hits-gate/outcome.sql
@@ -21,16 +21,9 @@ SELECT
   'repos populated by scan (got ' || COUNT(*) || ', expected >=1)' AS description
 FROM repos;
 
--- Folded from the (now-retired) step 14: the Skill PostToolUse hook
--- (#2886) must record at least one tmb_* skill invocation for the bro
--- agent_run that fired this turn. Bro loads `tmb_planning` and
--- `tmb:agent-create`-adjacent skills during the planning chain, so by
--- the end of this row the hook should have written rows.
-SELECT
-  CASE WHEN COUNT(*) >= 1 THEN 1 ELSE 0 END AS pass,
-  'skill_invocations tmb_* rows (got ' || COUNT(*) || ', expected >=1) — folded from retired step 14' AS description
-FROM skill_invocations
-WHERE skill_name LIKE 'tmb_%';
+-- bro's `tmb_planning` usage for this row is asserted from the stream-json
+-- run log via the `usage` scorer (outcome-usage.json), not skill_invocations
+-- — that table is retiring (#118/#119).
 
 SELECT
   CASE WHEN COUNT(*) >= 1 THEN 1 ELSE 0 END AS pass,


### PR DESCRIPTION
Fixes #119 (GH #826). Moves L5/L6 skill-usage verification off the retiring skill_invocations table onto the claude stream-json run log: new lib/assert-usage.sh (tmb_usage_in_log) + l5_score_usage scorer + outcome-usage.json, row 04 re-pointed. swe/row-05 attribution documented as known limitation. assert-usage self-test 6/6, scorers regression 15/15. Unblocks #118. pr-reviewer: PASS (validation #159).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)