### PR TITLE
🐛 fix(hooks): swe-scope-fence normalizes trailing-slash files[] tokens (#831)

### DIFF
--- a/scripts/hooks/swe-scope-fence.sh
+++ b/scripts/hooks/swe-scope-fence.sh
@@ -86,6 +86,9 @@ ALLOWED_DIRS=()
 HAS_TESTS_DIR=""
 
 while IFS= read -r path_token; do
+  # Strip a single trailing slash so a dir token like "tests/" maps to "tests"
+  # instead of collapsing to "." via dirname. Skips empty lines and a bare "/".
+  path_token="${path_token%/}"
   [ -n "$path_token" ] || continue
   case "$path_token" in
     */*) dir=$(dirname "$path_token") ;;

--- a/tests/l3-integration/hooks/swe-scope-fence.test.sh
+++ b/tests/l3-integration/hooks/swe-scope-fence.test.sh
@@ -38,6 +38,7 @@ FILES_WITH_FILES='["scripts/hooks/my-hook.sh","tests/l3-integration/hooks/my-hoo
 FILES_MULTIDIR='["src/api/handler.ts","src/lib/util.ts","tests/unit/handler.test.ts"]'
 FILES_EMPTY='[]'
 FILES_ROOT_FILE='["Makefile"]'
+FILES_TRAILING_SLASH='["tests/"]'
 
 sqlite3 "$DB" "
   CREATE TABLE issues (
@@ -62,6 +63,7 @@ sqlite3 "$DB" "
   INSERT INTO tasks VALUES (2, 1, 'feat/task-beta', 'running', '', 0, '$FILES_MULTIDIR');
   INSERT INTO tasks VALUES (3, 1, 'feat/task-nofiles', 'running', '', 0, '$FILES_EMPTY');
   INSERT INTO tasks VALUES (5, 1, 'feat/task-rootfile', 'running', '', 0, '$FILES_ROOT_FILE');
+  INSERT INTO tasks VALUES (6, 1, 'feat/task-trailingslash', 'running', '', 0, '$FILES_TRAILING_SLASH');
 "
 
 run_hook() {
@@ -198,6 +200,21 @@ assert_not_contains "$out" '"permissionDecision":"deny"' "editing the exact root
 test_case "root-file: editing a different root file is denied"
 out=$(run_hook "$WT_ROOTFILE" "$(make_edit_input "package.json")")
 assert_contains "$out" '"permissionDecision":"deny"' "editing a different root file should be denied"
+
+# ===========================================================================
+# Trailing-slash files[] token → normalized to the dir (no '.' collapse)
+# ===========================================================================
+
+WT_TRAILINGSLASH="$WT_ROOT/task-trailingslash"
+mkdir -p "$WT_TRAILINGSLASH"
+
+test_case "trailing-slash: token 'tests/' allows an in-scope edit under tests/"
+out=$(run_hook "$WT_TRAILINGSLASH" "$(make_edit_input "tests/l3-integration/hooks/x.test.sh")")
+assert_not_contains "$out" '"permissionDecision":"deny"' "trailing-slash 'tests/' should resolve to dir 'tests' and allow in-scope edits"
+
+test_case "trailing-slash: token 'tests/' still denies an out-of-scope edit"
+out=$(run_hook "$WT_TRAILINGSLASH" "$(make_edit_input "src/api/handler.ts")")
+assert_contains "$out" '"permissionDecision":"deny"' "trailing-slash 'tests/' should still deny edits outside tests/"
 
 # ===========================================================================
 # Non-worktree PWD → hook is inactive (not in SWE worktree context)


### PR DESCRIPTION
Closes GH #831. swe-scope-fence.sh strips a single trailing slash from each files[] token before the */* dirname case, so a directory token like tests/ resolves to tests instead of collapsing to . and denying every in-scope edit. 26/26 incl. 2 new regression cases. pr-reviewer PASS (validation #168).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)