### PR TITLE
♻️ refactor(hooks): registration-based repo scoping + per-repo protected_branches authoritative (#693)

### DIFF
--- a/scripts/hooks/cleanup-worktree-on-task-close.sh
+++ b/scripts/hooks/cleanup-worktree-on-task-close.sh
@@ -66,27 +66,18 @@ BRANCH_ID=$(sqlite3 "$DB_PATH" "SELECT branch_id FROM tasks WHERE id=${SAFE_TASK
 [ -n "$BRANCH_ID" ] || exit 0
 
 TASK_REPO=$(sqlite3 "$DB_PATH" "SELECT repo FROM tasks WHERE id=${SAFE_TASK_ID} LIMIT 1;" 2>/dev/null || true)
-if [ -z "$TASK_REPO" ]; then
-  TASK_REPO=$(sqlite3 "$DB_PATH" "SELECT json_extract(value_json, '$') FROM plugin_config WHERE key='tmb_default_repo';" 2>/dev/null || true)
-fi
 
 WORKSPACE_ROOT="$(dirname "$(dirname "$(dirname "$DB_PATH")")")"
 if [ -n "$TASK_REPO" ]; then
-  # Prefer the absolute path recorded in the `repos` table (authoritative
-  # — set by /scan). Falls back to legacy workspace-join only when no
+  # Resolve the absolute path from the `repos` table (authoritative — set by
+  # /scan), matched by name. Falls back to legacy workspace-join only when no
   # matching repo row exists.
-  SAFE_TASK_REPO=$(tmb_sql_quote "$TASK_REPO")
-  REPO_ROOT=$(sqlite3 "$DB_PATH" "SELECT path FROM repos WHERE name='${SAFE_TASK_REPO}' LIMIT 1;" 2>/dev/null || true)
+  REPO_ROOT=$(tmb_repo_path_by_name "$DB_PATH" "$TASK_REPO")
   [ -z "$REPO_ROOT" ] && REPO_ROOT="$WORKSPACE_ROOT/$TASK_REPO"
 else
-  # Single-repo fallback when no default config.
-  REPO_COUNT=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM repos;" 2>/dev/null || echo 0)
-  if [ "$REPO_COUNT" = "1" ]; then
-    REPO_ROOT=$(sqlite3 "$DB_PATH" "SELECT path FROM repos LIMIT 1;" 2>/dev/null || true)
-    [ -z "$REPO_ROOT" ] && REPO_ROOT="$WORKSPACE_ROOT"
-  else
-    REPO_ROOT="$WORKSPACE_ROOT"
-  fi
+  # Single-repo fallback when task.repo is unset.
+  REPO_ROOT=$(tmb_repo_single_path "$DB_PATH")
+  [ -z "$REPO_ROOT" ] && REPO_ROOT="$WORKSPACE_ROOT"
 fi
 [ -d "$REPO_ROOT/.git" ] || exit 0
 

--- a/scripts/hooks/git-guards.sh
+++ b/scripts/hooks/git-guards.sh
@@ -104,32 +104,14 @@ _CMD_CWD=$(cmd_cwd "$CMD")
 _GIT_ROOT=$(tmb_repo_git_root "$_CMD_CWD")
 _DB=$(tmb_db_path 2>/dev/null || true)
 
-# --- Managed-repo scope (#631, mirrors #592) ---
+# --- Managed-repo scope by REGISTRATION (#693, ADR: path-keyed repo resolution) ---
 # In a multi-repo workspace these guards (Rule 1 PR-target, Rule 2
-# no-direct-commit, Rule 4 branch-from-pr_target) must only fire for the managed
+# no-direct-commit, Rule 4 branch-from-pr_target) must only fire for a REGISTERED
 # product repo, not its siblings (e.g. marketplace-rc, which is main-only and has
-# no dev branch). The DB lives at <workspace_root>/.claude/<plugin>/trajectory.db,
-# so the workspace root is three levels above _DB and the managed repo is
-# <workspace_root>/<tmb_default_repo>. When the command's git root is outside that
-# subtree it belongs to a sibling repo — the guards no-op (exit 0). When
-# tmb_default_repo is empty or '.' (the normal single-repo user project), the gate
-# is inert and the whole tree is guarded as before.
-if [ -n "$_DB" ] && [ -f "$_DB" ] && tmb_have_sqlite && [ -n "$_GIT_ROOT" ]; then
-  _DEFAULT_REPO=$(tmb_config_get "tmb_default_repo" "$_DB")
-  if [ -n "$_DEFAULT_REPO" ] && [ "$_DEFAULT_REPO" != "." ]; then
-    _WORKSPACE_ROOT=$(dirname "$(dirname "$(dirname "$_DB")")")
-    _MANAGED_ROOT="$_WORKSPACE_ROOT/$_DEFAULT_REPO"
-    # Canonicalize the managed root so it compares equal to git's already-
-    # canonical _GIT_ROOT (e.g. /tmp vs /private/tmp on macOS).
-    if [ -d "$_MANAGED_ROOT" ]; then
-      _MANAGED_ROOT=$(cd "$_MANAGED_ROOT" 2>/dev/null && pwd -P || echo "$_MANAGED_ROOT")
-    fi
-    if [ "$_GIT_ROOT" != "$_MANAGED_ROOT" ]; then
-      exit 0
-    fi
-  fi
-fi
-
+# no dev branch). A git op is enforced iff its git-root resolves to a `repos` row
+# (matched by path); when the command's git root is an unregistered sibling tree
+# the guards no-op (exit 0). For single-repo user projects the sole repo IS the
+# registered root (recorded by /scan), so the whole tree is guarded as before.
 if [ -n "$_DB" ] && [ -f "$_DB" ] && tmb_have_sqlite && [ -n "$_GIT_ROOT" ]; then
   if ! tmb_repo_is_registered "$_DB" "$_GIT_ROOT"; then
     exit 0

--- a/scripts/hooks/lib/resolve-repo.sh
+++ b/scripts/hooks/lib/resolve-repo.sh
@@ -11,6 +11,15 @@
 #                                 Prints empty when no row matches (unregistered repo).
 #   tmb_repo_is_registered <db> <git_root>
 #                               — exits 0 when a repos row with path=<git_root> exists, 1 otherwise.
+#   tmb_repo_path_by_name <db> <name>
+#                               — print repos.path for the row with name=<name>, or empty.
+#   tmb_repo_single_path <db>   — print repos.path when EXACTLY one repo is
+#                                 registered (single-repo fallback), else empty.
+#   tmb_repo_resolve_path <db> <name>
+#                               — print the absolute repo path for <name> via
+#                                 repos.path; when <name> is empty, fall back to
+#                                 the sole registered repo (single-repo). Empty
+#                                 when neither resolves.
 #
 # All functions never fail the caller (use || true / return 0 patterns).
 
@@ -59,4 +68,48 @@ tmb_repo_is_registered() {
     "SELECT COUNT(*) FROM repos WHERE path = '$(printf '%s' "$git_root" | sed "s/'/''/g")';" \
     2>/dev/null || echo 0)
   [ "${count:-0}" -gt 0 ]
+}
+
+# tmb_repo_path_by_name <db> <name>
+# Prints repos.path for the row whose name matches <name>; empty when absent.
+tmb_repo_path_by_name() {
+  local db="$1"
+  local name="$2"
+  [ -f "$db" ] || return 0
+  command -v sqlite3 >/dev/null 2>&1 || return 0
+  [ -n "$name" ] || return 0
+  sqlite3 -readonly -cmd '.timeout 500' "$db" \
+    "SELECT path FROM repos WHERE name = '$(printf '%s' "$name" | sed "s/'/''/g")' LIMIT 1;" \
+    2>/dev/null | head -1 || true
+}
+
+# tmb_repo_single_path <db>
+# Prints repos.path when EXACTLY one repo is registered, else empty.
+# This is the single-repo fallback (matches the MCP resolveDefaultRepoPath).
+tmb_repo_single_path() {
+  local db="$1"
+  [ -f "$db" ] || return 0
+  command -v sqlite3 >/dev/null 2>&1 || return 0
+  local count
+  count=$(sqlite3 -readonly -cmd '.timeout 500' "$db" \
+    "SELECT COUNT(*) FROM repos;" 2>/dev/null || echo 0)
+  [ "${count:-0}" = "1" ] || return 0
+  sqlite3 -readonly -cmd '.timeout 500' "$db" \
+    "SELECT path FROM repos LIMIT 1;" 2>/dev/null | head -1 || true
+}
+
+# tmb_repo_resolve_path <db> <name>
+# Resolve the absolute repo path: by <name> via repos.path; when <name> is
+# empty, fall back to the sole registered repo (single-repo). Empty when neither.
+tmb_repo_resolve_path() {
+  local db="$1"
+  local name="$2"
+  local path=""
+  if [ -n "$name" ]; then
+    path=$(tmb_repo_path_by_name "$db" "$name")
+  fi
+  if [ -z "$path" ]; then
+    path=$(tmb_repo_single_path "$db")
+  fi
+  printf '%s' "$path"
 }

--- a/scripts/hooks/no-source-edit-from-main.sh
+++ b/scripts/hooks/no-source-edit-from-main.sh
@@ -14,10 +14,10 @@
 #   - Normalized agent role == 'swe' (non-isolated SWE running in main checkout)
 #   Enforcement surfaces (scripts/hooks/, hooks/hooks.json) are ALWAYS denied from
 #   main, even for swe — they sit above the swe permit and are never re-opened.
-#   Managed-repo scope: in a multi-repo workspace Rule 1 only guards the managed
-#   product repo (plugin_config tmb_default_repo); absolute targets in sibling
-#   repos are allowed. Empty/'.' tmb_default_repo guards the whole tree (the
-#   normal single-repo user project).
+#   Managed-repo scope: in a multi-repo workspace Rule 1 only guards a REGISTERED
+#   product repo; absolute targets whose git-root is an unregistered sibling repo
+#   are allowed. A single-repo project's sole registered repo IS the root, so the
+#   whole tree is guarded.
 #
 # Rule 2 — Bash write-form targeting a prompt surface from main checkout:
 #   Denied for every agent identity (bro, subagent, swe, unknown) when outside a
@@ -34,6 +34,8 @@ set -uo pipefail
 PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=scripts/hooks/lib/normalize-role.sh
 . "$PLUGIN_ROOT/scripts/hooks/lib/normalize-role.sh"
+# shellcheck source=scripts/hooks/lib/resolve-repo.sh
+. "$PLUGIN_ROOT/scripts/hooks/lib/resolve-repo.sh"
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
@@ -211,54 +213,27 @@ case "$TARGET" in
   */.claude/worktrees/*|.claude/worktrees/*) exit 0 ;;
 esac
 
-# Managed-repo scope (#592): in a multi-repo workspace, Rule 1 must only guard
-# the managed product repo (plugin_config tmb_default_repo), not its siblings.
-# tmb_default_repo is the repo NAME, so the managed root is resolved by a
-# path-keyed lookup against repos.path (the canonical absolute path set by scan)
-# rather than string-joining the workspace root with the name — that join
-# mis-scopes single-repo-at-root layouts (where the git repo IS the workspace
-# root) one level too deep, leaking the whole tree as a "sibling". Both the
-# resolved MANAGED_ROOT and the absolute target are realpath-normalized before
-# the enclosure test (handles /tmp->/private/tmp symlinks and trailing slashes).
-# Fail-closed: if the repos.path lookup is empty (repo name not found), the whole
-# tree is guarded — the same as an empty/'.' tmb_default_repo (single-repo user
-# project). Only a resolved MANAGED_ROOT plus a target outside it allows a
-# sibling-repo edit.
-_realpath() {
-  if command -v realpath >/dev/null 2>&1; then
-    realpath -m "$1" 2>/dev/null || printf '%s' "$1"
-  elif command -v python3 >/dev/null 2>&1; then
-    python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' "$1" 2>/dev/null || printf '%s' "$1"
-  else
-    printf '%s' "$1"
-  fi
-}
-DEFAULT_REPO=""
-if command -v sqlite3 >/dev/null 2>&1; then
-  DEFAULT_REPO=$(sqlite3 -readonly -cmd '.timeout 500' "$DB_PATH" \
-    "SELECT json_extract(value_json, '\$') FROM plugin_config WHERE key='tmb_default_repo' LIMIT 1;" \
-    2>/dev/null || true)
-fi
-if [ -n "$DEFAULT_REPO" ] && [ "$DEFAULT_REPO" != "." ]; then
-  case "$TARGET" in
-    /*)
-      MANAGED_ROOT=""
-      if command -v sqlite3 >/dev/null 2>&1; then
-        MANAGED_ROOT=$(sqlite3 -readonly -cmd '.timeout 500' "$DB_PATH" \
-          "SELECT path FROM repos WHERE name='$(printf '%s' "$DEFAULT_REPO" | sed "s/'/''/g")' LIMIT 1;" \
-          2>/dev/null || true)
+# Managed-repo scope by REGISTRATION (#693, ADR: path-keyed repo resolution):
+# in a multi-repo workspace Rule 1 must only guard a REGISTERED product repo,
+# not its siblings. Resolve the target's git-root and enforce iff that root is a
+# `repos` row (matched by path); an absolute target whose git-root is an
+# unregistered sibling tree is outside Rule 1 scope (exit 0). A target with no
+# resolvable git-root (or a single-repo project whose sole repo IS the root) is
+# guarded as before — registration of the lone repo covers the whole tree.
+case "$TARGET" in
+  /*)
+    TARGET_DIR=$(dirname "$TARGET")
+    # Only consult registration when the target's directory actually exists —
+    # otherwise tmb_repo_git_root falls back to $PWD (the hook's cwd) and would
+    # mis-scope. A target whose parent dir is absent fails closed (guarded).
+    if command -v sqlite3 >/dev/null 2>&1 && [ -d "$TARGET_DIR" ]; then
+      TARGET_GIT_ROOT=$(tmb_repo_git_root "$TARGET_DIR")
+      if [ -n "$TARGET_GIT_ROOT" ] && ! tmb_repo_is_registered "$DB_PATH" "$TARGET_GIT_ROOT"; then
+        exit 0                          # unregistered sibling repo — outside Rule 1 scope
       fi
-      if [ -n "$MANAGED_ROOT" ]; then
-        MANAGED_ROOT=$(_realpath "$MANAGED_ROOT")
-        TARGET_REAL=$(_realpath "$TARGET")
-        case "$TARGET_REAL" in
-          "$MANAGED_ROOT"/*) : ;;       # inside the managed repo — keep guarding
-          *) exit 0 ;;                  # sibling repo — outside Rule 1 scope
-        esac
-      fi
-      ;;
-  esac
-fi
+    fi
+    ;;
+esac
 
 # Enforcement surfaces: deny before any allowlist entry is evaluated.
 # No pattern — including *.md or docs/ — can re-open these paths from

--- a/scripts/hooks/require-feature-branch-active.sh
+++ b/scripts/hooks/require-feature-branch-active.sh
@@ -12,6 +12,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$SCRIPT_DIR/lib/query-task.sh"
 # shellcheck source=lib/normalize-role.sh
 . "$SCRIPT_DIR/lib/normalize-role.sh"
+# shellcheck source=lib/resolve-repo.sh
+. "$SCRIPT_DIR/lib/resolve-repo.sh"
 
 if [ "${TMB_ALLOW_BRANCH_MISMATCH:-0}" = "1" ]; then
   exit 0
@@ -39,16 +41,11 @@ REPO=$(echo "$ROW" | cut -d'|' -f2)
 
 WORKSPACE_ROOT="$(dirname "$(dirname "$(dirname "$DB")")")"
 
-if [ -z "$REPO" ]; then
-  REPO=$(sqlite3 "$DB" "SELECT json_extract(value_json, '$') FROM plugin_config WHERE key='tmb_default_repo';" 2>/dev/null || true)
-fi
-
 if [ -n "$REPO" ]; then
-  # Prefer the absolute path recorded in the `repos` table (authoritative
-  # — set by /scan). Falls back to the legacy workspace-join only when
+  # Resolve the absolute path from the `repos` table (authoritative — set by
+  # /scan), matched by name. Falls back to the legacy workspace-join only when
   # no matching repo row exists (e.g. pre-scan or non-workspace layout).
-  SAFE_REPO=$(tmb_sql_quote "$REPO")
-  REPO_ABS=$(sqlite3 "$DB" "SELECT path FROM repos WHERE name='${SAFE_REPO}' LIMIT 1;" 2>/dev/null || true)
+  REPO_ABS=$(tmb_repo_path_by_name "$DB" "$REPO")
   if [ -z "$REPO_ABS" ]; then
     REPO_ABS="$WORKSPACE_ROOT/$REPO"
   fi
@@ -58,17 +55,14 @@ if [ -n "$REPO" ]; then
     exit 0
   fi
 else
-  # No explicit repo + no default config. Single-repo fallback: if the
-  # repos table has exactly one entry, use it (matches the
-  # resolveDefaultRepo MCP-side fallback for single-repo projects).
-  REPO_ABS=$(sqlite3 "$DB" "SELECT path FROM repos LIMIT 2;" 2>/dev/null | head -1 || true)
-  REPO_COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM repos;" 2>/dev/null || echo 0)
-  if [ "$REPO_COUNT" != "1" ] || [ -z "$REPO_ABS" ]; then
-    REPO_ABS="$WORKSPACE_ROOT"
-  fi
+  # No explicit task.repo. Single-repo fallback: if the repos table has exactly
+  # one entry, use it (matches the resolveDefaultRepoPath MCP-side fallback for
+  # single-repo projects). Otherwise fall back to the workspace root.
+  REPO_ABS=$(tmb_repo_single_path "$DB")
+  [ -n "$REPO_ABS" ] || REPO_ABS="$WORKSPACE_ROOT"
   if [ ! -d "$REPO_ABS/.git" ]; then
     jq -nc --arg id "$TASK_ID" \
-      '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: cannot resolve repo for task "+$id+". tasks.repo IS NULL and tmb_default_repo config is unset. Set via `config_set tmb_default_repo <inner>` for multi-repo workspaces.")}}'
+      '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: cannot resolve repo for task "+$id+". tasks.repo IS NULL and no single registered repo could be resolved. For a multi-repo workspace, set the task'"'"'s repo (task_create repo=<name>) so it maps to a repos row.")}}'
     exit 0
   fi
 fi

--- a/scripts/hooks/worktree-create.sh
+++ b/scripts/hooks/worktree-create.sh
@@ -9,13 +9,13 @@
 # trajectory DB to find tasks.repo.
 #
 # Repo resolution order:
-#   1. tasks.repo (matched by branch)
-#   2. tmb_default_repo (plugin_config) — used when CWD is not a git repo
+#   1. tasks.repo (matched by branch) → repos.path
+#   2. single-repo fallback (repos.path when exactly one repo is registered)
 #   3. WORKSPACE_ROOT — fallback for single-repo layouts where workspace IS the repo
 #
 # No-match (branch not in tasks table):
 #   Create the worktree in the resolution-order repo (tasks.repo unavailable →
-#   tmb_default_repo → workspace root), creating the branch if it does not exist.
+#   single-repo fallback → workspace root), creating the branch if it does not exist.
 #
 # DB-absent (non-TMB project):
 #   Create under <cwd>/.claude/worktrees/<sanitized-branch> from the cwd repo.
@@ -40,6 +40,8 @@ set -uo pipefail
 PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=scripts/hooks/lib/query-task.sh
 . "$PLUGIN_ROOT/scripts/hooks/lib/query-task.sh"
+# shellcheck source=scripts/hooks/lib/resolve-repo.sh
+. "$PLUGIN_ROOT/scripts/hooks/lib/resolve-repo.sh"
 
 INPUT=$(cat)
 
@@ -101,39 +103,19 @@ TASK_COUNT=$(sqlite3 "$DB_PATH" \
   2>/dev/null || echo 0)
 
 if [ "$TASK_COUNT" = "0" ]; then
-  # No matching task — create in the default-repo resolution order
-  DEFAULT_REPO=$(tmb_config_get "tmb_default_repo" "$DB_PATH" 2>/dev/null || true)
-  if [ -n "$DEFAULT_REPO" ]; then
-    case "$DEFAULT_REPO" in
-      /*) REPO_ABS="$DEFAULT_REPO" ;;
-      *)  REPO_ABS="$WORKSPACE_ROOT/$DEFAULT_REPO" ;;
-    esac
-  else
-    REPO_ABS="$WORKSPACE_ROOT"
-  fi
+  # No matching task — single-repo fallback (repos.path), else workspace root.
+  REPO_ABS=$(tmb_repo_single_path "$DB_PATH" 2>/dev/null || true)
+  [ -n "$REPO_ABS" ] || REPO_ABS="$WORKSPACE_ROOT"
   WORKTREE_PATH="$WORKSPACE_ROOT/.claude/worktrees/$SLUG"
 else
   REPO=$(sqlite3 "$DB_PATH" \
     "SELECT COALESCE(repo,'') FROM tasks WHERE branch_id='$SAFE_BRANCH' LIMIT 1;" \
     2>/dev/null || true)
 
-  DEFAULT_REPO=""
-  if [ -n "$REPO" ]; then
-    case "$REPO" in
-      /*) REPO_ABS="$REPO" ;;
-      *)  REPO_ABS="$WORKSPACE_ROOT/$REPO" ;;
-    esac
-  else
-    DEFAULT_REPO=$(tmb_config_get "tmb_default_repo" "$DB_PATH" 2>/dev/null || true)
-    if [ -n "$DEFAULT_REPO" ]; then
-      case "$DEFAULT_REPO" in
-        /*) REPO_ABS="$DEFAULT_REPO" ;;
-        *)  REPO_ABS="$WORKSPACE_ROOT/$DEFAULT_REPO" ;;
-      esac
-    else
-      REPO_ABS="$WORKSPACE_ROOT"
-    fi
-  fi
+  # Resolve tasks.repo (a repo name) via repos.path; when it is unset, fall back
+  # to the sole registered repo (single-repo), else the workspace root.
+  REPO_ABS=$(tmb_repo_resolve_path "$DB_PATH" "$REPO" 2>/dev/null || true)
+  [ -n "$REPO_ABS" ] || REPO_ABS="$WORKSPACE_ROOT"
 
   WORKTREE_PATH="$WORKSPACE_ROOT/.claude/worktrees/$SLUG"
 fi

--- a/tests/l3-integration/hooks/cleanup-worktree-on-task-close.test.sh
+++ b/tests/l3-integration/hooks/cleanup-worktree-on-task-close.test.sh
@@ -105,7 +105,7 @@ out=$(run_hook "$(input 'mcp__plugin_tmb-rc_trajectory-server__task_update_statu
 [ ! -d "$REPO/.claude/worktrees/bar" ] || { echo "FAIL: rc-channel match didn't fire"; exit 1; }
 echo "  rc-channel tool name handled"
 
-test_case "TMB workspace shape: workspace-rooted DB + tasks.repo=null + tmb_default_repo='plugin' → worktree removed"
+test_case "TMB workspace shape: workspace-rooted DB + tasks.repo=null + single-repo fallback → worktree removed"
 WORKSPACE_TMP=$(mktemp -d -t tmb-ws-XXXX)
 INNER="$WORKSPACE_TMP/plugin"
 mkdir -p "$INNER"
@@ -116,6 +116,7 @@ git -C "$INNER" config user.name t
 echo init > "$INNER/README.md"
 git -C "$INNER" add .
 git -C "$INNER" commit -qm init
+INNER_ROOT=$(git -C "$INNER" rev-parse --show-toplevel)
 WS_DB="$WORKSPACE_TMP/.claude/tmb/trajectory.db"
 mkdir -p "$(dirname "$WS_DB")"
 sqlite3 "$WS_DB" "
@@ -123,8 +124,8 @@ sqlite3 "$WS_DB" "
   INSERT INTO tasks (id, branch_id, repo, status) VALUES (20, 'fix/ws-test', NULL, 'completed');
 "
 sqlite3 "$WS_DB" "
-  CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT, updated_at TEXT);
-  INSERT INTO plugin_config (key, value_json, updated_at) VALUES ('tmb_default_repo', '\"plugin\"', datetime('now'));
+  CREATE TABLE repos (name TEXT PRIMARY KEY, path TEXT NOT NULL, target_branch TEXT, protected_branches TEXT);
+  INSERT INTO repos (name, path) VALUES ('plugin', '$INNER_ROOT');
 "
 git -C "$INNER" branch fix/ws-test HEAD
 git -C "$INNER" worktree add -q "$WORKSPACE_TMP/.claude/worktrees/ws-test" fix/ws-test

--- a/tests/l3-integration/hooks/git-guards.test.sh
+++ b/tests/l3-integration/hooks/git-guards.test.sh
@@ -498,19 +498,19 @@ out=$(run_hook_in_repo "echo \"run glab mr create --target-branch dev from your 
 assert_not_contains "$out" '"permissionDecision":"deny"' "glab mr create inside quoted echo must not block"
 cleanup_repo
 
-# ---- #631: managed-repo scope (mirrors #592) -----------------------------------
-# In a multi-repo workspace, git-guards' Rule 1/2/4 must only fire for the
-# managed product repo (plugin_config tmb_default_repo). Sibling repos
-# (e.g. marketplace-rc, main-only with no dev branch) are exempt. When
-# tmb_default_repo is empty/'.', behavior is unchanged (single-repo guarding).
+# ---- #693: registration-based managed-repo scope (ADR: path-keyed resolution) --
+# In a multi-repo workspace, git-guards' Rule 1/2/4 fire only for a REGISTERED
+# product repo (a `repos` row matched by git-root path). Sibling trees that are
+# NOT registered (e.g. an ad-hoc clone, or a main-only marketplace tree never
+# scanned in) are exempt — the guard no-ops. A single registered repo's whole
+# tree is guarded as before.
 #
-# Layout: <ws>/.claude/tmb/trajectory.db with managed + sibling repos as
-# siblings under <ws>. The DB is three levels above each repo's git root, so
-# managed = <ws>/<tmb_default_repo>; sibling git roots fall outside that subtree.
+# Layout: <ws>/.claude/tmb/trajectory.db with a registered repo + an
+# unregistered sibling, both siblings under <ws>.
 
 setup_multirepo_workspace() {
-  # $1 = tmb_default_repo value to store (e.g. "managed", "" for single-repo).
-  local default_repo="$1"
+  # $1 = "single" registers only `managed`; "both" registers managed + sibling.
+  local mode="$1"
   local ws
   ws=$(mktemp -d -t tmb-guards-ws-XXXX)
   mkdir -p "$ws/.claude/tmb"
@@ -524,7 +524,7 @@ setup_multirepo_workspace() {
     echo init > README.md
     git add . && git commit -qm init
   )
-  # Sibling repo (e.g. marketplace-rc): also on main, also registered.
+  # Sibling repo (e.g. an ad-hoc clone): also on main.
   (
     cd "$ws" && git init -q -b main sibling
     cd "$ws/sibling" || exit 1
@@ -539,11 +539,10 @@ setup_multirepo_workspace() {
   managed_root=$(git -C "$ws/managed" rev-parse --show-toplevel)
   sibling_root=$(git -C "$ws/sibling" rev-parse --show-toplevel)
   sqlite3 "$ws/.claude/tmb/trajectory.db" \
-    "INSERT INTO repos (name, path) VALUES ('managed', '$managed_root');
-     INSERT INTO repos (name, path) VALUES ('sibling', '$sibling_root');" >/dev/null
-  if [ -n "$default_repo" ]; then
+    "INSERT INTO repos (name, path) VALUES ('managed', '$managed_root');" >/dev/null
+  if [ "$mode" = "both" ]; then
     sqlite3 "$ws/.claude/tmb/trajectory.db" \
-      "INSERT OR REPLACE INTO plugin_config (key, value_json) VALUES ('tmb_default_repo', '\"${default_repo}\"');" >/dev/null
+      "INSERT INTO repos (name, path) VALUES ('sibling', '$sibling_root');" >/dev/null
   fi
   WS_PATH="$ws"
 }
@@ -562,34 +561,76 @@ cleanup_ws() {
   WS_PATH=""
 }
 
-test_case "#631: managed-repo direct commit to main IS still blocked (tmb_default_repo=managed)"
-setup_multirepo_workspace "managed"
+test_case "#693: registered repo direct commit to main IS blocked"
+setup_multirepo_workspace "single"
 out=$(run_hook_in_ws "$WS_PATH/managed" "git commit -m broken")
-assert_contains "$out" '"permissionDecision":"deny"' "commit on managed repo's protected main must still block"
+assert_contains "$out" '"permissionDecision":"deny"' "commit on registered repo's protected main must block"
 cleanup_ws
 
-test_case "#631: sibling-repo direct commit to main is ALLOWED (outside managed scope)"
-setup_multirepo_workspace "managed"
+test_case "#693: unregistered sibling direct commit to main is ALLOWED (no-op)"
+setup_multirepo_workspace "single"
 out=$(run_hook_in_ws "$WS_PATH/sibling" "git commit -m wip")
-assert_not_contains "$out" '"permissionDecision":"deny"' "commit on sibling repo must be exempt from git-guards"
+assert_not_contains "$out" '"permissionDecision":"deny"' "commit in unregistered sibling tree must no-op"
 cleanup_ws
 
-test_case "#631: sibling-repo branch-from-main is ALLOWED (Rule 4 exempt outside managed scope)"
-setup_multirepo_workspace "managed"
+test_case "#693: unregistered sibling branch-from-main is ALLOWED (Rule 4 no-op)"
+setup_multirepo_workspace "single"
 out=$(run_hook_in_ws "$WS_PATH/sibling" "git checkout -b feat/x")
-assert_not_contains "$out" '"permissionDecision":"deny"' "branch creation in sibling repo must be exempt"
+assert_not_contains "$out" '"permissionDecision":"deny"' "branch creation in unregistered sibling must no-op"
 cleanup_ws
 
-test_case "#631: single-repo (empty tmb_default_repo) commit to main STILL blocked (unchanged)"
-setup_multirepo_workspace ""
+test_case "#693: when BOTH siblings are registered, each is independently guarded"
+setup_multirepo_workspace "both"
 out=$(run_hook_in_ws "$WS_PATH/managed" "git commit -m broken")
-assert_contains "$out" '"permissionDecision":"deny"' "empty tmb_default_repo must guard the whole tree as before"
+assert_contains "$out" '"permissionDecision":"deny"' "registered managed repo must block"
+out=$(run_hook_in_ws "$WS_PATH/sibling" "git commit -m broken")
+assert_contains "$out" '"permissionDecision":"deny"' "registered sibling repo must also block"
 cleanup_ws
 
-test_case "#631: single-repo sibling commit also blocked when tmb_default_repo empty (no scoping)"
-setup_multirepo_workspace ""
-out=$(run_hook_in_ws "$WS_PATH/sibling" "git commit -m broken")
-assert_contains "$out" '"permissionDecision":"deny"' "with no managed scope, every registered repo is guarded (status quo)"
-cleanup_ws
+# ---- #693: per-repo protected_branches is authoritative -------------------------
+# repos.protected_branches (resolved by git-root path) WINS; the global
+# plugin_config.protected_branches is a fallback used ONLY when the row's column
+# is empty/NULL.
+
+setup_perrepo_protected() {
+  # $1 = repos.protected_branches JSON (may be empty to test the global fallback).
+  local repo_protected="$1"
+  local dir
+  dir=$(mktemp -d -t tmb-guards-perrepo-XXXX)
+  (
+    cd "$dir" || exit 1
+    git init -q -b release
+    git config user.email t@t.t
+    git config user.name T
+    echo init > README.md
+    git add . && git commit -qm init
+    mkdir -p .claude/tmb
+    sqlite3 .claude/tmb/trajectory.db < "$PLUGIN_ROOT/mcp/trajectory-server/src/schema.sql" >/dev/null
+    # Global protected_branches is ["main"] (schema default) — does NOT cover
+    # the current branch `release`. The per-repo value, when set, must win.
+    local root
+    root=$(git rev-parse --show-toplevel)
+    if [ -n "$repo_protected" ]; then
+      sqlite3 .claude/tmb/trajectory.db \
+        "INSERT INTO repos (name, path, protected_branches) VALUES ('fixture', '$root', '$repo_protected');" >/dev/null
+    else
+      sqlite3 .claude/tmb/trajectory.db \
+        "INSERT INTO repos (name, path) VALUES ('fixture', '$root');" >/dev/null
+    fi
+  )
+  REPO_PATH="$dir"
+}
+
+test_case "#693: per-repo protected_branches wins — commit on per-repo-protected 'release' blocks"
+setup_perrepo_protected '[\"release\"]'
+out=$(run_hook_in_repo "git commit -m broken")
+assert_contains "$out" '"permissionDecision":"deny"' "per-repo protected_branches=[release] must block commit on release"
+cleanup_repo
+
+test_case "#693: per-repo unset → global protected_branches fallback (release NOT in global [main], commit allowed)"
+setup_perrepo_protected ''
+out=$(run_hook_in_repo "git commit -m wip")
+assert_not_contains "$out" '"permissionDecision":"deny"' "with per-repo empty, global [main] does not cover release → no block"
+cleanup_repo
 
 summarize

--- a/tests/l3-integration/hooks/no-source-edit-from-main.test.sh
+++ b/tests/l3-integration/hooks/no-source-edit-from-main.test.sh
@@ -347,52 +347,56 @@ out=$(run_hook "$(input_with_agent 'Edit' 'src/foo.ts' 'bro')")
 assert_not_contains "$out" 'bashrc' "deny message must not mention bashrc"
 assert_contains "$out" 'non-isolated' "deny message mentions non-isolated mode"
 
-# ---- Managed-repo scope (#592): multi-repo workspace ----
-# The hook resolves the managed root from repos.path (path-keyed), so build a
-# repos row whose path is the managed repo's absolute location. tmb_default_repo
-# carries the repo NAME; repos.path carries the canonical absolute path.
+# ---- Managed-repo scope by REGISTRATION (#693): multi-repo workspace ----
+# Rule 1 now scopes by REGISTRATION: an absolute target is guarded iff its
+# git-root resolves to a `repos` row (matched by path). Build two REAL git repos
+# under the workspace — register only the managed one; the sibling is an
+# unregistered tree whose source edits are outside Rule 1 scope.
 WS_ROOT="$TMPDIR/ws"
-MANAGED_DB="$WS_ROOT/.claude/tmb/trajectory.db"
+MANAGED_REPO="$WS_ROOT/plugin"
+SIBLING_REPO="$WS_ROOT/benchmarks"
 mkdir -p "$WS_ROOT/.claude/tmb"
+git init -q -b main "$MANAGED_REPO"
+mkdir -p "$MANAGED_REPO/src"
+git init -q -b main "$SIBLING_REPO"
+mkdir -p "$SIBLING_REPO/src"
+MANAGED_ROOT=$(git -C "$MANAGED_REPO" rev-parse --show-toplevel)
+SIBLING_ROOT=$(git -C "$SIBLING_REPO" rev-parse --show-toplevel)
+
+MANAGED_DB="$WS_ROOT/.claude/tmb/trajectory.db"
 sqlite3 "$MANAGED_DB" "CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT);"
-sqlite3 "$MANAGED_DB" "INSERT INTO plugin_config (key, value_json) VALUES ('tmb_default_repo', '\"plugin\"');"
 sqlite3 "$MANAGED_DB" "CREATE TABLE repos(name TEXT PRIMARY KEY, path TEXT NOT NULL, file_count INTEGER NOT NULL DEFAULT 0, last_scanned_at TEXT NOT NULL DEFAULT (datetime('now')), target_branch TEXT, branching_model TEXT, protected_branches TEXT);"
-sqlite3 "$MANAGED_DB" "INSERT INTO repos (name, path) VALUES ('plugin', '$WS_ROOT/plugin');"
+sqlite3 "$MANAGED_DB" "INSERT INTO repos (name, path) VALUES ('plugin', '$MANAGED_ROOT');"
 
 run_hook_db() {
   echo "$2" | env TRAJECTORY_DB_PATH="$1" bash "$HOOK" 2>&1 || true
 }
 
-test_case "managed repo scope + edit inside managed repo from main: BLOCK"
-out=$(run_hook_db "$MANAGED_DB" "$(input 'Edit' "$WS_ROOT/plugin/src/foo.ts" "$TRANSCRIPT_BRO")")
-assert_contains "$out" '"permissionDecision":"deny"' "source edit inside the managed repo still denied from main"
+test_case "registration scope + edit inside REGISTERED repo from main: BLOCK"
+out=$(run_hook_db "$MANAGED_DB" "$(input 'Edit' "$MANAGED_ROOT/src/foo.ts" "$TRANSCRIPT_BRO")")
+assert_contains "$out" '"permissionDecision":"deny"' "source edit inside the registered repo still denied from main"
 
-test_case "managed repo scope + edit in sibling repo from main: ALLOWED"
-out=$(run_hook_db "$MANAGED_DB" "$(input 'Edit' "$WS_ROOT/benchmarks/src/foo.ts" "$TRANSCRIPT_BRO")")
-assert_eq "" "$out" "sibling-repo source edit allowed — outside managed-repo scope"
+test_case "registration scope + edit in UNREGISTERED sibling repo from main: ALLOWED (no-op)"
+out=$(run_hook_db "$MANAGED_DB" "$(input 'Edit' "$SIBLING_ROOT/src/foo.ts" "$TRANSCRIPT_BRO")")
+assert_eq "" "$out" "unregistered sibling-repo source edit allowed — outside Rule 1 scope"
 
-test_case "single-repo project (empty tmb_default_repo) + src/foo.ts: BLOCK (whole tree guarded)"
-SINGLE_DB="$TMPDIR/single.db"
-sqlite3 "$SINGLE_DB" "CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT);"
-out=$(run_hook_db "$SINGLE_DB" "$(input 'Edit' '/some/project/src/foo.ts' "$TRANSCRIPT_BRO")")
-assert_contains "$out" '"permissionDecision":"deny"' "empty tmb_default_repo guards the whole tree as before"
+test_case "registration scope + target with no resolvable git-root: BLOCK (fail-closed)"
+out=$(run_hook_db "$MANAGED_DB" "$(input 'Edit' '/some/project/src/foo.ts' "$TRANSCRIPT_BRO")")
+assert_contains "$out" '"permissionDecision":"deny"' "target outside any git tree fails closed (guarded)"
 
-# ---- Single-repo-at-root: the git repo IS the workspace root ----
-# repos.path == workspace root, so the managed root resolves to the workspace
-# itself and source under it must be guarded. The old string-join (workspace +
-# name) computed one level too deep and leaked $WS/src/* as a "sibling" — this
-# is the regression the path-keyed lookup closes.
+test_case "single-repo-at-root: the git repo IS the registered root + src/foo.ts: BLOCK"
+# repos.path == the repo root, so the target's git-root resolves to a registered
+# row and source under it is guarded (the whole tree, since the lone repo is the
+# root). This is the single-repo project case.
 SR_ROOT="$TMPDIR/repo-at-root"
+mkdir -p "$SR_ROOT/.claude/tmb" "$SR_ROOT/src"
+git init -q -b main "$SR_ROOT"
+SR_REAL=$(git -C "$SR_ROOT" rev-parse --show-toplevel)
 SR_DB="$SR_ROOT/.claude/tmb/trajectory.db"
-mkdir -p "$SR_ROOT/.claude/tmb"
-SR_NAME=$(basename "$SR_ROOT")
 sqlite3 "$SR_DB" "CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT);"
-sqlite3 "$SR_DB" "INSERT INTO plugin_config (key, value_json) VALUES ('tmb_default_repo', '\"$SR_NAME\"');"
 sqlite3 "$SR_DB" "CREATE TABLE repos(name TEXT PRIMARY KEY, path TEXT NOT NULL, file_count INTEGER NOT NULL DEFAULT 0, last_scanned_at TEXT NOT NULL DEFAULT (datetime('now')), target_branch TEXT, branching_model TEXT, protected_branches TEXT);"
-sqlite3 "$SR_DB" "INSERT INTO repos (name, path) VALUES ('$SR_NAME', '$SR_ROOT');"
-
-test_case "single-repo-at-root + src/foo.ts from main as bro: BLOCK (regression)"
-out=$(run_hook_db "$SR_DB" "$(input_with_agent 'Edit' "$SR_ROOT/src/foo.ts" 'bro')")
-assert_contains "$out" '"permissionDecision":"deny"' "source under the single repo-at-root is guarded, not leaked as a sibling"
+sqlite3 "$SR_DB" "INSERT INTO repos (name, path) VALUES ('$(basename "$SR_REAL")', '$SR_REAL');"
+out=$(run_hook_db "$SR_DB" "$(input_with_agent 'Edit' "$SR_REAL/src/foo.ts" 'bro')")
+assert_contains "$out" '"permissionDecision":"deny"' "source under the single registered repo-at-root is guarded"
 
 summarize

--- a/tests/l3-integration/hooks/require-feature-branch-active.test.sh
+++ b/tests/l3-integration/hooks/require-feature-branch-active.test.sh
@@ -138,7 +138,7 @@ out=$(
 assert_not_contains "$out" '"permissionDecision":"deny"' "bypass env var must suppress block even on mismatch"
 cleanup
 
-test_case "TMB workspace shape: tasks.repo=null + tmb_default_repo='plugin' + branch exists → passes"
+test_case "TMB workspace shape: tasks.repo=null + single-repo fallback (one registered repo) + branch exists → passes"
 WORKSPACE=$(mktemp -d -t tmb-workspace-XXXX)
 INNER_REPO="$WORKSPACE/plugin"
 mkdir -p "$INNER_REPO"
@@ -151,12 +151,12 @@ mkdir -p "$INNER_REPO"
   git add README.md
   git commit -qm "init"
 )
+INNER_ROOT=$(git -C "$INNER_REPO" rev-parse --show-toplevel)
 WS_DB="$WORKSPACE/.claude/tmb/trajectory.db"
 mkdir -p "$(dirname "$WS_DB")"
 sqlite3 "$WS_DB" < "$PLUGIN_ROOT/mcp/trajectory-server/src/schema.sql" >/dev/null
 sqlite3 "$WS_DB" "
-  INSERT OR REPLACE INTO plugin_config (key, value_json)
-    VALUES ('tmb_default_repo', '\"plugin\"');
+  INSERT INTO repos (name, path) VALUES ('plugin', '$INNER_ROOT');
   INSERT OR IGNORE INTO issues (id, objective, description, status, created_at, updated_at)
     VALUES (1, 'test', 'test', 'open', datetime('now'), datetime('now'));
   INSERT INTO tasks (id, issue_id, branch_id, title, description, status, spec_body, repo, created_at, updated_at)
@@ -165,14 +165,15 @@ sqlite3 "$WS_DB" "
 REPO_PATH="$INNER_REPO"
 payload=$(make_payload "swe" "task_id=10 You are SWE.")
 out=$(run_hook "$payload" "$WS_DB")
-assert_not_contains "$out" '"permissionDecision":"deny"' "TMB workspace shape with default_repo set + branch exists must not block"
+assert_not_contains "$out" '"permissionDecision":"deny"' "single-repo fallback + branch exists must not block"
 rm -rf "$WORKSPACE"
 REPO_PATH=""
 
-test_case "TMB workspace shape: tasks.repo=null + tmb_default_repo unset → blocks with clear error"
+test_case "TMB workspace shape: tasks.repo=null + no single-repo fallback (two repos) + no .git at workspace root → blocks with clear error"
 WORKSPACE=$(mktemp -d -t tmb-workspace-XXXX)
 INNER_REPO="$WORKSPACE/plugin"
-mkdir -p "$INNER_REPO"
+SIBLING_REPO="$WORKSPACE/sibling"
+mkdir -p "$INNER_REPO" "$SIBLING_REPO"
 (
   cd "$INNER_REPO" || exit 1
   git init -q -b "fix/1-foo"
@@ -182,10 +183,23 @@ mkdir -p "$INNER_REPO"
   git add README.md
   git commit -qm "init"
 )
+(
+  cd "$SIBLING_REPO" || exit 1
+  git init -q -b main
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  echo "init" > README.md
+  git add README.md
+  git commit -qm "init"
+)
+INNER_ROOT=$(git -C "$INNER_REPO" rev-parse --show-toplevel)
+SIBLING_ROOT=$(git -C "$SIBLING_REPO" rev-parse --show-toplevel)
 WS_DB="$WORKSPACE/.claude/tmb/trajectory.db"
 mkdir -p "$(dirname "$WS_DB")"
 sqlite3 "$WS_DB" < "$PLUGIN_ROOT/mcp/trajectory-server/src/schema.sql" >/dev/null
 sqlite3 "$WS_DB" "
+  INSERT INTO repos (name, path) VALUES ('plugin', '$INNER_ROOT');
+  INSERT INTO repos (name, path) VALUES ('sibling', '$SIBLING_ROOT');
   INSERT OR IGNORE INTO issues (id, objective, description, status, created_at, updated_at)
     VALUES (1, 'test', 'test', 'open', datetime('now'), datetime('now'));
   INSERT INTO tasks (id, issue_id, branch_id, title, description, status, spec_body, repo, created_at, updated_at)
@@ -194,9 +208,10 @@ sqlite3 "$WS_DB" "
 REPO_PATH="$WORKSPACE"
 payload=$(make_payload "swe" "task_id=11 You are SWE.")
 out=$(run_hook "$payload" "$WS_DB")
-assert_contains "$out" '"permissionDecision":"deny"' "TMB workspace with no default_repo and no .git at workspace root must block"
-assert_contains "$out" "tmb_default_repo" "block message must mention tmb_default_repo config key"
-assert_contains "$out" "config_set" "block message must suggest config_set remedy"
+assert_contains "$out" '"permissionDecision":"deny"' "multi-repo with no task.repo and no .git at workspace root must block"
+assert_contains "$out" "tasks.repo IS NULL" "block message must explain the unresolved-repo cause"
+assert_contains "$out" "task_create repo" "block message must suggest setting the task's repo"
+assert_not_contains "$out" "tmb_default_repo" "block message must NOT mention the retired tmb_default_repo key"
 rm -rf "$WORKSPACE"
 REPO_PATH=""
 

--- a/tests/l3-integration/hooks/worktree-create.test.sh
+++ b/tests/l3-integration/hooks/worktree-create.test.sh
@@ -31,6 +31,7 @@ echo init > README.md && git add . && git commit -qm init
 
 DB="$WORKSPACE/.claude/tmb/trajectory.db"
 mkdir -p "$(dirname "$DB")"
+INNER_ROOT=$(git -C "$INNER_REPO" rev-parse --show-toplevel)
 sqlite3 "$DB" "
   CREATE TABLE tasks (
     id INTEGER PRIMARY KEY,
@@ -42,6 +43,12 @@ sqlite3 "$DB" "
     key TEXT PRIMARY KEY,
     value_json TEXT NOT NULL
   );
+  CREATE TABLE repos (
+    name TEXT PRIMARY KEY,
+    path TEXT NOT NULL,
+    protected_branches TEXT
+  );
+  INSERT INTO repos (name, path) VALUES ('inner', '$INNER_ROOT');
   INSERT INTO tasks (id, branch_id, status, repo)
     VALUES (1, 'fix/123-with-repo', 'pending', 'inner');
   INSERT INTO tasks (id, branch_id, status, repo)
@@ -86,19 +93,29 @@ esac
 assert_not_contains "$stdout_only" '"continue"' "stdout must not contain JSON"
 assert_not_contains "$stdout_only" 'tmb worktree-create' "informational text must be on stderr"
 
-test_case "no-match + no default repo + workspace not git: exit non-zero with stderr reason"
-# feat/888-unknown not in tasks; workspace root is not a git repo; no tmb_default_repo
+# A second registered repo so the single-repo fallback is NOT silently in play
+# for the no-match / NULL-repo cases — they must resolve to the workspace root
+# (which is not a git repo) and fail loudly, proving no name-keyed default is used.
+SIBLING_REPO="$WORKSPACE/sibling"
+mkdir -p "$SIBLING_REPO"
+git init -q -b main "$SIBLING_REPO"
+git -C "$SIBLING_REPO" config user.email t@t.io && git -C "$SIBLING_REPO" config user.name t
+echo init > "$SIBLING_REPO/README.md"
+git -C "$SIBLING_REPO" add . && git -C "$SIBLING_REPO" commit -qm init
+SIBLING_ROOT=$(git -C "$SIBLING_REPO" rev-parse --show-toplevel)
+
+test_case "no-match + multi-repo (no single-repo fallback) + workspace not git: exit non-zero with stderr reason"
+# feat/888-unknown not in tasks; two repos registered → no single-repo fallback;
+# workspace root is not a git repo → loud failure.
+sqlite3 "$DB" "INSERT INTO repos (name, path) VALUES ('sibling', '$SIBLING_ROOT');"
 no_match_exit=0
 echo "$(input_event 'feat/888-unknown')" | TRAJECTORY_DB_PATH="$DB" bash "$HOOK" 2>/dev/null || no_match_exit=$?
 if [ "$no_match_exit" -ne 0 ]; then _pass; else _fail "expected non-zero when workspace root is not a git repo"; fi
 no_match_stderr=$(run_hook_stderr "$(input_event 'feat/888-unknown')")
 assert_contains "$no_match_stderr" 'not a git work tree' "stderr explains why creation failed"
+sqlite3 "$DB" "DELETE FROM repos WHERE name='sibling';"
 
-test_case "no-match with tmb_default_repo set: worktree created, bare path on stdout"
-sqlite3 "$DB" "
-  INSERT OR REPLACE INTO plugin_config (key, value_json)
-    VALUES ('tmb_default_repo', '\"inner\"');
-"
+test_case "no-match + single-repo fallback (one registered repo): worktree created, bare path on stdout"
 git -C "$INNER_REPO" branch feat/777-nomatch HEAD 2>/dev/null || true
 no_match_path=$(echo "$(input_event 'feat/777-nomatch')" | bash "$HOOK" 2>/dev/null)
 case "$no_match_path" in
@@ -108,13 +125,8 @@ esac
 assert_contains "$no_match_path" '777-nomatch' "path contains slug"
 NOMATCH_WT="$WORKSPACE/.claude/worktrees/777-nomatch"
 if [ -d "$NOMATCH_WT" ]; then _pass; else _fail "worktree not created at $NOMATCH_WT"; fi
-sqlite3 "$DB" "DELETE FROM plugin_config WHERE key='tmb_default_repo';"
 
-test_case "no-match with tmb_default_repo set: branch auto-created when missing"
-sqlite3 "$DB" "
-  INSERT OR REPLACE INTO plugin_config (key, value_json)
-    VALUES ('tmb_default_repo', '\"inner\"');
-"
+test_case "no-match + single-repo fallback: branch auto-created when missing"
 # feat/666-autocreate does not exist as a branch in inner repo
 autocreate_path=$(echo "$(input_event 'feat/666-autocreate')" | bash "$HOOK" 2>/dev/null)
 case "$autocreate_path" in
@@ -128,20 +140,17 @@ if git -C "$INNER_REPO" show-ref --verify --quiet "refs/heads/feat/666-autocreat
 else
   _fail "branch feat/666-autocreate not auto-created"
 fi
-sqlite3 "$DB" "DELETE FROM plugin_config WHERE key='tmb_default_repo';"
 
-test_case "repo=NULL, no tmb_default_repo, workspace root is not a git repo: exit 1 with clear error"
+test_case "repo=NULL + multi-repo (no single-repo fallback) + workspace not git: exit 1 with clear error"
+sqlite3 "$DB" "INSERT INTO repos (name, path) VALUES ('sibling', '$SIBLING_ROOT');"
 null_repo_exit=0
 echo "$(input_event 'feat/456-no-repo')" | TRAJECTORY_DB_PATH="$DB" bash "$HOOK" 2>/dev/null || null_repo_exit=$?
 if [ "$null_repo_exit" -ne 0 ]; then _pass; else _fail "expected non-zero exit"; fi
 null_repo_stderr=$(run_hook_stderr "$(input_event 'feat/456-no-repo')")
 assert_contains "$null_repo_stderr" 'not a git work tree' "unroutable null repo → loud error"
+sqlite3 "$DB" "DELETE FROM repos WHERE name='sibling';"
 
-test_case "repo=NULL, tmb_default_repo set: worktree created in default repo, bare path on stdout"
-sqlite3 "$DB" "
-  INSERT OR REPLACE INTO plugin_config (key, value_json)
-    VALUES ('tmb_default_repo', '\"inner\"');
-"
+test_case "repo=NULL + single-repo fallback: worktree created in the sole repo, bare path on stdout"
 git -C "$INNER_REPO" branch feat/456-no-repo HEAD 2>/dev/null || true
 no_repo_path=$(echo "$(input_event 'feat/456-no-repo')" | bash "$HOOK" 2>/dev/null)
 case "$no_repo_path" in
@@ -150,7 +159,6 @@ case "$no_repo_path" in
 esac
 assert_contains "$no_repo_path" '456-no-repo' "path contains slug"
 if [ -d "$WORKSPACE/.claude/worktrees/456-no-repo" ]; then _pass; else _fail "worktree not created"; fi
-sqlite3 "$DB" "DELETE FROM plugin_config WHERE key='tmb_default_repo';"
 
 test_case "branch matching task with repo set: stdout is bare absolute path"
 task_path=$(echo "$(input_event 'fix/123-with-repo')" | bash "$HOOK" 2>/dev/null)
@@ -212,8 +220,11 @@ echo init > "$SINGLE/README.md"
 git -C "$SINGLE" add . && git -C "$SINGLE" commit -qm init
 SDB="$SINGLE/.claude/tmb/trajectory.db"
 mkdir -p "$(dirname "$SDB")"
+SINGLE_ROOT=$(git -C "$SINGLE" rev-parse --show-toplevel)
 sqlite3 "$SDB" "
   CREATE TABLE tasks (id INTEGER PRIMARY KEY, branch_id TEXT NOT NULL, status TEXT, repo TEXT);
+  CREATE TABLE repos (name TEXT PRIMARY KEY, path TEXT NOT NULL, protected_branches TEXT);
+  INSERT INTO repos (name, path) VALUES ('single', '$SINGLE_ROOT');
   INSERT INTO tasks (id, branch_id, status, repo) VALUES (1, 'fix/789-single', 'pending', NULL);
 "
 git -C "$SINGLE" branch fix/789-single HEAD
@@ -254,6 +265,7 @@ git -C "$MR_REPO" add . && git -C "$MR_REPO" commit -qm init
 
 MR_DB="$MR_WORKSPACE/.claude/tmb/trajectory.db"
 mkdir -p "$(dirname "$MR_DB")"
+MR_REPO_ROOT=$(git -C "$MR_REPO" rev-parse --show-toplevel)
 sqlite3 "$MR_DB" "
   CREATE TABLE tasks (
     id INTEGER PRIMARY KEY,
@@ -265,6 +277,8 @@ sqlite3 "$MR_DB" "
     key TEXT PRIMARY KEY,
     value_json TEXT NOT NULL
   );
+  CREATE TABLE repos (name TEXT PRIMARY KEY, path TEXT NOT NULL, protected_branches TEXT);
+  INSERT INTO repos (name, path) VALUES ('plugin', '$MR_REPO_ROOT');
   INSERT INTO tasks (id, branch_id, status, repo)
     VALUES (10, 'fix/330-subdir', 'pending', 'plugin');
 "


### PR DESCRIPTION
Task B (hooks) of the path-keyed repo-resolution refactor (ADR on #81). Closes GH #693. Retires tmb_default_repo from the 5 git-guard hooks; git-guards scope by REGISTRATION (cwd git-root → repos row), per-repo protected_branches authoritative (global fallback); worktree/branch/cleanup resolve via task.repo→repos.path + single-repo fallback. Fails closed (verified). L3: git-guards 100/100 + all 60 hook test files green. pr-reviewer PASS (validation #176). Pairs with Task A (#692) + Task C.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)