### PR TITLE
✨ feat(scan): discover local skills/plugins/mcp and reconcile into the cheatcodes table (#846)

### DIFF
--- a/scripts/scan.sh
+++ b/scripts/scan.sh
@@ -31,6 +31,8 @@
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 SESSION_DIR="${1:-$PWD}"
 SESSION_DIR=$(cd "$SESSION_DIR" 2>/dev/null && pwd)
 [ -d "$SESSION_DIR" ] || { echo '{"error":"session_dir does not exist"}' >&2; exit 1; }
@@ -228,6 +230,126 @@ while IFS= read -r repo_root; do
     '{name:$name,path:$path,file_count:$file_count}' \
     >> "$repos_jsonl"
 done < <(discover_repos)
+
+# --- Resource discovery (#124/#846) --------------------------------------
+# After the repo/file walk, reconcile locally-present resources into the
+# cheatcodes table: project-local skills, enabled plugins, configured MCP
+# servers. Each discovered resource not already tracked (name+kind) is
+# INSERTed (origin=installed, status=installed, source_url='scan_discovered'
+# so it is distinguishable from pipeline-installed) and a scan_discovered
+# audit row is emitted. Already-tracked rows are left to the #113 health-check.
+#
+# Non-load-bearing: this never alters stdout (the world-model JSON below is
+# unchanged) and never fails the scan — every step is guarded and best-effort.
+discover_resources() {
+  local lib="$SCRIPT_DIR/hooks/lib/query-task.sh"
+  [ -f "$lib" ] || return 0
+  # shellcheck source=scripts/hooks/lib/query-task.sh
+  . "$lib" 2>/dev/null || return 0
+
+  tmb_have_sqlite || return 0
+  local db
+  db=$(tmb_db_path) || return 0
+  [ -n "$db" ] || return 0
+
+  # cheatcodes + audit tables must exist.
+  local have_cc
+  have_cc=$(tmb_sqlite_ro "$db" "SELECT name FROM sqlite_master WHERE type='table' AND name='cheatcodes';")
+  [ -n "$have_cc" ] || return 0
+
+  local claude_timeout="${TMB_SCAN_DISCOVERY_TIMEOUT:-4}"
+  _run_bounded() {
+    if command -v timeout >/dev/null 2>&1; then
+      timeout "$claude_timeout" "$@" 2>/dev/null || true
+    elif command -v gtimeout >/dev/null 2>&1; then
+      gtimeout "$claude_timeout" "$@" 2>/dev/null || true
+    else
+      "$@" 2>/dev/null || true
+    fi
+  }
+
+  local now
+  now=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+
+  # INSERT one discovered resource if it is not already a cheatcodes row
+  # (matched on name+kind). Emits a scan_discovered audit row on insert.
+  _register() {
+    local kind="$1" name="$2" file_path="$3"
+    [ -n "$name" ] || return 0
+    local safe_name safe_kind
+    safe_name=$(tmb_sql_quote "$name")
+    safe_kind=$(tmb_sql_quote "$kind")
+
+    local existing
+    existing=$(tmb_sqlite_ro "$db" "
+      SELECT 1 FROM cheatcodes
+       WHERE name = '$safe_name' AND kind = '$safe_kind' LIMIT 1;")
+    [ -n "$existing" ] && return 0
+
+    local fp_sql="NULL"
+    if [ -n "$file_path" ]; then
+      fp_sql="'$(tmb_sql_quote "$file_path")'"
+    fi
+    local content_json
+    content_json=$(printf '{"name":"%s","kind":"%s","source":"scan_discovered"}' \
+      "$safe_name" "$safe_kind")
+
+    sqlite3 "$db" <<SQL 2>/dev/null || true
+INSERT INTO cheatcodes (name, kind, origin, source_url, file_path, scope, status, installed_at, created_at, updated_at)
+VALUES ('$safe_name', '$safe_kind', 'installed', 'scan_discovered', $fp_sql, 'project-local', 'installed', '$now', '$now', '$now');
+INSERT INTO audit (issue_id, branch_id, from_node, event_type, summary, content_json, created_at)
+VALUES (-1, '', 'scan',
+        'scan_discovered',
+        '$safe_name ($safe_kind): discovered',
+        '$content_json', '$now');
+SQL
+  }
+
+  # skills — project-local .claude/skills/<name>/SKILL.md.
+  local skills_dir="$SESSION_DIR/.claude/skills"
+  if [ -d "$skills_dir" ]; then
+    local skill_md
+    while IFS= read -r skill_md; do
+      [ -n "$skill_md" ] || continue
+      local sname
+      sname=$(basename "$(dirname "$skill_md")")
+      _register skill "$sname" ".claude/skills/$sname/SKILL.md"
+    done < <(find "$skills_dir" -mindepth 2 -maxdepth 2 -name SKILL.md 2>/dev/null | sort)
+  fi
+
+  # plugins + mcp — only when the claude CLI is available.
+  if command -v claude >/dev/null 2>&1; then
+    local plugin_list mcp_list
+    plugin_list=$(_run_bounded claude plugin list)
+    mcp_list=$(_run_bounded claude mcp list)
+
+    # plugins: each non-empty line's first token is the plugin name.
+    local pname
+    while IFS= read -r pname; do
+      pname=$(printf '%s' "$pname" | awk '{print $1}' | sed 's/[:@].*$//')
+      [ -n "$pname" ] && _register plugin "$pname" ""
+    done < <(printf '%s\n' "$plugin_list")
+
+    # mcp: `claude mcp list` prints "name: ..." per server.
+    local mname
+    while IFS= read -r mname; do
+      mname=$(printf '%s' "$mname" | sed -n 's/^\([A-Za-z0-9._-]\{1,\}\):.*$/\1/p')
+      [ -n "$mname" ] && _register mcp "$mname" ""
+    done < <(printf '%s\n' "$mcp_list")
+  fi
+
+  # mcp fallback — ~/.claude.json mcpServers keys (covers a stale CLI).
+  if [ -f "$HOME/.claude.json" ]; then
+    local jkey
+    while IFS= read -r jkey; do
+      [ -n "$jkey" ] && _register mcp "$jkey" ""
+    done < <(jq -r '.mcpServers // {} | keys[]' "$HOME/.claude.json" 2>/dev/null || true)
+  fi
+
+  return 0
+}
+
+discover_resources >/dev/null 2>&1 || true
 
 scanned_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 

--- a/tests/l3-integration/hooks/scan-resource-discovery.test.sh
+++ b/tests/l3-integration/hooks/scan-resource-discovery.test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# L3: scan resource-discovery (#124/#846).
+# scripts/scan.sh — after the repo/file walk, reconciles locally-present
+# resources (project-local skills, plugins, mcp servers) into the cheatcodes
+# table: each not-already-tracked resource is INSERTed (origin=installed,
+# status=installed, source_url='scan_discovered') + a scan_discovered audit row.
+#
+# Cases:
+#   - a new local skill on disk          → registered + audited
+#   - re-run                             → no duplicate (idempotent on name+kind)
+#   - already-tracked skill              → untouched, no audit (left to #113)
+#   - absent `claude` CLI                → graceful (skills still from disk)
+#
+# All state lives under a mktemp sandbox (per #810); TRAJECTORY_DB_PATH pins
+# the DB so the real plugin DB is never touched. assert_not_in_plugin_repo
+# guards against running with cwd inside the real plugin repo.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../lib/assert.sh"
+PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
+SCAN="$PLUGIN_ROOT/scripts/scan.sh"
+
+command -v sqlite3 >/dev/null 2>&1 || { printf "SKIP sqlite3 not found\n"; exit 0; }
+command -v jq >/dev/null 2>&1 || { printf "SKIP jq not found\n"; exit 0; }
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+cd "$TMPDIR"
+assert_not_in_plugin_repo "$PLUGIN_ROOT"
+
+WS="$TMPDIR/ws"
+mkdir -p "$WS/.claude/tmb"
+DB="$WS/.claude/tmb/trajectory.db"
+
+# Minimal schema: tasks carries prompt_bearing so tmb_db_schema_current accepts
+# the DB; cheatcodes carries the columns the discovery INSERT names; audit
+# mirrors the production shape.
+seed_db() {
+  rm -f "$DB"
+  sqlite3 "$DB" "
+    CREATE TABLE tasks (id INTEGER PRIMARY KEY, prompt_bearing INTEGER NOT NULL DEFAULT 0);
+    CREATE TABLE cheatcodes (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      name         TEXT NOT NULL,
+      kind         TEXT NOT NULL,
+      origin       TEXT NOT NULL DEFAULT 'installed',
+      source_url   TEXT,
+      file_path    TEXT,
+      scope        TEXT NOT NULL DEFAULT 'project-local',
+      status       TEXT NOT NULL DEFAULT 'installed',
+      installed_at TEXT NOT NULL,
+      created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE audit (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      issue_id     INTEGER NOT NULL DEFAULT -1,
+      branch_id    TEXT,
+      from_node    TEXT NOT NULL DEFAULT 'bro',
+      event_type   TEXT NOT NULL,
+      summary      TEXT NOT NULL DEFAULT '',
+      content_json TEXT NOT NULL DEFAULT '{}',
+      created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  "
+}
+
+# A project-local skill on disk under the scanned session dir.
+mk_skill() {
+  local name="$1"
+  mkdir -p "$WS/.claude/skills/$name"
+  printf -- '---\nname: %s\n---\nbody\n' "$name" > "$WS/.claude/skills/$name/SKILL.md"
+}
+
+# A PATH that excludes any system `claude` but keeps the tools scan.sh needs.
+NOCLAUDE_BIN="$TMPDIR/nocl_bin"
+mkdir -p "$NOCLAUDE_BIN" "$TMPDIR/home"
+for t in sqlite3 jq grep sed cat dirname basename date timeout env bash awk find sort md5 md5sum stat wc xargs printf tr which head mktemp rm mkdir ln; do
+  p=$(command -v "$t" 2>/dev/null || true)
+  [ -n "$p" ] && ln -sf "$p" "$NOCLAUDE_BIN/$t" 2>/dev/null || true
+done
+
+# Run scan.sh with an isolated PATH (claude absent), TRAJECTORY_DB_PATH pinned,
+# scanning the workspace dir. stdout (world-model JSON) is captured separately.
+run_scan() {
+  env -i \
+    HOME="$TMPDIR/home" \
+    PATH="$1" \
+    TRAJECTORY_DB_PATH="$DB" \
+    bash "$SCAN" "$WS" 2>/dev/null || true
+}
+
+cc_row() { sqlite3 "$DB" "SELECT origin||'|'||COALESCE(source_url,'')||'|'||status||'|'||COALESCE(file_path,'') FROM cheatcodes WHERE name='$1' AND kind='$2';"; }
+cc_count() { sqlite3 "$DB" "SELECT COUNT(*) FROM cheatcodes WHERE name='$1' AND kind='$2';"; }
+audit_count() { sqlite3 "$DB" "SELECT COUNT(*) FROM audit WHERE event_type='scan_discovered' AND summary LIKE '$1%';"; }
+
+# ---------------------------------------------------------------------------
+# Case 1 — a new local skill on disk is registered + audited.
+# ---------------------------------------------------------------------------
+seed_db
+mk_skill "alpha-skill"
+JSON=$(run_scan "$NOCLAUDE_BIN")
+
+test_case "scan still emits valid world-model JSON (stdout unchanged)"
+assert_contains "$JSON" '"session_dir"' "scan json"
+
+test_case "new local skill registered as installed/scan_discovered row"
+assert_eq "installed|scan_discovered|installed|.claude/skills/alpha-skill/SKILL.md" \
+  "$(cc_row alpha-skill skill)" "alpha-skill row"
+
+test_case "discovery emits a scan_discovered audit row for the skill"
+assert_eq "1" "$(audit_count 'alpha-skill')" "alpha-skill audit count"
+
+# ---------------------------------------------------------------------------
+# Case 2 — re-run is idempotent: no duplicate row, no second audit row.
+# ---------------------------------------------------------------------------
+run_scan "$NOCLAUDE_BIN" >/dev/null
+
+test_case "re-scan inserts no duplicate cheatcodes row"
+assert_eq "1" "$(cc_count alpha-skill skill)" "alpha-skill row count after re-scan"
+
+test_case "re-scan emits no second audit row"
+assert_eq "1" "$(audit_count 'alpha-skill')" "alpha-skill audit count after re-scan"
+
+# ---------------------------------------------------------------------------
+# Case 3 — an already-tracked skill is left untouched (no dup, no audit).
+# ---------------------------------------------------------------------------
+seed_db
+mk_skill "tracked-skill"
+sqlite3 "$DB" "INSERT INTO cheatcodes (name, kind, origin, source_url, file_path, status, installed_at)
+  VALUES ('tracked-skill','skill','builtin',NULL,'skills/tracked-skill/SKILL.md','active','x');"
+run_scan "$NOCLAUDE_BIN" >/dev/null
+
+test_case "already-tracked skill not duplicated"
+assert_eq "1" "$(cc_count tracked-skill skill)" "tracked-skill row count"
+
+test_case "already-tracked row left untouched (origin/status unchanged)"
+assert_eq "builtin|active" "$(sqlite3 "$DB" "SELECT origin||'|'||status FROM cheatcodes WHERE name='tracked-skill';")" "tracked-skill unchanged"
+
+test_case "already-tracked skill emits no audit row"
+assert_eq "0" "$(audit_count 'tracked-skill')" "tracked-skill audit count"
+
+# ---------------------------------------------------------------------------
+# Case 4 — absent claude: skills still reconcile from disk; scan succeeds.
+# ---------------------------------------------------------------------------
+seed_db
+mk_skill "beta-skill"
+rm -f "$TMPDIR/home/.claude.json"
+JSON=$(run_scan "$NOCLAUDE_BIN")
+
+test_case "absent claude: scan still emits valid JSON"
+assert_contains "$JSON" '"session_dir"' "scan json (no-claude)"
+
+test_case "absent claude: local skill still registered from disk"
+assert_eq "1" "$(cc_count beta-skill skill)" "beta-skill row count (no-claude)"
+
+test_case "absent claude: local skill audited"
+assert_eq "1" "$(audit_count 'beta-skill')" "beta-skill audit count (no-claude)"
+
+# ---------------------------------------------------------------------------
+# Case 5 — graceful skip when sqlite3/DB absent (no TRAJECTORY_DB_PATH match):
+#          scan still succeeds and emits JSON.
+# ---------------------------------------------------------------------------
+test_case "missing DB: scan still emits valid JSON (graceful skip)"
+JSON=$(env -i HOME="$TMPDIR/home" PATH="$NOCLAUDE_BIN" \
+  TRAJECTORY_DB_PATH="$TMPDIR/nope/trajectory.db" \
+  bash "$SCAN" "$WS" 2>/dev/null || true)
+assert_contains "$JSON" '"session_dir"' "scan json (no-db)"
+
+summarize
+printf "PASS scan-resource-discovery\n"


### PR DESCRIPTION
Closes GH #846. scan.sh gains a discover_resources() pass reconciling local skills/plugins/mcp into the cheatcodes table via sqlite3 (origin=installed, source_url='scan_discovered' marker), idempotent on name+kind, bounded, graceful; world-model stdout byte-unchanged; never fails scan. New L3 test 12/12. pr-reviewer PASS (validation #174).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)