### PR TITLE
♻️ feat(hooks): auto-clean worktree + branch after gh pr merge (#772)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -309,6 +309,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/attribution-footer.sh",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/clean-merged-branch.sh",
+            "timeout": 10
           }
         ]
       }

--- a/scripts/hooks/clean-merged-branch.sh
+++ b/scripts/hooks/clean-merged-branch.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# PostToolUse hook on Bash — auto-clean a merged feature branch + its worktree
+# after its PR is merged (#772/#89).
+#
+# After `gh pr merge` / `glab mr merge` succeeds, the merged feature branch and
+# its SWE worktree linger locally. This hook removes them:
+#   - derive the merged branch (explicit `<branch>` arg, else the current branch),
+#   - refuse to touch a protected branch (main/dev, plus repos.protected_branches),
+#   - confirm the branch is actually merged into its base (ancestor check),
+#   - if the branch's worktree is dirty (uncommitted/untracked), skip + warn,
+#   - else `git worktree remove`, `git branch -d`, `git worktree prune`.
+#
+# Non-load-bearing: every path exits 0. Failures emit an informational note to
+# stderr (visible in CC's debug log) and never block. Remote deletion is out of
+# scope — `gh pr merge --delete-branch` already handles the remote.
+#
+# Bypass: TMB_DISABLE_CLEAN_MERGED_BRANCH=1.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/query-task.sh
+. "$SCRIPT_DIR/lib/query-task.sh"
+# shellcheck source=lib/resolve-repo.sh
+. "$SCRIPT_DIR/lib/resolve-repo.sh"
+
+# When sourced (e.g. by a test exercising helpers), stop after defining them.
+_clean_merged_branch_main() {
+  if [ "${TMB_DISABLE_CLEAN_MERGED_BRANCH:-0}" = "1" ]; then
+    exit 0
+  fi
+
+  command -v jq >/dev/null 2>&1 || exit 0
+  command -v git >/dev/null 2>&1 || exit 0
+
+  local input tool_name cmd resp
+  input=$(cat 2>/dev/null) || exit 0
+  tool_name=$(printf '%s' "$input" | jq -r '.tool_name // ""' 2>/dev/null)
+  [ "$tool_name" = "Bash" ] || exit 0
+
+  cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
+  resp=$(printf '%s' "$input" | jq -r '.tool_response | if type == "string" then . else tojson end' 2>/dev/null)
+  [ -n "$cmd" ] || exit 0
+
+  # Act only on a PR/MR merge command (word-boundary match; git/gh/glab parity).
+  if ! printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]_-])(gh[[:space:]]+pr[[:space:]]+merge|glab[[:space:]]+mr[[:space:]]+merge)([^[:alnum:]_-]|$)'; then
+    exit 0
+  fi
+
+  # The tool result must indicate success. A failed merge (auth, conflict,
+  # not-mergeable) must never trigger deletion. Treat an explicit failure
+  # signal in the response as a hard stop; otherwise assume success (PostToolUse
+  # only fires after the tool ran, and CC reports failures in tool_response).
+  if printf '%s' "$resp" | grep -qiE '(is_error|"error"|failed to merge|not mergeable|merge conflict|GraphQL: |pull request is not mergeable)'; then
+    exit 0
+  fi
+
+  local cwd
+  cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null)
+  [ -n "$cwd" ] || cwd="$PWD"
+
+  # Resolve the MAIN repo root (the merge may run from a worktree).
+  local repo_root
+  repo_root=$(tmb_repo_git_root "$cwd")
+  [ -n "$repo_root" ] || exit 0
+  [ -d "$repo_root" ] || exit 0
+
+  # Derive the merged branch. `gh pr merge [<number|url|branch>]` /
+  # `glab mr merge [<id>]` may name a branch explicitly; only a non-numeric,
+  # non-flag token that resolves to a local branch counts. Otherwise fall back
+  # to the branch checked out where the merge ran.
+  local branch=""
+  branch=$(_cmb_branch_from_cmd "$cmd" "$repo_root")
+  if [ -z "$branch" ]; then
+    branch=$(git -C "$cwd" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  fi
+  [ -n "$branch" ] || exit 0
+  [ "$branch" != "HEAD" ] || exit 0
+
+  # The branch must exist locally to be a deletion candidate.
+  git -C "$repo_root" rev-parse --verify --quiet "refs/heads/$branch" >/dev/null 2>&1 || exit 0
+
+  # Protected-branch guard: hard-exclude main/dev, plus repos.protected_branches.
+  if _cmb_is_protected "$repo_root" "$branch"; then
+    exit 0
+  fi
+
+  # Determine the base branch to validate the merge against.
+  local base
+  base=$(_cmb_base_branch "$repo_root")
+  [ -n "$base" ] || base="dev"
+  # The base must exist; never compare against a missing ref.
+  git -C "$repo_root" rev-parse --verify --quiet "refs/heads/$base" >/dev/null 2>&1 || exit 0
+  # Don't delete the base itself.
+  [ "$branch" != "$base" ] || exit 0
+
+  # Ancestor check: the branch tip must be reachable from the base (i.e. its
+  # commits are already merged). If not, do nothing — the merge may have been a
+  # different branch, or this is a squash/rebase merge we can't safely confirm.
+  if ! git -C "$repo_root" merge-base --is-ancestor "refs/heads/$branch" "refs/heads/$base" 2>/dev/null; then
+    exit 0
+  fi
+
+  # Locate the branch's worktree (if any), and refuse to act on a dirty one.
+  local worktree_path
+  worktree_path=$(_cmb_worktree_for_branch "$repo_root" "$branch")
+
+  if [ -n "$worktree_path" ] && [ -d "$worktree_path" ]; then
+    if [ -n "$(git -C "$worktree_path" status --porcelain 2>/dev/null)" ]; then
+      printf 'tmb: branch %s is merged but its worktree %s has uncommitted/untracked changes — skipping cleanup (never force)\n' "$branch" "$worktree_path" >&2
+      exit 0
+    fi
+    git -C "$repo_root" worktree remove "$worktree_path" >/dev/null 2>&1 || {
+      printf 'tmb: worktree remove failed for %s — leaving branch %s in place\n' "$worktree_path" "$branch" >&2
+      exit 0
+    }
+  fi
+
+  # Delete the local branch. Try `git branch -d` first (git's own merged-safety
+  # check, relative to HEAD/upstream). When the main checkout is parked on a
+  # branch that doesn't contain the feature commits, `-d` refuses even though we
+  # have already PROVEN — via the base-relative ancestor check above — that the
+  # branch is fully merged into its base. In that proven-merged case only, fall
+  # back to `-D`. This is not a blind force: the merge is independently
+  # confirmed, so no commits can be lost.
+  if git -C "$repo_root" branch -d "$branch" >/dev/null 2>&1 \
+    || git -C "$repo_root" branch -D "$branch" >/dev/null 2>&1; then
+    git -C "$repo_root" worktree prune >/dev/null 2>&1 || true
+    printf 'tmb: cleaned up merged branch %s%s\n' "$branch" \
+      "${worktree_path:+ (worktree $worktree_path)}" >&2
+  else
+    printf 'tmb: branch delete failed for %s — leaving in place\n' "$branch" >&2
+    git -C "$repo_root" worktree prune >/dev/null 2>&1 || true
+  fi
+
+  exit 0
+}
+
+# _cmb_branch_from_cmd <cmd> <repo_root>
+# Print an explicit branch named on the merge command line, if it resolves to a
+# local branch. Empty otherwise (numbers, URLs, and flags are ignored).
+_cmb_branch_from_cmd() {
+  local cmd="$1" repo_root="$2"
+  local merge_args tok
+  # Strip everything up to and including the `merge` keyword, then scan tokens.
+  merge_args=$(printf '%s' "$cmd" | sed -E 's/^.*(gh[[:space:]]+pr|glab[[:space:]]+mr)[[:space:]]+merge//')
+  for tok in $merge_args; do
+    case "$tok" in
+      -*) continue ;;                       # flag
+      *://*) continue ;;                    # URL
+      '' ) continue ;;
+    esac
+    # Pure number → PR/MR id, not a branch.
+    case "$tok" in
+      *[!0-9]*) ;;                          # has a non-digit → maybe a branch
+      *) continue ;;                        # all digits → id
+    esac
+    if git -C "$repo_root" rev-parse --verify --quiet "refs/heads/$tok" >/dev/null 2>&1; then
+      printf '%s' "$tok"
+      return 0
+    fi
+  done
+  return 0
+}
+
+# _cmb_is_protected <repo_root> <branch>
+# Exit 0 when <branch> is protected: hard-excluded main/dev, or listed in the
+# repos.protected_branches column for this repo.
+_cmb_is_protected() {
+  local repo_root="$1" branch="$2"
+  case "$branch" in
+    main|dev|master) return 0 ;;
+  esac
+  local db protected
+  db=$(tmb_db_path 2>/dev/null || true)
+  if [ -n "$db" ] && [ -f "$db" ]; then
+    local row
+    row=$(tmb_repo_resolve "$db" "$repo_root")
+    protected=$(printf '%s' "$row" | cut -d'|' -f3)
+    if [ -n "$protected" ]; then
+      # protected_branches is a JSON array or comma list; match the branch as a
+      # whole token regardless of surrounding quotes/brackets/commas.
+      local tokens
+      tokens=$(printf '%s' "$protected" | sed 's/[][",]/ /g')
+      local p
+      for p in $tokens; do
+        [ "$p" = "$branch" ] && return 0
+      done
+    fi
+  fi
+  return 1
+}
+
+# _cmb_base_branch <repo_root>
+# Print the repo's base branch (repos.target_branch, else plugin_config
+# pr_target, else dev).
+_cmb_base_branch() {
+  local repo_root="$1"
+  local db
+  db=$(tmb_db_path 2>/dev/null || true)
+  if [ -n "$db" ] && [ -f "$db" ]; then
+    local row target
+    row=$(tmb_repo_resolve "$db" "$repo_root")
+    target=$(printf '%s' "$row" | cut -d'|' -f1)
+    if [ -n "$target" ]; then
+      printf '%s' "$target"
+      return 0
+    fi
+    if command -v sqlite3 >/dev/null 2>&1; then
+      target=$(sqlite3 "$db" "SELECT json_extract(value_json, '\$') FROM plugin_config WHERE key='pr_target';" 2>/dev/null | sed -e 's/^"//' -e 's/"$//' || true)
+      if [ -n "$target" ]; then
+        printf '%s' "$target"
+        return 0
+      fi
+    fi
+  fi
+  printf 'dev'
+}
+
+# _cmb_worktree_for_branch <repo_root> <branch>
+# Print the worktree path attached to <branch>, or empty. Never prints the main
+# worktree (a feature branch isn't normally checked out there, but guard anyway).
+_cmb_worktree_for_branch() {
+  local repo_root="$1" branch="$2"
+  git -C "$repo_root" worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/$branch" -v root="$repo_root" '
+    /^worktree / { wt = substr($0, 10) }
+    /^branch /   { if (substr($0, 8) == b && wt != root) { print wt; exit } }
+  '
+}
+
+# Execute only when run directly; when sourced, expose helpers for tests.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  _clean_merged_branch_main
+fi

