### PR TITLE
✨ feat(cheatcode): SessionStart health-check reconciles cheatcodes.status against runtime (#113)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -38,6 +38,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/substrate-preflight.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/cheatcode-healthcheck.sh",
+            "timeout": 10
           }
         ]
       }

--- a/scripts/hooks/cheatcode-healthcheck.sh
+++ b/scripts/hooks/cheatcode-healthcheck.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Cheatcode health-check (#113): SessionStart probe that reconciles each
+# cheatcodes row's `status` against the real runtime.
+#
+# Per kind:
+#   skill  — file_path exists on disk  → active, else broken.
+#   mcp    — server present in `claude mcp list` (or ~/.claude.json
+#            mcpServers)             → active, else broken.
+#   plugin — present + enabled in `claude plugin list`
+#                                    → active, else broken.
+# For any row whose computed status differs from the stored one, UPDATE the
+# row and emit a `cheatcode_healthcheck` audit row (old→new, name, kind).
+#
+# Constraints:
+#   - Non-load-bearing: always exit 0; never block the session.
+#   - Bounded: each external `claude` call is run under `timeout`, and the
+#     mcp/plugin listings are fetched once and cached (not per-row).
+#   - Graceful skip when sqlite3 / claude / the DB are absent.
+#   - Honors TMB_DISABLE_CHEATCODE_HEALTHCHECK=1.
+set -uo pipefail
+
+[ "${TMB_DISABLE_CHEATCODE_HEALTHCHECK:-0}" = "1" ] && exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/hooks/lib/query-task.sh
+. "$SCRIPT_DIR/lib/query-task.sh" 2>/dev/null || exit 0
+
+# Drain stdin (CC delivers a hook payload); we don't read it.
+cat >/dev/null 2>&1 || true
+
+tmb_have_sqlite || exit 0
+
+DB=$(tmb_db_path) || exit 0
+[ -n "$DB" ] || exit 0
+
+# Cheatcodes table must exist.
+have_table=$(tmb_sqlite_ro "$DB" "SELECT name FROM sqlite_master WHERE type='table' AND name='cheatcodes';")
+[ -n "$have_table" ] || exit 0
+
+# Per-call bound for the external claude listings.
+CLAUDE_TIMEOUT="${TMB_CHEATCODE_HEALTHCHECK_TIMEOUT:-4}"
+
+_run_bounded() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$CLAUDE_TIMEOUT" "$@" 2>/dev/null || true
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$CLAUDE_TIMEOUT" "$@" 2>/dev/null || true
+  else
+    "$@" 2>/dev/null || true
+  fi
+}
+
+# --- Cache the runtime listings once (not per-row). ----------------------
+HAVE_CLAUDE=0
+command -v claude >/dev/null 2>&1 && HAVE_CLAUDE=1
+
+MCP_LIST=""
+PLUGIN_LIST=""
+if [ "$HAVE_CLAUDE" = "1" ]; then
+  MCP_LIST=$(_run_bounded claude mcp list)
+  PLUGIN_LIST=$(_run_bounded claude plugin list)
+fi
+
+# Fallback MCP source: ~/.claude.json mcpServers keys.
+CLAUDE_JSON_MCP=""
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  CLAUDE_JSON_MCP=$(jq -r '.mcpServers // {} | keys[]' "$HOME/.claude.json" 2>/dev/null || true)
+fi
+
+# --- Probe one row's computed status. ------------------------------------
+# Echoes the computed status, or nothing when this kind can't be probed
+# (caller leaves the row untouched — never flip on absent evidence).
+compute_status() {
+  local kind="$1" file_path="$2" name="$3"
+  case "$kind" in
+    skill)
+      [ -n "$file_path" ] || { echo "broken"; return 0; }
+      local resolved="$file_path"
+      case "$file_path" in
+        /*) ;;
+        *) [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && resolved="$CLAUDE_PLUGIN_ROOT/$file_path" ;;
+      esac
+      if [ -f "$resolved" ] || [ -f "$file_path" ]; then echo "active"; else echo "broken"; fi
+      ;;
+    mcp)
+      # No runtime evidence available at all → don't flip.
+      [ "$HAVE_CLAUDE" = "1" ] || [ -n "$CLAUDE_JSON_MCP" ] || return 0
+      if printf '%s\n' "$MCP_LIST" | grep -qiF -- "$name" \
+        || printf '%s\n' "$CLAUDE_JSON_MCP" | grep -qxF -- "$name"; then
+        echo "active"
+      else
+        echo "broken"
+      fi
+      ;;
+    plugin)
+      [ "$HAVE_CLAUDE" = "1" ] || return 0
+      if printf '%s\n' "$PLUGIN_LIST" | grep -qiF -- "$name"; then
+        echo "active"
+      else
+        echo "broken"
+      fi
+      ;;
+  esac
+}
+
+# --- Iterate rows + reconcile. -------------------------------------------
+ROWS=$(tmb_sqlite_ro "$DB" "
+  SELECT id || '|' || kind || '|' || status || '|' || COALESCE(file_path, '') || '|' || name
+    FROM cheatcodes;
+")
+[ -n "$ROWS" ] || exit 0
+
+NOW=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+
+while IFS='|' read -r id kind old_status file_path name; do
+  [ -n "$id" ] || continue
+  new_status=$(compute_status "$kind" "$file_path" "$name")
+  [ -n "$new_status" ] || continue
+  [ "$new_status" = "$old_status" ] && continue
+
+  safe_status=$(tmb_sql_quote "$new_status")
+  safe_name=$(tmb_sql_quote "$name")
+  safe_old=$(tmb_sql_quote "$old_status")
+  safe_kind=$(tmb_sql_quote "$kind")
+  content_json=$(printf '{"name":"%s","kind":"%s","from":"%s","to":"%s"}' \
+    "$safe_name" "$safe_kind" "$safe_old" "$safe_status")
+
+  sqlite3 "$DB" <<SQL 2>/dev/null || true
+UPDATE cheatcodes SET status = '$safe_status', updated_at = '$NOW' WHERE id = $id;
+INSERT INTO audit (issue_id, branch_id, from_node, event_type, summary, content_json, created_at)
+VALUES (-1, '', 'cheatcode-healthcheck',
+        'cheatcode_healthcheck',
+        '$safe_name ($safe_kind): $safe_old -> $safe_status',
+        '$content_json', '$NOW');
+SQL
+done <<< "$ROWS"
+
+exit 0

--- a/tests/l3-integration/hooks/cheatcode-healthcheck.test.sh
+++ b/tests/l3-integration/hooks/cheatcode-healthcheck.test.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# L3: cheatcode health-check (#113).
+# scripts/hooks/cheatcode-healthcheck.sh — SessionStart probe that reconciles
+# each cheatcodes row's `status` against the runtime and emits a
+# cheatcode_healthcheck audit row on every transition.
+#
+# Cases:
+#   - a skill whose file is missing  → flips to broken (+ audit row)
+#   - a present skill                → stays active, no transition, no audit
+#   - TMB_DISABLE_CHEATCODE_HEALTHCHECK=1 → no-op
+#   - absent `claude` CLI            → graceful skip (skills still reconcile;
+#                                      mcp/plugin rows untouched)
+#
+# All state lives under a mktemp sandbox (per #810); TRAJECTORY_DB_PATH pins
+# the DB so the real plugin DB is never touched. assert_not_in_plugin_repo
+# guards against running with cwd inside the real plugin repo.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../lib/assert.sh"
+PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
+HOOK="$PLUGIN_ROOT/scripts/hooks/cheatcode-healthcheck.sh"
+
+command -v sqlite3 >/dev/null 2>&1 || { printf "SKIP sqlite3 not found\n"; exit 0; }
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+cd "$TMPDIR"
+assert_not_in_plugin_repo "$PLUGIN_ROOT"
+
+WS="$TMPDIR/ws"
+mkdir -p "$WS/.claude/tmb"
+DB="$WS/.claude/tmb/trajectory.db"
+
+# Minimal schema: the tables the hook reads/writes. cheatcodes carries the
+# columns the probe selects; audit mirrors the production shape; tasks carries
+# prompt_bearing so tmb_db_schema_current accepts the DB.
+seed_db() {
+  rm -f "$DB"
+  sqlite3 "$DB" "
+    CREATE TABLE tasks (id INTEGER PRIMARY KEY, prompt_bearing INTEGER NOT NULL DEFAULT 0);
+    CREATE TABLE cheatcodes (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      name       TEXT NOT NULL,
+      kind       TEXT NOT NULL,
+      file_path  TEXT,
+      status     TEXT NOT NULL,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE audit (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      issue_id     INTEGER NOT NULL DEFAULT -1,
+      branch_id    TEXT,
+      from_node    TEXT NOT NULL DEFAULT 'bro',
+      event_type   TEXT NOT NULL,
+      summary      TEXT NOT NULL DEFAULT '',
+      content_json TEXT NOT NULL DEFAULT '{}',
+      created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  "
+}
+
+# Run the hook with an isolated PATH (claude absent unless we add it),
+# TRAJECTORY_DB_PATH pinned, empty hook payload on stdin.
+run_hook() {
+  printf '{}' | env -i \
+    HOME="$TMPDIR/home" \
+    PATH="$1" \
+    TRAJECTORY_DB_PATH="$DB" \
+    "${@:2}" \
+    bash "$HOOK" 2>&1 || true
+}
+
+# A PATH that excludes any system `claude` but keeps the tools the hook needs.
+NOCLAUDE_BIN="$TMPDIR/nocl_bin"
+mkdir -p "$NOCLAUDE_BIN" "$TMPDIR/home"
+for t in sqlite3 jq grep sed cat dirname date timeout env bash; do
+  p=$(command -v "$t" 2>/dev/null || true)
+  [ -n "$p" ] && ln -sf "$p" "$NOCLAUDE_BIN/$t" 2>/dev/null || true
+done
+NOCLAUDE_PATH="$NOCLAUDE_BIN"
+
+status_of() { sqlite3 "$DB" "SELECT status FROM cheatcodes WHERE name='$1';"; }
+audit_count() { sqlite3 "$DB" "SELECT COUNT(*) FROM audit WHERE event_type='cheatcode_healthcheck';"; }
+
+# ---------------------------------------------------------------------------
+# Case 1 — a skill whose file is missing flips to broken + emits an audit row.
+# ---------------------------------------------------------------------------
+seed_db
+GONE="$TMPDIR/does-not-exist/SKILL.md"
+sqlite3 "$DB" "INSERT INTO cheatcodes (name, kind, file_path, status) VALUES ('gone-skill', 'skill', '$GONE', 'active');"
+run_hook "$NOCLAUDE_PATH" >/dev/null
+
+test_case "missing-file skill flips active -> broken"
+assert_eq "broken" "$(status_of gone-skill)" "gone-skill status"
+
+test_case "transition emits a cheatcode_healthcheck audit row"
+assert_eq "1" "$(audit_count)" "audit row count"
+
+test_case "audit row records the old->new transition + name + kind"
+ROW=$(sqlite3 "$DB" "SELECT content_json FROM audit WHERE event_type='cheatcode_healthcheck' LIMIT 1;")
+assert_contains "$ROW" '"name":"gone-skill"' "audit name"
+assert_contains "$ROW" '"kind":"skill"' "audit kind"
+assert_contains "$ROW" '"from":"active"' "audit from"
+assert_contains "$ROW" '"to":"broken"' "audit to"
+
+# ---------------------------------------------------------------------------
+# Case 2 — a present skill stays active: no transition, no audit row.
+# ---------------------------------------------------------------------------
+seed_db
+PRESENT="$TMPDIR/present-skill.md"
+: > "$PRESENT"
+sqlite3 "$DB" "INSERT INTO cheatcodes (name, kind, file_path, status) VALUES ('present-skill', 'skill', '$PRESENT', 'active');"
+run_hook "$NOCLAUDE_PATH" >/dev/null
+
+test_case "present-file skill stays active (no-op)"
+assert_eq "active" "$(status_of present-skill)" "present-skill status"
+
+test_case "no-op leaves no cheatcode_healthcheck audit row"
+assert_eq "0" "$(audit_count)" "audit row count after no-op"
+
+# ---------------------------------------------------------------------------
+# Case 3 — TMB_DISABLE_CHEATCODE_HEALTHCHECK=1 is a no-op even when the file
+#          is missing (status would otherwise flip).
+# ---------------------------------------------------------------------------
+seed_db
+sqlite3 "$DB" "INSERT INTO cheatcodes (name, kind, file_path, status) VALUES ('gone-skill', 'skill', '$GONE', 'active');"
+run_hook "$NOCLAUDE_PATH" TMB_DISABLE_CHEATCODE_HEALTHCHECK=1 >/dev/null
+
+test_case "disable env leaves a flip-worthy row untouched"
+assert_eq "active" "$(status_of gone-skill)" "disabled status unchanged"
+
+test_case "disable env writes no audit row"
+assert_eq "0" "$(audit_count)" "disabled audit count"
+
+# ---------------------------------------------------------------------------
+# Case 4 — absent `claude` CLI: mcp/plugin rows are left untouched (no flip on
+#          absent runtime evidence); skill rows still reconcile.
+# ---------------------------------------------------------------------------
+seed_db
+sqlite3 "$DB" "
+  INSERT INTO cheatcodes (name, kind, file_path, status) VALUES
+    ('some-mcp',    'mcp',    NULL, 'active'),
+    ('some-plugin', 'plugin', NULL, 'installed'),
+    ('gone-skill',  'skill', '$GONE', 'active');
+"
+# HOME has no ~/.claude.json → no mcpServers fallback either.
+rm -f "$TMPDIR/home/.claude.json"
+run_hook "$NOCLAUDE_PATH" >/dev/null
+
+test_case "absent claude: mcp row untouched (no evidence)"
+assert_eq "active" "$(status_of some-mcp)" "some-mcp status"
+
+test_case "absent claude: plugin row untouched (no evidence)"
+assert_eq "installed" "$(status_of some-plugin)" "some-plugin status"
+
+test_case "absent claude: skill row still reconciles to broken"
+assert_eq "broken" "$(status_of gone-skill)" "gone-skill status (no-claude)"
+
+test_case "absent claude: only the skill transition is audited"
+assert_eq "1" "$(audit_count)" "audit count under no-claude"
+
+summarize
+printf "PASS cheatcode-healthcheck\n"


### PR DESCRIPTION
Fixes #113 (GH #820). New SessionStart hook probes each cheatcodes row (skill→file exists, mcp/plugin→claude list) and reconciles status active/broken with a cheatcode_healthcheck audit row; bounded, non-load-bearing, never flips on absent evidence. 14/14 tests. pr-reviewer: PASS (validation #162).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)