### PR TITLE
🧪 test(l6): assert on-disk agent materialization in the cheatcode install row — un-fake row 44 (#95)

### DIFF
--- a/skills/tmb_cheatcode/SKILL.md
+++ b/skills/tmb_cheatcode/SKILL.md
@@ -55,3 +55,5 @@ AskUserQuestion(
 ```
 
 Lead the chat with the rationale — what the cheatcode does, the tier and why, and the surface it would bring into the project — then let the Human make the call. The install itself is still a separate gate.
+
+When the install is FOR a specific agent — "install X for swe", "code-review for pr-reviewer" — pass that agent as `cheatcode_install`'s `target` so the consuming agent is materialized (`.claude/agents/<agent>.md` copied global→local with the skill added to its `skills:` header; `target=bro` materializes `.claude/CLAUDE.md` instead).

--- a/tests/l5-l6/lib/assert-materialized-test.sh
+++ b/tests/l5-l6/lib/assert-materialized-test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Self-test for assert-materialized.sh (issue #95). Builds synthetic project
+# .claude/ trees and asserts tmb_materialized_on_disk detects a materialized
+# agent md (skill present in its skills: frontmatter), a bro CLAUDE.md reference,
+# and rejects an absent agent md or one whose header lacks the skill.
+# Run: bash tests/l5-l6/lib/assert-materialized-test.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/assert-materialized.sh"
+
+PASS=0
+FAIL=0
+TMP=$(mktemp -d -t assert-materialized-test-XXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+assert_detect() {
+  local label="$1" project="$2" agent="$3" skill="$4" want="$5"
+  tmb_materialized_on_disk "$project" "$agent" "$skill"
+  local got=$?
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL $label — expected exit=$want, got exit=$got"
+  fi
+}
+
+# ---- Project where swe was materialized with feature-dev -------------------
+# Mirrors what cheatcode_install writes: global swe.md copied local, the skill
+# added to its skills: [...] frontmatter.
+MAT="$TMP/materialized"
+mkdir -p "$MAT/.claude/agents"
+cat > "$MAT/.claude/agents/swe.md" <<'EOF'
+---
+name: swe
+skills: [tmb_swe-checklist, feature-dev]
+---
+
+# You are swe
+EOF
+mkdir -p "$MAT/.claude"
+cat > "$MAT/.claude/CLAUDE.md" <<'EOF'
+# You are bro
+
+Installed skill: code-review — load it when its capability is needed.
+EOF
+
+# ---- Project where swe md exists but the skill is NOT in the header --------
+NO_SKILL="$TMP/no-skill"
+mkdir -p "$NO_SKILL/.claude/agents"
+cat > "$NO_SKILL/.claude/agents/swe.md" <<'EOF'
+---
+name: swe
+skills: [tmb_swe-checklist]
+---
+
+# You are swe
+EOF
+
+# ---- Project where the agent md was never materialized ---------------------
+ABSENT="$TMP/absent"
+mkdir -p "$ABSENT/.claude"
+
+echo "== detect: feature-dev materialized into swe =="
+assert_detect "swe.md lists feature-dev" "$MAT" "swe" "feature-dev" 0
+
+echo "== detect: bare skill matches plugin-prefixed query =="
+assert_detect "swe.md feature-dev via prefixed query" "$MAT" "swe" "tmb:feature-dev" 0
+
+echo "== detect: bro CLAUDE.md references code-review =="
+assert_detect "bro CLAUDE.md references code-review" "$MAT" "bro" "code-review" 0
+
+echo "== reject: agent md present but skill not in header =="
+assert_detect "swe.md missing feature-dev → fail" "$NO_SKILL" "swe" "feature-dev" 1
+
+echo "== reject: agent md absent =="
+assert_detect "pr-reviewer.md never materialized → fail" "$ABSENT" "pr-reviewer" "code-review" 1
+
+echo "== reject: bro CLAUDE.md does not reference the skill =="
+assert_detect "bro CLAUDE.md missing skill → fail" "$NO_SKILL" "bro" "feature-dev" 1
+
+echo "== reject: substring of a longer skill name must not match =="
+assert_detect "feature (substring) must not match feature-dev" "$MAT" "swe" "feature" 1
+
+echo
+echo "assert-materialized-test: $PASS pass / $FAIL fail"
+[ "$FAIL" = "0" ] && exit 0 || exit 1

--- a/tests/l5-l6/lib/assert-materialized.sh
+++ b/tests/l5-l6/lib/assert-materialized.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# On-disk consuming-agent materialization check for L5/L6 (issue #95).
+#
+# When bro installs a cheatcode FOR a specific agent, cheatcode_install (#115)
+# materializes that agent's prompt surface into the USER PROJECT's .claude/:
+#   - a non-bro target → copies the global agent md to
+#     <project>/.claude/agents/<agent>.md and adds the skill to its
+#     skills: [...] frontmatter
+#   - target=bro → writes/edits <project>/.claude/CLAUDE.md to reference the skill
+#
+# L6 row 44 previously asserted only the DB attachment rows, so a materialization
+# that never touched disk still "passed". This helper reads the filesystem so the
+# row proves the copy + header edit actually happened.
+
+set -uo pipefail
+
+# tmb_materialized_on_disk <project_dir> <agent> <skill>
+# Returns 0 iff the consuming agent's prompt surface was materialized for <skill>:
+#   - agent=bro → <project>/.claude/CLAUDE.md exists and references <skill>
+#   - other     → <project>/.claude/agents/<agent>.md exists AND lists <skill>
+#                 in its skills: [...] frontmatter
+# <skill> matches bare or plugin-prefixed; the bare form is compared.
+tmb_materialized_on_disk() {
+  local project="$1" agent="$2" skill="$3"
+  [ -n "$project" ] || return 1
+  [ -n "$agent" ] || return 1
+  [ -n "$skill" ] || return 1
+
+  # Bare skill name (strip any plugin prefix) for prefix-agnostic matching.
+  local bare="${skill#*:}"
+
+  if [ "$agent" = "bro" ]; then
+    # bro's surface is the project-local CLAUDE.md, not an agent md.
+    local claude_md="$project/.claude/CLAUDE.md"
+    [ -f "$claude_md" ] || return 1
+    grep -Fq "$bare" "$claude_md" 2>/dev/null && return 0
+    return 1
+  fi
+
+  local agent_md="$project/.claude/agents/${agent}.md"
+  [ -f "$agent_md" ] || return 1
+
+  # Pull the skills: [...] entries from the leading frontmatter block and test
+  # for an exact (bare) skill entry — substring of a longer name must not match.
+  local skills_line
+  skills_line=$(grep -E '^skills:[[:space:]]*\[.*\][[:space:]]*$' "$agent_md" 2>/dev/null | head -1)
+  [ -n "$skills_line" ] || return 1
+
+  local inner="${skills_line#*[}"
+  inner="${inner%]*}"
+  local IFS=','
+  local entry
+  for entry in $inner; do
+    entry="${entry#"${entry%%[![:space:]]*}"}"
+    entry="${entry%"${entry##*[![:space:]]}"}"
+    [ "$entry" = "$bare" ] && return 0
+  done
+  return 1
+}

--- a/tests/l5-l6/lib/flow-helpers.sh
+++ b/tests/l5-l6/lib/flow-helpers.sh
@@ -137,6 +137,7 @@ l5_run_claude() {
 #   6. coherence            — table-shape invariants (opt-in via outcome-coherence.json) — catches empty-table doctrine violations
 #   7. git                  — git-state invariants (opt-in via outcome-git.json) — catches base-branch contamination + worktree-on-wrong-branch
 #   8. usage                — skill/plugin usage from the stream-json run log (opt-in via outcome-usage.json) — replaces skill_invocations (#118/#119)
+#   9. materialized         — on-disk consuming-agent materialization (opt-in via outcome-materialized.json) — proves a targeted cheatcode install copied the agent md + skill header (#95)
 l5_score_flow() {
   local project="$1" flow="$2" scorer_dir="$3" run_id="$4"
   local total_fail=0
@@ -149,6 +150,7 @@ l5_score_flow() {
   l5_score_coherence            "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
   l5_score_git                  "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
   l5_score_usage                "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
+  l5_score_materialized         "$project" "$flow" "$scorer_dir" "$run_id" || total_fail=$((total_fail + 1))
 
   return "$total_fail"
 }

--- a/tests/l5-l6/lib/l6-chain-helpers.sh
+++ b/tests/l5-l6/lib/l6-chain-helpers.sh
@@ -158,6 +158,7 @@ l6c_score_step() {
   l5_score_coherence            "$project" "$step" "$row_dir" "$run_id" || fails=$((fails + 1))
   l5_score_git                  "$project" "$step" "$row_dir" "$run_id" || fails=$((fails + 1))
   l5_score_usage                "$project" "$step" "$row_dir" "$run_id" || fails=$((fails + 1))
+  l5_score_materialized         "$project" "$step" "$row_dir" "$run_id" || fails=$((fails + 1))
 
   return "$fails"
 }

--- a/tests/l5-l6/lib/scorers.sh
+++ b/tests/l5-l6/lib/scorers.sh
@@ -16,6 +16,8 @@ set -uo pipefail
 
 # shellcheck source=tests/l5-l6/lib/assert-usage.sh
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/assert-usage.sh"
+# shellcheck source=tests/l5-l6/lib/assert-materialized.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/assert-materialized.sh"
 
 # l5_record_score <db_path> <run_id> <flow> <scorer> <pass:0|1> <value> <explanation>
 l5_record_score() {
@@ -624,6 +626,58 @@ l5_score_usage() {
     return 0
   else
     l5_record_score "$db" "$run_id" "$flow" "usage" 0 "missing" "$missing"
+    return 1
+  fi
+}
+
+# l5_score_materialized <project_dir> <flow> <scorer_dir> <run_id>
+# Reads scorer_dir/outcome-materialized.json: a JSON array of (agent, skill)
+# pairs that a targeted cheatcode install must have materialized ON DISK this
+# row. Each pair is checked against the project's .claude/ via
+# tmb_materialized_on_disk — proving the agent md was copied global→local with
+# the skill in its skills: frontmatter (bro → CLAUDE.md reference), the
+# previously-faked half of L6 row 44 (#95).
+#
+# Schema:
+#   { "materialized": [ {"agent": "swe", "skill": "feature-dev"} ] }
+#
+# Opt-in: silently returns 0 when no outcome-materialized.json is present.
+l5_score_materialized() {
+  local project="$1" flow="$2" scorer_dir="$3" run_id="$4"
+  local cfg="$scorer_dir/outcome-materialized.json"
+  local db="$project/.claude/tmb/trajectory.db"
+
+  [ -f "$cfg" ] || return 0
+
+  local pairs
+  pairs=$(jq -c '(.materialized // [])[]' "$cfg" 2>/dev/null)
+
+  local checked=0 missing=""
+  while IFS= read -r pair; do
+    [ -z "$pair" ] && continue
+    local agent skill
+    agent=$(jq -r '.agent // ""' <<< "$pair" 2>/dev/null)
+    skill=$(jq -r '.skill // ""' <<< "$pair" 2>/dev/null)
+    [ -z "$agent" ] && continue
+    [ -z "$skill" ] && continue
+    checked=$((checked + 1))
+    if tmb_materialized_on_disk "$project" "$agent" "$skill"; then
+      echo "  ✓ materialized: '$skill' into '$agent' (on disk)"
+    else
+      echo "  ✗ materialized: '$skill' not materialized into '$agent'" >&2
+      missing="${missing}; ${skill}→${agent}"
+    fi
+  done <<< "$pairs"
+
+  if [ "$checked" = "0" ]; then
+    return 0
+  fi
+
+  if [ -z "$missing" ]; then
+    l5_record_score "$db" "$run_id" "$flow" "materialized" 1 "${checked}" "all agents materialized"
+    return 0
+  else
+    l5_record_score "$db" "$run_id" "$flow" "materialized" 0 "missing" "$missing"
     return 1
   fi
 }

--- a/tests/l5-l6/rows/44-cheatcode-install-plugins/README.md
+++ b/tests/l5-l6/rows/44-cheatcode-install-plugins/README.md
@@ -1,8 +1,8 @@
 # 44-cheatcode-install-plugins
 
-**Scenario:** Onboarded project. The user tells bro to install two already-chosen plugins — `feature-dev` and `code-review` — in local scope. Installs are human-approved, never silent (#659): bro records the per-candidate approval via `cheatcode_approve`, then calls `cheatcode_install` once per plugin. The PreToolUse approval gate allows each install only because the matching `cheatcode_approved` record now exists — it fails closed otherwise. Each install writes the `cheatcodes` row (scope='local') + its attachment record in one transaction and emits the `cheatcode_install` / `cheatcode_installed` audit rows. The per-agent attachment routes feature-dev → swe and code-review → pr-reviewer.
+**Scenario:** Onboarded project. The user tells bro to install two already-chosen plugins — `feature-dev` for swe and `code-review` for pr-reviewer — in local scope. Installs are human-approved, never silent (#659): bro records the per-candidate approval via `cheatcode_approve`, then calls `cheatcode_install` once per plugin, passing the consuming agent as `target` so the install materializes it. The PreToolUse approval gate allows each install only because the matching `cheatcode_approved` record now exists — it fails closed otherwise. Each install writes the `cheatcodes` row (scope='local') + its attachment record in one transaction and emits the `cheatcode_install` / `cheatcode_installed` audit rows. The per-agent attachment routes feature-dev → swe and code-review → pr-reviewer.
 
-**Determinism:** `setup-l5.sh` writes a marketplace-install fixture and points `cheatcode_install` at it via `TMB_CHEATCODE_INSTALL_FIXTURE` — no live web, no real marketplace call. The fixture supplies the per-agent attachment targets (swe, pr-reviewer) that pass through verbatim. This row asserts the flow ran (approval recorded, install gate cleared, both installs + audit + per-agent attachment records present), not marketplace results.
+**Determinism:** `setup-l5.sh` writes a marketplace-install fixture and points `cheatcode_install` at it via `TMB_CHEATCODE_INSTALL_FIXTURE` — no live web, no real marketplace call. The fixture supplies the per-agent attachment targets (swe, pr-reviewer) that pass through verbatim. This row asserts the flow ran (approval recorded, install gate cleared, both installs + audit + per-agent attachment records present) AND that the targeted install materialized each consuming agent on disk (#95) — not marketplace results. The marketplace boundary stays fixtured (#108/#120's offline-tested domain); the materialization — the previously-faked part — runs for real and is asserted by `outcome-materialized.json`.
 
 **L5 mode:** `setup-l5.sh` seeds the fixture; `fixture.txt` seeds `onboarding-named` identity.
 **L6 mode:** Standalone here — NOT in the chain manifest (L6-B renumbers + wires it into the cheatcode journey chain).
@@ -12,5 +12,8 @@
 | Scorer | Asserts |
 |---|---|
 | `outcome.sql` | Two `cheatcode_installed` audit rows; two `cheatcodes` rows `scope='local'`; the feature-dev AND code-review cheatcodes rows; `cheatcode_attachments` target='swe' AND target='pr-reviewer' |
+| `outcome-materialized.json` | On disk: `.claude/agents/swe.md` lists `feature-dev` and `.claude/agents/pr-reviewer.md` lists `code-review` in their `skills:` headers — the agent md copied global→local + header edit (#95), no longer faked |
 | `tools-required.json` | `cheatcode_approve` + `cheatcode_install` called |
 | `cost-budget.json` | Soft 60K tokens / 90s |
+
+> Row 05 (swe hot-load) asserts swe-side skill USAGE, which the run-log scorer cannot attribute because swe runs in its own CC session whose stream-json is not merged into bro's log — a known limitation (#119, see `lib/assert-usage.sh`). This row proves the on-disk materialization that precedes that hot-load; the usage attribution is left untouched.

--- a/tests/l5-l6/rows/44-cheatcode-install-plugins/outcome-materialized.json
+++ b/tests/l5-l6/rows/44-cheatcode-install-plugins/outcome-materialized.json
@@ -1,0 +1,6 @@
+{
+  "materialized": [
+    { "agent": "swe", "skill": "feature-dev" },
+    { "agent": "pr-reviewer", "skill": "code-review" }
+  ]
+}

--- a/tests/l5-l6/rows/44-cheatcode-install-plugins/prompt.txt
+++ b/tests/l5-l6/rows/44-cheatcode-install-plugins/prompt.txt
@@ -1,1 +1,1 @@
-@bro install the feature-dev and code-review plugins in local scope. Don't ask questions.
+@bro install feature-dev for swe and code-review for pr-reviewer in local scope. Don't ask questions.


### PR DESCRIPTION
Fixes #95 (GH #778). L6 row 44 was a faked pass (DB-rows only). Adds a filesystem-materialization scorer (assert-materialized.sh + l5_score_materialized wired into L5/L6) + row 44 outcome-materialized.json asserting feature-dev→swe + code-review→pr-reviewer on disk (kept DB-row outcome.sql); explicit-target prompt + tmb_cheatcode SKILL.md guidance. Self-test 7/7, scorers 15/15. Plugin-kind materialization is the #123 follow-up so the row passes live. pr-reviewer PASS (validation #165).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)