### PR TITLE
🔒 feat(hooks): remote-id guard — block local issue ids in gh/glab remote-bound text, cite gh_iid (#798)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -122,6 +122,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/no-remote-auth-guard.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/remote-id-guard.sh",
+            "timeout": 5
           }
         ]
       },

--- a/scripts/hooks/remote-id-guard.sh
+++ b/scripts/hooks/remote-id-guard.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# PreToolUse hook — deny remote-bound text that cites a LOCAL trajectory issue
+# id instead of its REMOTE iid.
+#
+# bro writes LOCAL issue ids into REMOTE artifacts (PR bodies, gh issue close
+# comments). On the remote a bare `#N` resolves to the unrelated remote issue N.
+# This guard catches that: it scans author-supplied text on remote-write
+# commands for `#<n>` tokens, and denies when `<n>` is a local issue id whose
+# `gh_iid` (or `gl_iid`) differs — naming the correct remote ref.
+#
+# Acts ONLY on remote-WRITE commands carrying author text:
+#   gh   pr    create|edit
+#   gh   issue create|edit|comment|close
+#   glab mr    create|update
+#   glab issue create|update|note|close
+# and only when the command carries --body/--title/--comment/-b/-t/-m or a
+# heredoc body. Plain reads (gh pr list, gh issue view) → no-op.
+#
+# Fail-OPEN (allow) on any error: missing DB/sqlite/issues-table, no offending
+# token, or a `#<n>` that is not a local id (a real remote ref). Bypass:
+# TMB_DISABLE_REMOTE_ID_GUARD=1.
+
+[ "${TMB_DISABLE_REMOTE_ID_GUARD:-}" = "1" ] && exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/hooks/lib/query-task.sh
+. "$SCRIPT_DIR/lib/query-task.sh"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+[ -n "$CMD" ] || exit 0
+
+# Is this a remote-WRITE command? (git/gh/glab parity)
+#   gh pr create|edit · gh issue create|edit|comment|close
+#   glab mr create|update · glab issue create|update|note|close
+REMOTE_WRITE=0
+if printf '%s' "$CMD" | grep -qE '(^|[[:space:];|&(])gh[[:space:]]+pr[[:space:]]+(create|edit)([[:space:]]|$)'; then
+  REMOTE_WRITE=1
+elif printf '%s' "$CMD" | grep -qE '(^|[[:space:];|&(])gh[[:space:]]+issue[[:space:]]+(create|edit|comment|close)([[:space:]]|$)'; then
+  REMOTE_WRITE=1
+elif printf '%s' "$CMD" | grep -qE '(^|[[:space:];|&(])glab[[:space:]]+mr[[:space:]]+(create|update)([[:space:]]|$)'; then
+  REMOTE_WRITE=1
+elif printf '%s' "$CMD" | grep -qE '(^|[[:space:];|&(])glab[[:space:]]+issue[[:space:]]+(create|update|note|close)([[:space:]]|$)'; then
+  REMOTE_WRITE=1
+fi
+[ "$REMOTE_WRITE" = "1" ] || exit 0
+
+# Does the command carry author-supplied text? Only then is a mis-citation
+# possible. Flag long/short body/title/comment options, or a heredoc body.
+CARRIES_TEXT=0
+if printf '%s' "$CMD" | grep -qE '(--body|--title|--comment|--message|--description|--note)([[:space:]=]|$)'; then
+  CARRIES_TEXT=1
+elif printf '%s' "$CMD" | grep -qE '(^|[[:space:]])-[btm]([[:space:]]|$)'; then
+  CARRIES_TEXT=1
+elif printf '%s' "$CMD" | grep -qE '<<-?[[:space:]]*[A-Za-z_'"'"'"]'; then
+  CARRIES_TEXT=1
+fi
+[ "$CARRIES_TEXT" = "1" ] || exit 0
+
+# Extract candidate #<n> tokens from the command text. Over-broad is fine: a
+# non-local <n> is left alone below, so scanning the whole command is safe.
+TOKENS=$(printf '%s' "$CMD" | grep -oE '#[0-9]+' | sed 's/#//' | sort -u)
+[ -n "$TOKENS" ] || exit 0
+
+# Resolve DB — fail-open on any resolution failure.
+DB=$(tmb_db_path 2>/dev/null || true)
+[ -n "$DB" ] || exit 0
+tmb_have_sqlite || exit 0
+
+# issues table must exist — else fail-open.
+HAS_ISSUES=$(tmb_sqlite_ro "$DB" "SELECT name FROM sqlite_master WHERE type='table' AND name='issues';")
+[ "$HAS_ISSUES" = "issues" ] || exit 0
+
+OFFENSES=""
+while IFS= read -r n; do
+  [ -n "$n" ] || continue
+  safe_n=$(tmb_sql_int "$n")
+  [ -n "$safe_n" ] || continue
+  # Local id → its remote iid (gh_iid preferred, then gl_iid).
+  ROW=$(tmb_sqlite_ro "$DB" "
+    SELECT COALESCE(gh_iid, ''), COALESCE(gl_iid, '')
+      FROM issues WHERE id = ${safe_n};
+  ")
+  # No row → <n> is not a local id → real remote ref → leave alone.
+  [ -n "$ROW" ] || continue
+  GH=$(printf '%s' "$ROW" | cut -d'|' -f1)
+  GL=$(printf '%s' "$ROW" | cut -d'|' -f2)
+  if [ -n "$GH" ] && [ "$GH" != "$safe_n" ]; then
+    OFFENSES="${OFFENSES}#${safe_n} → #${GH} (GitHub)\n"
+  elif [ -z "$GH" ] && [ -n "$GL" ] && [ "$GL" != "$safe_n" ]; then
+    OFFENSES="${OFFENSES}#${safe_n} → #${GL} (GitLab)\n"
+  fi
+done <<< "$TOKENS"
+
+[ -n "$OFFENSES" ] || exit 0
+
+REASON="BLOCKED: this remote-bound text cites LOCAL trajectory issue id(s) that resolve to a DIFFERENT issue on the remote. Re-issue with the remote iid:
+$(printf '%b' "$OFFENSES")
+A bare #N in a PR body / gh issue comment resolves to remote issue N, not the local one. Use the remote id shown above. (Bypass: TMB_DISABLE_REMOTE_ID_GUARD=1.)"
+
+jq -nc --arg reason "$REASON" \
+  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":$reason}}'

--- a/tests/l3-integration/hooks/remote-id-guard.test.sh
+++ b/tests/l3-integration/hooks/remote-id-guard.test.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Tests for scripts/hooks/remote-id-guard.sh.
+# Hook contract: PreToolUse/Bash hook denies remote-WRITE text (gh/glab
+# create|edit|comment|close|… with author text) that cites a LOCAL trajectory
+# issue id whose remote iid differs — naming the correct remote ref. Fail-open
+# on real refs, reads, missing DB; bypass via TMB_DISABLE_REMOTE_ID_GUARD=1.
+#
+# Each case uses a mktemp-isolated fixture DB pinned via TRAJECTORY_DB_PATH —
+# sandbox-isolated per #810, never touching the live trajectory DB.
+#
+# Cases:
+#   (a) gh pr create --body 'Closes #5' where local #5 → gh_iid 42 → deny, shows #42
+#   (b) gh pr create --body citing #42 (a real GH ref, not a local id) → allow
+#   (c) gh pr list (read) → no-op
+#   (d) missing DB → allow (fail-open)
+#   (e) bypass env set → allow
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../lib/assert.sh"
+PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
+HOOK="$PLUGIN_ROOT/scripts/hooks/remote-id-guard.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Fixture DB — issues table with a local→remote iid mismatch.
+#   id=5  → gh_iid=42  (mismatch: bare #5 on the remote ≠ local issue 5)
+#   id=42 → gh_iid=42  (aligned)
+#   id=7  → gl_iid=88, gh_iid NULL (GitLab project)
+#   id=9  → gh_iid NULL, gl_iid NULL (unmapped local)
+DB="$TMPDIR/trajectory.db"
+sqlite3 "$DB" "
+  CREATE TABLE issues (
+    id INTEGER PRIMARY KEY,
+    gh_iid INTEGER,
+    gl_iid INTEGER
+  );
+  INSERT INTO issues (id, gh_iid, gl_iid) VALUES
+    (5, 42, NULL),
+    (42, 42, NULL),
+    (7, NULL, 88),
+    (9, NULL, NULL);
+"
+
+input_bash() {
+  local cmd="$1"
+  jq -n --arg cmd "$cmd" '{
+    tool_name: "Bash",
+    tool_input: { command: $cmd }
+  }'
+}
+
+run_hook() {
+  local input="$1"
+  local db="${2:-$DB}"
+  echo "$input" | TRAJECTORY_DB_PATH="$db" bash "$HOOK" 2>/dev/null || true
+}
+
+# ============================================================================
+# Case (a) — mismatch → deny, naming the correct remote ref
+# ============================================================================
+test_case "(a) gh pr create body citing local #5 (gh_iid 42): deny"
+out_a=$(run_hook "$(input_bash "gh pr create --title x --body 'Closes #5'")")
+assert_contains "$out_a" '"permissionDecision":"deny"' "deny decision"
+
+test_case "(a) deny reason names the correct remote ref #42"
+assert_contains "$out_a" "#42" "correct remote ref shown"
+
+test_case "(a) deny output is valid JSON"
+if printf '%s' "$out_a" | jq . >/dev/null 2>&1; then _pass; else _fail "not JSON: $out_a"; fi
+
+test_case "(a) -b short flag form also denies"
+out_a2=$(run_hook "$(input_bash "gh pr create -t x -b 'fixes #5'")")
+assert_contains "$out_a2" '"permissionDecision":"deny"' "deny on -b form"
+
+test_case "(a) gh issue close --comment with local #5: deny"
+out_a3=$(run_hook "$(input_bash "gh issue close 1 --comment 'dup of #5'")")
+assert_contains "$out_a3" '"permissionDecision":"deny"' "deny on issue close comment"
+
+test_case "(a) glab mr create body with local #7 (gl_iid 88): deny, shows #88"
+out_a4=$(run_hook "$(input_bash "glab mr create --title x --description 'see #7'")")
+assert_contains "$out_a4" '"permissionDecision":"deny"' "deny on glab gl_iid mismatch"
+assert_contains "$out_a4" "#88" "correct gl remote ref shown"
+
+# ============================================================================
+# Case (b) — real remote ref (#42 is not a mis-cited local id) → allow
+# ============================================================================
+test_case "(b) gh pr create body citing #42 (aligned/real ref): allow (silent)"
+out_b=$(run_hook "$(input_bash "gh pr create --title x --body 'Closes #42'")")
+assert_eq "" "$out_b" "aligned ref allowed"
+
+test_case "(b) gh pr create citing #9 (local but unmapped): allow"
+out_b2=$(run_hook "$(input_bash "gh pr create --title x --body 'about #9'")")
+assert_eq "" "$out_b2" "unmapped local id left alone"
+
+test_case "(b) gh pr create citing #999 (not a local id at all): allow"
+out_b3=$(run_hook "$(input_bash "gh pr create --title x --body 'see #999'")")
+assert_eq "" "$out_b3" "non-local ref left alone"
+
+# ============================================================================
+# Case (c) — plain read commands → no-op
+# ============================================================================
+test_case "(c) gh pr list: no-op (silent)"
+out_c=$(run_hook "$(input_bash 'gh pr list')")
+assert_eq "" "$out_c" "read command silent"
+
+test_case "(c) gh issue view 5: no-op even though #5 mismatched"
+out_c2=$(run_hook "$(input_bash 'gh issue view 5')")
+assert_eq "" "$out_c2" "view is a read, no text flag"
+
+test_case "(c) gh pr create WITHOUT author text (no body/title): no-op"
+out_c3=$(run_hook "$(input_bash 'gh pr create --fill')")
+assert_eq "" "$out_c3" "no author text → no scan"
+
+# ============================================================================
+# Case (d) — missing DB → fail-open (allow)
+# ============================================================================
+test_case "(d) missing DB: fail-open (allow)"
+out_d=$(echo "$(input_bash "gh pr create --body 'Closes #5'")" | \
+  TRAJECTORY_DB_PATH="$TMPDIR/no-such.db" bash "$HOOK" 2>/dev/null || true)
+assert_eq "" "$out_d" "missing DB → allow"
+
+test_case "(d) DB without issues table: fail-open (allow)"
+DB_NO_ISSUES="$TMPDIR/no-issues.db"
+sqlite3 "$DB_NO_ISSUES" "CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT);"
+out_d2=$(run_hook "$(input_bash "gh pr create --body 'Closes #5'")" "$DB_NO_ISSUES")
+assert_eq "" "$out_d2" "absent issues table → allow"
+
+# ============================================================================
+# Case (e) — bypass env → allow even on a true mismatch
+# ============================================================================
+test_case "(e) TMB_DISABLE_REMOTE_ID_GUARD=1: bypass (allow)"
+out_e=$(echo "$(input_bash "gh pr create --body 'Closes #5'")" | \
+  TRAJECTORY_DB_PATH="$DB" TMB_DISABLE_REMOTE_ID_GUARD=1 bash "$HOOK" 2>/dev/null || true)
+assert_eq "" "$out_e" "bypass env honored"
+
+summarize


### PR DESCRIPTION
Closes GH #798. New PreToolUse(Bash) remote-id-guard.sh denies gh/glab remote-write commands whose #<n> text cites a LOCAL issue id whose gh_iid/gl_iid differs, naming the correct remote ref; fails OPEN otherwise (false-positive-safe); bypass env. 16/16 + full L3 hooks green. pr-reviewer PASS (validation #180). Unblocks #836 (auto-close id translation).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)