--- a/tests/l3-integration/hooks/clean-merged-branch.test.sh
+++ b/tests/l3-integration/hooks/clean-merged-branch.test.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Tests for scripts/hooks/clean-merged-branch.sh.
+# Hook contract: PostToolUse on Bash. After a successful `gh pr merge` /
+# `glab mr merge`, derive the merged branch and — if it is NOT protected
+# (main/dev), is actually merged into its base (ancestor check), and its
+# worktree is clean — remove the worktree, `git branch -d` the local branch,
+# and prune. Skip + warn on a dirty worktree; never force; silent (exit 0)
+# on everything else; bypass via TMB_DISABLE_CLEAN_MERGED_BRANCH=1.
+#
+# All git state lives under a mktemp sandbox driven by `git -C` (per #810 —
+# no commits leak to the caller branch). assert_not_in_plugin_repo guards
+# against running with cwd inside the real plugin repo.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../lib/assert.sh"
+PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
+HOOK="$PLUGIN_ROOT/scripts/hooks/clean-merged-branch.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+# Run from the sandbox, never the plugin repo, so a stray commit can't land on
+# the caller branch.
+cd "$TMPDIR"
+assert_not_in_plugin_repo "$PLUGIN_ROOT"
+
+REPO="$TMPDIR/repo"
+# Init on a parking branch so `dev` is never the main checkout's HEAD — that
+# lets the test fast-forward `dev` (simulating a merge landing) and lets the
+# hook delete branches without colliding with the checked-out ref.
+git init -q -b _parking "$REPO"
+git -C "$REPO" config user.email t@t.io
+git -C "$REPO" config user.name t
+echo init > "$REPO/README.md"
+git -C "$REPO" add .
+git -C "$REPO" commit -qm init
+git -C "$REPO" branch dev _parking
+
+# input <command> [cwd] — synthesize a PostToolUse(Bash) payload. Defaults to a
+# successful response and cwd=$REPO.
+input() {
+  local cmd="$1" cwd="${2:-$REPO}"
+  jq -n --arg cmd "$cmd" --arg cwd "$cwd" '{
+    tool_name: "Bash",
+    tool_input: { command: $cmd },
+    tool_response: "✓ Merged pull request",
+    cwd: $cwd
+  }'
+}
+
+run_hook() { printf '%s' "$1" | bash "$HOOK" 2>&1 || true; }
+
+branch_exists() { git -C "$REPO" rev-parse --verify --quiet "refs/heads/$1" >/dev/null 2>&1; }
+
+# Build a feature branch merged into dev, with an attached worktree.
+# make_merged <branch> <slug>
+make_merged() {
+  local branch="$1" slug="$2"
+  git -C "$REPO" branch "$branch" dev
+  git -C "$REPO" worktree add -q "$TMPDIR/wt-$slug" "$branch"
+  echo "feature $slug" > "$TMPDIR/wt-$slug/f-$slug.txt"
+  git -C "$TMPDIR/wt-$slug" add .
+  git -C "$TMPDIR/wt-$slug" commit -qm "feat $slug"
+  # Fast-forward dev to the branch tip (simulates the merge landing on base).
+  git -C "$REPO" branch -f dev "$branch"
+}
+
+# ---------------------------------------------------------------------------
+test_case "(a) merged clean branch + worktree → both removed"
+make_merged feat/clean clean
+[ -d "$TMPDIR/wt-clean" ] || { echo "FAIL: setup worktree missing"; exit 1; }
+out=$(run_hook "$(input 'gh pr merge feat/clean --squash --delete-branch')")
+assert_contains "$out" 'cleaned up merged branch feat/clean' "cleanup report"
+branch_exists feat/clean && { echo "FAIL: branch still present"; exit 1; }
+_pass
+[ -d "$TMPDIR/wt-clean" ] && { echo "FAIL: worktree still present"; exit 1; }
+_pass
+
+# ---------------------------------------------------------------------------
+test_case "(a') glab mr merge also triggers cleanup (git/gh/glab parity)"
+make_merged feat/glab glab
+out=$(run_hook "$(input 'glab mr merge feat/glab --squash')")
+assert_contains "$out" 'cleaned up merged branch feat/glab' "glab cleanup report"
+branch_exists feat/glab && { echo "FAIL: glab branch still present"; exit 1; }
+_pass
+
+# ---------------------------------------------------------------------------
+test_case "(b) protected branch (dev) → untouched"
+# Run the merge from a clean worktree checked out on dev, no explicit branch arg
+# so the hook derives the current branch (dev) — which must be refused.
+git -C "$REPO" worktree add -q "$TMPDIR/wt-dev" dev
+out=$(run_hook "$(input 'gh pr merge --squash' "$TMPDIR/wt-dev")")
+branch_exists dev || { echo "FAIL: dev branch was deleted"; exit 1; }
+_pass
+[ -d "$TMPDIR/wt-dev" ] || { echo "FAIL: dev worktree was removed"; exit 1; }
+_pass
+git -C "$REPO" worktree remove "$TMPDIR/wt-dev" >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
+test_case "(b') protected via repos.protected_branches → untouched"
+# main is hard-excluded, but also exercise the DB-driven protected list with a
+# custom branch name 'release'.
+DB="$TMPDIR/.claude/tmb/trajectory.db"
+mkdir -p "$(dirname "$DB")"
+_REPO_REAL=$(git -C "$REPO" rev-parse --show-toplevel)
+sqlite3 "$DB" "
+  CREATE TABLE repos (name TEXT PRIMARY KEY, path TEXT NOT NULL, target_branch TEXT, branching_model TEXT, protected_branches TEXT);
+  INSERT INTO repos (name, path, target_branch, protected_branches) VALUES ('repo', '${_REPO_REAL}', 'dev', '[\"release\"]');
+"
+git -C "$REPO" branch release dev
+out=$(TRAJECTORY_DB_PATH="$DB" run_hook "$(input 'gh pr merge release --squash')")
+branch_exists release || { echo "FAIL: protected 'release' branch deleted"; exit 1; }
+_pass
+git -C "$REPO" branch -D release >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
+test_case "(c) dirty worktree → skipped with warning, not removed"
+make_merged feat/dirty dirty
+echo "uncommitted" > "$TMPDIR/wt-dirty/scratch.txt"
+out=$(run_hook "$(input 'gh pr merge feat/dirty --squash')")
+assert_contains "$out" 'uncommitted/untracked changes' "dirty warning"
+branch_exists feat/dirty || { echo "FAIL: dirty branch was deleted"; exit 1; }
+_pass
+[ -d "$TMPDIR/wt-dirty" ] || { echo "FAIL: dirty worktree was removed"; exit 1; }
+_pass
+
+# ---------------------------------------------------------------------------
+test_case "(d) non-merge Bash command → no-op (silent)"
+make_merged feat/nonmerge nonmerge
+out=$(run_hook "$(input 'git status')")
+assert_eq "" "$out" "non-merge command is silent"
+branch_exists feat/nonmerge || { echo "FAIL: branch deleted on non-merge cmd"; exit 1; }
+_pass
+
+# ---------------------------------------------------------------------------
+test_case "(e) not-merged branch (not an ancestor of base) → untouched"
+git -C "$REPO" branch feat/unmerged dev
+git -C "$REPO" worktree add -q "$TMPDIR/wt-unmerged" feat/unmerged
+echo diverge > "$TMPDIR/wt-unmerged/d.txt"
+git -C "$TMPDIR/wt-unmerged" add .
+git -C "$TMPDIR/wt-unmerged" commit -qm diverge
+# dev is NOT advanced — the branch tip is not an ancestor of dev.
+out=$(run_hook "$(input 'gh pr merge feat/unmerged --squash')")
+branch_exists feat/unmerged || { echo "FAIL: unmerged branch deleted"; exit 1; }
+_pass
+git -C "$REPO" worktree remove --force "$TMPDIR/wt-unmerged" >/dev/null 2>&1 || true
+git -C "$REPO" branch -D feat/unmerged >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
+test_case "(f) TMB_DISABLE_CLEAN_MERGED_BRANCH=1 bypass → untouched"
+make_merged feat/bypass bypass
+out=$(printf '%s' "$(input 'gh pr merge feat/bypass --squash')" \
+  | env TMB_DISABLE_CLEAN_MERGED_BRANCH=1 bash "$HOOK" 2>&1 || true)
+assert_eq "" "$out" "bypass silences the hook"
+branch_exists feat/bypass || { echo "FAIL: branch deleted despite bypass"; exit 1; }
+_pass
+
+# ---------------------------------------------------------------------------
+test_case "(g) failed merge response → untouched"
+make_merged feat/failed failed
+fail_input=$(jq -n --arg cmd 'gh pr merge feat/failed --squash' --arg cwd "$REPO" '{
+  tool_name: "Bash",
+  tool_input: { command: $cmd },
+  tool_response: "GraphQL: Pull request is not mergeable",
+  cwd: $cwd
+}')
+out=$(run_hook "$fail_input")
+branch_exists feat/failed || { echo "FAIL: branch deleted on failed merge"; exit 1; }
+_pass
+
+# ---------------------------------------------------------------------------
+test_case "(h) merged branch with no worktree → branch still deleted"
+git -C "$REPO" branch feat/nowt dev
+# advance dev to a commit that includes the branch tip (branch == dev tip → ancestor)
+out=$(run_hook "$(input 'gh pr merge feat/nowt --squash')")
+assert_contains "$out" 'cleaned up merged branch feat/nowt' "no-worktree cleanup report"
+branch_exists feat/nowt && { echo "FAIL: branch not deleted"; exit 1; }
+_pass
+
+summarize


### PR DESCRIPTION
Fixes #772 (local #89). New PostToolUse(Bash) clean-merged-branch.sh removes a merged feature branch's worktree + local branch after gh pr merge / glab mr merge — protected-branch + ancestor + dirty-tree safety, always exit 0, TMB_DISABLE bypass. 19/19 tests. pr-reviewer: PASS (validation #160).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)