### PR TITLE
📝 docs(repo-resolution): REPO_RESOLUTION.md ADR + path-keyed updates across docs + L5/L6 row 33 (#692)

### DIFF
--- a/docs/architecture/FLOWS.md
+++ b/docs/architecture/FLOWS.md
@@ -20,7 +20,7 @@ All consultants (architect, cto, ceo, pm, project-local) advise but never write 
 | 8 | SWE retry / escalation | Bro verification or pr-reviewer verdict='fail' | bro ↔ swe (↔ pr-reviewer at push) | `validation_attempts` (multiple), `discussions` | `task_retry_batch` composite |
 | 9 | Roundtable | Multi-consultant deliberation with AUQ ratification | bro orchestrates 2–4 consultants | `roundtables`, `roundtable_votes`, `discussions`, `audit` | `roundtable-auq-shape`, `roundtable-cleanup-postcheck` |
 | 13 | Bulk cleanup | Human pre-authorizes a bulk delete | bro (direct Bash, no SWE spawn) | — | — |
-| 33 | Multi-repo path discipline | `tmb_default_repo` set; bro indexes inner repo | bro | kuzu Directory nodes (repo-relative paths; `repo` property scopes to the right inner git repo) | — |
+| 33 | Multi-repo path discipline | Inner repos registered in `repos`; bro indexes them | bro | kuzu Directory nodes (repo-relative paths; `repo` property scopes to the right inner git repo) | — |
 | **C** | Consultant invocation | Human asks for second opinion | bro → consultant | `discussions(kind='analysis'/'concern')` | — |
 | **M** | Monitor PR comments | `/monitor <PR_number>` (invokes `tmb_review` §C) | bro → pr-reviewer per actionable comment batch | `pr_review_runs`, `issues`, `tasks`, `audit` | — |
 
@@ -235,11 +235,11 @@ When the Human's prompt names what to delete (branches, temp files, etc.), bro e
 
 ## 33. Multi-repo path discipline
 
-When a workspace has multiple inner git repos (siblings or submodules), `tmb_default_repo` config or per-task `tasks.repo` names the active inner repo. Directory node `path` properties are stored repo-relative — `scan_run` does NOT prepend the inner repo directory when writing nodes.
+When a workspace has multiple inner git repos (siblings or submodules), each is identified by its `repos` row (path-keyed resolution; an operation matches its path against `repos.path`, or a task names its repo via `tasks.repo`). Directory node `path` properties are stored repo-relative — `scan_run` does NOT prepend the inner repo directory when writing nodes. See [`REPO_RESOLUTION.md`](./REPO_RESOLUTION.md).
 
 The L5 row `tests/l5-l6/rows/33-multirepo-commit/` catches regressions at the storage layer: a Cypher `MATCH (d:Directory) WHERE d.path STARTS WITH 'api/' OR d.path STARTS WITH 'app/'` returns ≥1 node only on a workspace-rooted path leak.
 
-`tmb_default_repo` also scopes the `no-source-edit-from-main.sh` guard: Rule 1 only protects the managed-repo subtree, so absolute edits to sibling repos are allowed (an empty/`.` default guards the whole tree). See `docs/architecture/RESPONSIBILITIES.md` (#592).
+Registration also scopes the `no-source-edit-from-main.sh` guard: Rule 1 only protects registered repo subtrees, so absolute edits to unregistered sibling repos are allowed. See `docs/architecture/RESPONSIBILITIES.md` (#592).
 
 ---
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -8,6 +8,7 @@ Design rationale for how the TMB plugin is built — the schema, the workflow ga
 | [`FLOWS.md`](./FLOWS.md) | The Human → bro → SWE decision chain and the two gates (bro = task gate, pr-reviewer = push gate) |
 | [`RESPONSIBILITIES.md`](./RESPONSIBILITIES.md) | The role × tool matrix — what each shipped agent is actually instructed to do, plus server-enforced boundaries |
 | [`GIT.md`](./GIT.md) | Where each actor's git state lives across a task lifecycle; the local-is-canonical invariant |
+| [`REPO_RESOLUTION.md`](./REPO_RESOLUTION.md) | Path-keyed repo resolution — how an operation's path identifies its repo via the `repos` table; registration-based guard scoping; per-repo `protected_branches` |
 | [`WORLD_MODEL.md`](./WORLD_MODEL.md) | The kuzu world-model graph — bro's queryable project map, built by `scan_run` |
 | [`TYPED_RAILS.md`](./TYPED_RAILS.md) | Promoting enforced fields (`files`, `verification`) from markdown to typed schema columns |
 | [`CHEATCODES.md`](./CHEATCODES.md) | The discover → vet → install → hot-load pipeline for acquiring skills, MCP toolkits, and plugins on demand |

--- a/docs/architecture/REPO_RESOLUTION.md
+++ b/docs/architecture/REPO_RESOLUTION.md
@@ -1,0 +1,38 @@
+# Repo Resolution (path-keyed)
+
+How TMB answers "which repo does this operation belong to" in a single- or multi-repo workspace. Resolution is **path-keyed**: an operation's path identifies its repo against the `repos` table — there is no global default-repo name.
+
+## Context
+
+A workspace can hold more than one inner git repo (siblings or submodules) under one trajectory DB. Each discovered repo gets a `repos` row (written by `/scan`), keyed by `name` with an authoritative `path`. The canonical resolvers — `mcp/utils/repo-paths.ts` and `scripts/hooks/lib/resolve-repo.sh` — both resolve by `repos.path` / cwd git-root.
+
+A name-keyed global default forced one repo to be "the" repo and made the git guards string-join `<workspace>/<name>` to decide what to enforce on. That breaks the moment a second repo enters the workspace, and it duplicates state the `repos` table already holds path-first.
+
+## Decision
+
+1. **Resolution is path-keyed.** "Which repo does this operation belong to" = match the operation's path — the cwd git-root for a hook, or `tasks.repo` for a task — against `repos.path`. There is no global default-repo name.
+
+2. **Repos are identified by registration.** A repo participates in TMB resolution iff it has a `repos` row (matched by path). `/scan` records the row; unregistered sibling trees are invisible to resolution.
+
+3. **git-guard scoping is registration-based.** A git op is enforced iff its git-root resolves to a registered `repos` row. When the command's git-root is an unregistered sibling tree, the guards no-op — they never enforce on a tree TMB doesn't manage. For a single-repo user project the sole repo *is* the registered root, so the whole tree is guarded as before.
+
+4. **`protected_branches` is per-repo authoritative.** `repos.protected_branches` (resolved path-keyed) wins. The global `plugin_config.protected_branches` is a fallback used only when the matched repo row carries no per-repo value.
+
+5. **Single-repo fallback.** When exactly one repo is registered, resolution defaults to it. This keeps single-repo projects (the common case) working without any per-operation repo argument.
+
+6. **Read-tolerant migration.** No data migration is needed. Existing projects keep working: a single registered repo resolves via the single-repo fallback, and a multi-repo workspace resolves each operation by its path.
+
+## The resolution contract
+
+Implementers (MCP source and hooks) agree on one shape:
+
+- **Canonical resolver** — `resolveDefaultRepoPath(db)` returns the path of the sole registered repo (single-repo fallback), else `null`. A caller that needs a *specific* repo passes `tasks.repo` or the cwd git-root and resolves it against `repos.path`.
+- **Hooks** resolve the acting repo from the command's git-root → `repos` row. Absent a matching row, they apply the single-repo fallback; if that doesn't resolve either, they no-op rather than enforce on an unregistered tree.
+- **`scripts/hooks/lib/resolve-repo.sh`** is the shell side of this contract: `tmb_repo_git_root` (cwd → main worktree root), `tmb_repo_is_registered`, `tmb_repo_resolve` (per-repo `target_branch|branching_model|protected_branches`), `tmb_repo_single_path` (single-repo fallback), and `tmb_repo_resolve_path` (by name, falling back to single-repo).
+
+## Consequences
+
+- **Multi-repo workspaces work without ceremony.** Each operation resolves to its own repo by path; sibling repos coexist without one being privileged.
+- **Guards never fire on unmanaged trees.** Editing or committing in an unregistered sibling repo is allowed — TMB only enforces on trees it registered.
+- **Per-repo branch policy.** Each repo carries its own `target_branch`, `branching_model`, and `protected_branches`; the global config is a fallback, not the source of truth.
+- **`/scan` is the registration point.** A repo must be scanned to participate; this is the same step that warms the world model, so the two stay aligned.

--- a/docs/architecture/RESPONSIBILITIES.md
+++ b/docs/architecture/RESPONSIBILITIES.md
@@ -76,7 +76,7 @@ Bro is the only agent allowed to call:
 | `activation-routine.sh` | UserPromptSubmit | Inject onboarded marker + pending issue as context |
 | `session-start-prescan.sh` | SessionStart | Inject project inventory (git state, stacks, world-model warmth); emit the active `Plugin version:` line, plus a "restart to apply" note when a newer version sits in the marketplace cache (#602) |
 | `ensure-gitignore.sh` | SessionStart | Ensure `.claude/` is gitignored |
-| `no-source-edit-from-main.sh` | PreToolUse Edit/Write | Deny bro source edits outside SWE worktree, scoped to the managed repo: Rule 1 only guards the `tmb_default_repo` subtree, so absolute edits to sibling repos in a multi-repo workspace are allowed; an empty or `.` `tmb_default_repo` guards the whole tree (#592) |
+| `no-source-edit-from-main.sh` | PreToolUse Edit/Write | Deny bro source edits outside SWE worktree, scoped by registration: Rule 1 only guards registered repo subtrees (a `repos` row matched by path), so absolute edits to unregistered sibling repos in a multi-repo workspace are allowed (#592) |
 | `no-worktree-branch-create.sh` | PreToolUse Bash | Deny `git worktree add -b/-B/--detach` (branch authority is bro's pre-creation; attached worktrees only) |
 | `branch-up-to-date-with-remote.sh` | PreToolUse Bash | Deny worktree-add to a branch behind `origin/<pr_target>` |
 | `cleanup-worktree-on-task-close.sh` | PostToolUse `task_update_status` | Remove worktree after bro closes task |
@@ -84,7 +84,7 @@ Bro is the only agent allowed to call:
 
 ### Universal rules
 
-- **Bro never edits source code** — every code change goes through SWE (Layer 2 hook enforces). The guard is scoped to the managed repo (`tmb_default_repo`): sibling repos in a multi-repo workspace are outside Rule 1's scope, while an empty/`.` default guards the whole tree (#592).
+- **Bro never edits source code** — every code change goes through SWE (Layer 2 hook enforces). The guard is scoped by registration: a code edit is guarded only when its path resolves to a registered `repos` row, so unregistered sibling repos in a multi-repo workspace are outside Rule 1's scope (#592). See [`REPO_RESOLUTION.md`](./REPO_RESOLUTION.md).
 - **Voice**: relaxed tone, action-first, no padding.
 
 ---

--- a/docs/prompt-engineering/DETERMINISM.md
+++ b/docs/prompt-engineering/DETERMINISM.md
@@ -12,7 +12,7 @@ Skills, CLAUDE.md, and agent files are reserved for the irreducibly judgment-bou
 
 | # | Mechanism | What it does | Right shape for |
 |---|---|---|---|
-| 1 | **Server-side defaults** | LLM omits an arg; server fills it from policy state | Per-arg defaults: `parent_branch_id` ← `config('pr_target')`; `repo` ← `config('tmb_default_repo')` |
+| 1 | **Server-side defaults** | LLM omits an arg; server fills it from policy state | Per-arg defaults: `parent_branch_id` ← `config('pr_target')`; `repo` ← the sole registered repo (single-repo fallback; see [`REPO_RESOLUTION.md`](../architecture/REPO_RESOLUTION.md)) |
 | 2 | **Atomic composite tools** | Multi-step workflow wrapped into one MCP call inside one DB transaction | Multi-step batches that the LLM today emits as N separate calls and frequently drops the last one |
 | 3 | **PreToolUse hooks (block)** | LLM cannot proceed without prerequisite; hook returns `decision: block` | "Don't run X without Y first" — e.g. push-gate, no-source-edit-from-main, require-task-spec, require-feature-branch-active |
 | 4 | **PostToolUse hooks (side-effect)** | After a tool call, auto-emit follow-up events or queue downstream work | Auto-derived audit events, cleanup-worktree-on-task-close, write-active-workspace-sentinel |

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -11,7 +11,7 @@ The Claude Code lifecycle hook engine — the deterministic enforcement layer th
 `activation-routine.sh`, `mcp-health-check.sh`, `session-log-capture.sh`, `prompt-intent-hints.sh`, `roundtable-slash-detect.sh` — inject identity/context, log the turn, and route phrasing hints (onboarding nudges, roundtable detection).
 
 ### PreToolUse — gates (deny on violation)
-Git: `git-guards.sh`, `git-push-guard.sh`, `no-remote-auth-guard.sh`, `stay-on-base-guard.sh`, `no-source-edit-from-main.sh`, `no-worktree-branch-create.sh`, `branch-up-to-date-with-remote.sh`, `commit-msg-lint.sh`.
+Git: `git-guards.sh`, `git-push-guard.sh`, `no-remote-auth-guard.sh`, `stay-on-base-guard.sh`, `no-source-edit-from-main.sh`, `no-worktree-branch-create.sh`, `branch-up-to-date-with-remote.sh`, `commit-msg-lint.sh`. The git guards are **registration-scoped**: they resolve the command's cwd git-root to a `repos` row (via `lib/resolve-repo.sh`) and only enforce on a registered repo — unregistered sibling trees no-op. `protected_branches` is read per-repo (`repos.protected_branches`) with the global `plugin_config` value as fallback. See [`docs/architecture/REPO_RESOLUTION.md`](../../docs/architecture/REPO_RESOLUTION.md).
 Agent dispatch: `agent-spawn-dispatch.sh`, `swe-brief-gate.sh`, `swe-verification-gate.sh`, `swe-boundary.sh`, `swe-scope-fence.sh`.
 AUQ / roundtable / cheatcode: `askuserquestion-length-lint.sh`, `auq-headless-deny.sh`, `roundtable-auq-shape.sh`, `cheatcode-install-approval.sh`.
 Lint: `naming-lint.sh`, `code-quality-lint.sh`, `debug-trajectory.sh`.

--- a/tests/l5-l6/rows/33-multirepo-commit/README.md
+++ b/tests/l5-l6/rows/33-multirepo-commit/README.md
@@ -1,39 +1,39 @@
 # 33-multirepo-commit
 
-**Flow under test:** path discipline in a multi-repo workspace — `tasks.repo` / `tmb_default_repo` consult + repo-relative indexing in the kuzu world model (graph DB per ADR 0002).
+**Flow under test:** path discipline in a multi-repo workspace — path-keyed repo resolution (each inner repo registered by path in the `repos` table; see [`docs/architecture/REPO_RESOLUTION.md`](../../../../docs/architecture/REPO_RESOLUTION.md)) + repo-relative indexing in the kuzu world model (graph DB per ADR 0002).
 
 **Pre-state**: `onboarding-named` fixture + workspace fixture with **two sibling inner git repos**, each with a top-level `README.md` so `/scan` produces author-curated dir summaries in the kuzu graph:
 
 ```
 PROJECT/
 ├── .claude/tmb/trajectory.db   ← workspace-rooted (MCP DB lives here)
-├── api/                         ← inner git repo (tmb_default_repo='api')
+├── api/                         ← inner git repo (registered in repos by path)
 │   ├── README.md
 │   ├── handler.py
 │   └── utils.py
-└── app/                         ← sibling repo
+└── app/                         ← sibling repo (also registered by path)
     ├── README.md
     └── src/index.ts
 ```
 
-`tmb_default_repo` is set to `"api"` via `setup-l5.sh`.
+Both inner repos are registered by path in the `repos` table via `setup-l5.sh` — `api` carries a per-repo `protected_branches=["main"]` (authoritative), `app` omits it (falls back to the global config).
 
 **Trigger**: `@bro this is a multi-repo workspace. Run /scan and confirm the world model has the api repo indexed correctly.`
 
 **Expected behavior**:
-1. Bro reads `tmb_default_repo` → `"api"`
-2. Runs `scan_run` which populates the kuzu graph with Directory nodes for both inner repos
+1. Each operation resolves to its repo by path against `repos.path` — no global default-repo name
+2. Bro runs `scan_run` which populates the kuzu graph with Directory nodes for both inner repos
 3. Repo-relative paths land as kuzu node keys (no `api/` or `app/` prefix)
 4. Each node's `repo` field correctly distinguishes which inner repo it belongs to
 
-**L5 mode**: `setup-l5.sh` builds the two sibling repos + configures `tmb_default_repo`.
+**L5 mode**: `setup-l5.sh` builds the two sibling repos + registers both by path in the `repos` table.
 **L6 mode**: standalone row, not in chain.
 
 ## Scorers
 
 | Scorer | What it asserts |
 |---|---|
-| `outcome.sql` | `repos` table has ≥1 row with `name='api'`; `deep_scan_completed` audit row exists |
+| `outcome.sql` | `repos` table has both inner repos registered by path (`api` + `app`); `deep_scan_completed` audit row exists |
 | `tools-required.json` | `scan_run` |
 | `tools-forbidden.json` | `task_create_batch`, `validation_record` |
 | `cost-budget.json` | 50K / 90s soft |

--- a/tests/l5-l6/rows/33-multirepo-commit/outcome.sql
+++ b/tests/l5-l6/rows/33-multirepo-commit/outcome.sql
@@ -1,6 +1,7 @@
 -- 33-multirepo-commit: assert path discipline in a multi-repo workspace.
 --
--- Setup: workspace has two inner repos, api/ and app/. tmb_default_repo='api'.
+-- Setup: workspace has two inner repos, api/ and app/, each registered by path
+-- in the `repos` table (path-keyed resolution — docs/architecture/REPO_RESOLUTION.md).
 -- Bro runs /scan which writes Directory nodes per-repo into the sibling kuzu
 -- graph DB (ADR 0002). The path-discipline contract — repo-relative paths,
 -- repo-scoped writes — is identical to the pre-graph-DB regime; only the
@@ -8,15 +9,16 @@
 --
 -- The kuzu node assertions (api dirs indexed; no workspace-rooted paths;
 -- no cross-repo leak) live in the L3 kuzu integration fixture (TBD
--- post-v0.7). Here the SQLite-side assertion verifies the per-repo `repos`
--- table is populated correctly (the deterministic precursor to the kuzu
--- writes), and the deep_scan_completed audit row exists.
+-- post-v0.7). Here the SQLite-side assertion verifies both inner repos are
+-- registered by path in the `repos` table (the registration that scopes
+-- resolution + the precursor to the kuzu writes), and the deep_scan_completed
+-- audit row exists.
 
 SELECT
-  CASE WHEN COUNT(*) >= 1 THEN 1 ELSE 0 END AS pass,
-  'api repo registered in repos table (got ' || COUNT(*) || ', expected >=1)' AS description
+  CASE WHEN COUNT(*) >= 2 THEN 1 ELSE 0 END AS pass,
+  'api + app repos registered by path in repos table (got ' || COUNT(*) || ', expected >=2)' AS description
 FROM repos
-WHERE name = 'api';
+WHERE name IN ('api', 'app') AND path IS NOT NULL AND path != '';
 
 SELECT
   CASE WHEN COUNT(*) >= 1 THEN 1 ELSE 0 END AS pass,

--- a/tests/l5-l6/rows/33-multirepo-commit/setup-l5.sh
+++ b/tests/l5-l6/rows/33-multirepo-commit/setup-l5.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # 33-multirepo-commit L5 isolation: builds the multi-repo workspace fixture.
-# Configures tmb_default_repo='api', creates api/ and app/ sibling git repos.
+# Creates api/ and app/ sibling git repos and registers both via the `repos`
+# table (path-keyed resolution — see docs/architecture/REPO_RESOLUTION.md).
 # README per inner repo lets scan_run populate the kuzu world model with
 # README-derived summaries when bro runs /scan.
 set -uo pipefail
@@ -8,9 +9,6 @@ set -uo pipefail
 PROJECT="$1"
 # shellcheck disable=SC2034
 SCENARIO_DIR="$2"
-
-sqlite3 "$PROJECT/.claude/tmb/trajectory.db" \
-  "INSERT OR REPLACE INTO plugin_config (key, value_json) VALUES ('tmb_default_repo', '\"api\"');"
 
 mkdir -p "$PROJECT/api"
 (
@@ -50,3 +48,15 @@ export const hello = () => 'world';
 TS
   git add . && git commit -qm "seed: app initial"
 ) >/dev/null
+
+# Register both inner repos by path (path-keyed resolution).
+# api carries a per-repo protected_branches value to exercise the per-repo
+# authoritative model; app omits it (falls back to the global config).
+API_PATH=$(cd "$PROJECT/api" && pwd -P)
+APP_PATH=$(cd "$PROJECT/app" && pwd -P)
+sqlite3 "$PROJECT/.claude/tmb/trajectory.db" <<SQL
+INSERT OR REPLACE INTO repos (name, path, protected_branches)
+VALUES ('api', '$API_PATH', '["main"]');
+INSERT OR REPLACE INTO repos (name, path)
+VALUES ('app', '$APP_PATH');
+SQL


### PR DESCRIPTION
Task C (docs) of the path-keyed repo-resolution refactor. New docs/architecture/REPO_RESOLUTION.md (the #81 ADR, linked from the architecture README); FLOWS/RESPONSIBILITIES/DETERMINISM + scripts/hooks/README refreshed to path-keyed/registration-based; L5/L6 33-multirepo row registers repos by path (no tmb_default_repo). grep-clean in the touched surface. pr-reviewer PASS (validation #177). Completes the refactor (Tasks A #855 + B #856).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)