### PR TITLE
♻️ fix(hooks): deterministically create swe's worktree at spawn — headless + interactive, canonical slug (#669)

### DIFF
--- a/scripts/hooks/agent-spawn-dispatch.sh
+++ b/scripts/hooks/agent-spawn-dispatch.sh
@@ -14,6 +14,10 @@
 #   5. pr-reviewer-after-atomic-close — pr-reviewer task must be status=closed
 #
 # Silent on success (no context gathered); emits deny verbatim on first block.
+#
+# After all gates pass, a final PREPARE step runs (ensure-swe-worktree.sh). It
+# ACTS — deterministically creates swe's worktree at the canonical slug — rather
+# than gates: it is non-blocking and fail-open, so it never denies a spawn.
 
 set -uo pipefail
 
@@ -46,6 +50,14 @@ for hook in "${HOOKS[@]}"; do
   CTX=$(printf '%s' "$OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
   [ -n "$CTX" ] && CONTEXT_PARTS+=("$CTX")
 done
+
+# PREPARE step — all gates passed. Deterministically create swe's worktree at
+# the canonical slug so the headless path is isolated and the verification gate
+# finds the right slug. Fail-open: never denies the spawn.
+PREPARE="$SCRIPT_DIR/ensure-swe-worktree.sh"
+if [ -x "$PREPARE" ]; then
+  printf '%s' "$INPUT" | bash "$PREPARE" >/dev/null 2>&1 || true
+fi
 
 if [ "${#CONTEXT_PARTS[@]}" -gt 0 ]; then
   MERGED=""

--- a/scripts/hooks/ensure-swe-worktree.sh
+++ b/scripts/hooks/ensure-swe-worktree.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# PreToolUse(Agent) PREPARE step — deterministically create swe's worktree.
+#
+# Headless `claude -p` skips the native WorktreeCreate tool, so bro spawns swe
+# NON-isolated (edits the main checkout) and swe self-creates a mis-named
+# worktree the verification gate can't find. This hook closes that gap: at
+# swe-spawn time it creates the worktree via `git worktree add` at the CANONICAL
+# slug path, so the path matches the slug the verification gate derives.
+#
+# This step ACTS, it does NOT gate. It is NON-BLOCKING and fail-open: any error
+# (sqlite/git absent, add fails, no task row) logs to stderr and exits 0 — it
+# never denies the spawn (the non-isolated fallback still works).
+#
+# Scope: only `subagent_type` resolving to `swe` with a `task_id=<N>` in the
+# prompt. Other spawns (pr-reviewer, consultants) → no-op.
+#
+# Bypass: TMB_DISABLE_ENSURE_SWE_WORKTREE=1.
+set -uo pipefail
+
+if [ "${TMB_DISABLE_ENSURE_SWE_WORKTREE:-0}" = "1" ]; then
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/query-task.sh
+. "$SCRIPT_DIR/lib/query-task.sh"
+# shellcheck source=lib/normalize-role.sh
+. "$SCRIPT_DIR/lib/normalize-role.sh"
+# shellcheck source=lib/resolve-repo.sh
+. "$SCRIPT_DIR/lib/resolve-repo.sh"
+
+INPUT=$(cat 2>/dev/null) || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+AGENT_TYPE=$(tmb_normalize_role "$(echo "$INPUT" | jq -r '.tool_input.subagent_type // empty')")
+PROMPT=$(echo "$INPUT" | jq -r '.tool_input.prompt // empty')
+
+# Only act for swe spawns.
+[ "$AGENT_TYPE" = "swe" ] || exit 0
+
+# Require a task_id in the prompt (require-task-spec already enforces presence).
+TASK_ID=$(echo "$PROMPT" | grep -oE 'task_id[=:][[:space:]]*[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
+SAFE_TASK_ID=$(tmb_sql_int "$TASK_ID")
+[ -n "$SAFE_TASK_ID" ] || exit 0
+
+DB=$(tmb_db_path 2>/dev/null || true)
+if [ -z "$DB" ] || ! tmb_have_sqlite; then
+  echo "ensure-swe-worktree: no trajectory.db or sqlite3 — skipping (non-isolated fallback)" >&2
+  exit 0
+fi
+
+ROW=$(tmb_sqlite_ro "$DB" "SELECT branch_id, repo FROM tasks WHERE id=${SAFE_TASK_ID};")
+if [ -z "$ROW" ]; then
+  echo "ensure-swe-worktree: no tasks row for task_id=${SAFE_TASK_ID} — skipping" >&2
+  exit 0
+fi
+
+BRANCH=$(echo "$ROW" | cut -d'|' -f1)
+REPO=$(echo "$ROW" | cut -d'|' -f2)
+if [ -z "$BRANCH" ]; then
+  echo "ensure-swe-worktree: task_id=${SAFE_TASK_ID} has empty branch_id — skipping" >&2
+  exit 0
+fi
+
+# slug = branch's last path component (fix/foo-bar → foo-bar).
+SLUG="${BRANCH##*/}"
+
+# Resolve the repo root via the path-keyed model:
+#   tasks.repo → repos.path, else single-repo fallback, else workspace root.
+WORKSPACE_ROOT="$(dirname "$(dirname "$(dirname "$DB")")")"
+if [ -n "$REPO" ]; then
+  REPO_ROOT=$(tmb_repo_path_by_name "$DB" "$REPO")
+  [ -n "$REPO_ROOT" ] || REPO_ROOT="$WORKSPACE_ROOT/$REPO"
+else
+  REPO_ROOT=$(tmb_repo_single_path "$DB")
+  [ -n "$REPO_ROOT" ] || REPO_ROOT="$WORKSPACE_ROOT"
+fi
+
+if [ ! -d "$REPO_ROOT/.git" ]; then
+  echo "ensure-swe-worktree: repo root '$REPO_ROOT' is not a git repo — skipping" >&2
+  exit 0
+fi
+
+WT_REL=".claude/worktrees/$SLUG"
+WT_ABS="$REPO_ROOT/$WT_REL"
+
+# Idempotent: if the canonical path is already a registered worktree, no-op.
+# git reports worktree paths in canonicalized form (e.g. macOS resolves
+# /var → /private/var), so compare against the basename rather than the full
+# REPO_ROOT-relative prefix — the slug is unique under .claude/worktrees/.
+if git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null \
+    | grep -qE "^worktree .*/\.claude/worktrees/${SLUG}$"; then
+  exit 0
+fi
+
+# A directory at the path that is NOT a registered worktree: leave it alone
+# (git worktree add would fail) — fail-open.
+if [ -e "$WT_ABS" ]; then
+  echo "ensure-swe-worktree: '$WT_ABS' exists but is not a registered worktree — skipping" >&2
+  exit 0
+fi
+
+if git -C "$REPO_ROOT" worktree add "$WT_REL" "$BRANCH" >/dev/null 2>&1; then
+  echo "ensure-swe-worktree: created worktree $WT_ABS for branch $BRANCH" >&2
+else
+  echo "ensure-swe-worktree: 'git worktree add $WT_REL $BRANCH' failed — skipping (non-isolated fallback)" >&2
+fi
+
+exit 0

--- a/tests/l3-integration/hooks/ensure-swe-worktree.test.sh
+++ b/tests/l3-integration/hooks/ensure-swe-worktree.test.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Tests for scripts/hooks/ensure-swe-worktree.sh
+#
+# Hook contract: at swe-spawn time, deterministically create swe's worktree at
+# the CANONICAL slug path (<repo-root>/.claude/worktrees/<slug>) via
+# `git worktree add`. Only acts for swe spawns with task_id=<N>; non-swe and
+# missing-task → no-op. NON-BLOCKING + fail-open: any error → stderr + exit 0,
+# never a deny. Idempotent. Bypass: TMB_DISABLE_ENSURE_SWE_WORKTREE=1.
+#
+# Sandbox-isolated per #810: every fixture lives in a fresh mktemp git repo and
+# is removed in cleanup — nothing is created in the plugin tree.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../lib/assert.sh"
+PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
+HOOK="$PLUGIN_ROOT/scripts/hooks/ensure-swe-worktree.sh"
+
+# ----- helpers ----------------------------------------------------------
+
+# Create a fresh temp git repo with a base branch + a feature branch.
+# Sets REPO_PATH. The feature branch is created but NOT checked out (mirrors
+# bro pre-creating <feature> while the main checkout stays on <base>).
+setup_repo() {
+  local feature="${1:-fix/1-foo-bar}"
+  local dir
+  dir=$(mktemp -d -t tmb-ensure-wt-XXXX)
+  (
+    cd "$dir" || exit 1
+    git init -q -b dev
+    git config user.email "test@example.com"
+    git config user.name  "Test"
+    echo "init" > README.md
+    git add README.md
+    git commit -qm "init"
+    git branch "$feature"
+  )
+  REPO_PATH="$dir"
+}
+
+# Apply the schema to a fresh trajectory.db inside the repo.
+setup_db() {
+  local repo="$1"
+  local db="$repo/.claude/tmb/trajectory.db"
+  mkdir -p "$(dirname "$db")"
+  sqlite3 "$db" < "$PLUGIN_ROOT/mcp/trajectory-server/src/schema.sql" >/dev/null
+  echo "$db"
+}
+
+# Insert a minimal issue + task row (repo column optional).
+insert_task() {
+  local db="$1" task_id="$2" branch_id="$3" repo="${4:-}"
+  local repo_sql="NULL"
+  [ -n "$repo" ] && repo_sql="'$repo'"
+  sqlite3 "$db" "
+    INSERT OR IGNORE INTO issues (id, objective, description, status, created_at, updated_at)
+      VALUES (1, 'test', 'test', 'open', datetime('now'), datetime('now'));
+    INSERT INTO tasks (id, issue_id, branch_id, title, description, status, spec_body, repo, created_at, updated_at)
+      VALUES ($task_id, 1, '$branch_id', 'task $task_id', 'd', 'pending', '## body', $repo_sql, datetime('now'), datetime('now'));
+  " >/dev/null
+}
+
+make_payload() {
+  local agent_type="$1" prompt="$2"
+  jq -cn --arg a "$agent_type" --arg p "$prompt" \
+    '{tool_input:{subagent_type:$a,prompt:$p}}'
+}
+
+# Run the hook from inside REPO_PATH with a pinned DB.
+run_hook() {
+  local payload="$1" db="${2:-/nonexistent.db}" extra_env="${3:-}"
+  (
+    cd "$REPO_PATH" || exit 1
+    [ -n "$extra_env" ] && eval "export $extra_env"
+    echo "$payload" | TRAJECTORY_DB_PATH="$db" bash "$HOOK" 2>&1 || true
+  )
+}
+
+# True when <repo> has a registered worktree at the given absolute path.
+# git canonicalizes worktree paths (macOS /var → /private/var), so match on
+# the .claude/worktrees/<slug> suffix rather than the raw mktemp prefix.
+is_registered_worktree() {
+  local repo="$1" wt_abs="$2"
+  local slug="${wt_abs##*/}"
+  git -C "$repo" worktree list --porcelain 2>/dev/null \
+    | grep -qE "^worktree .*/\.claude/worktrees/${slug}$"
+}
+
+cleanup() {
+  [ -n "${REPO_PATH:-}" ] && [ -d "${REPO_PATH:-}" ] && rm -rf "$REPO_PATH"
+  [ -n "${WORKSPACE:-}" ] && [ -d "${WORKSPACE:-}" ] && rm -rf "$WORKSPACE"
+  REPO_PATH=""
+  WORKSPACE=""
+}
+
+# ----- tests ------------------------------------------------------------
+
+test_case "swe + task → worktree created at canonical slug"
+setup_repo "fix/1-foo-bar"
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "fix/1-foo-bar"
+payload=$(make_payload "swe" "task_id=1 You are SWE.")
+out=$(run_hook "$payload" "$db")
+assert_not_contains "$out" '"permissionDecision":"deny"' "prepare step must never deny"
+WT="$REPO_PATH/.claude/worktrees/1-foo-bar"
+assert_eq "yes" "$([ -d "$WT" ] && echo yes || echo no)" "canonical-slug worktree dir must exist"
+assert_eq "yes" "$(is_registered_worktree "$REPO_PATH" "$WT" && echo yes || echo no)" "worktree must be registered with git"
+cleanup
+
+test_case "prefixed subagent_type (tmb:swe) is normalized and acts"
+setup_repo "fix/2-baz"
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 2 "fix/2-baz"
+payload=$(make_payload "tmb:swe" "task_id=2 You are SWE.")
+out=$(run_hook "$payload" "$db")
+WT="$REPO_PATH/.claude/worktrees/2-baz"
+assert_eq "yes" "$([ -d "$WT" ] && echo yes || echo no)" "tmb:swe must normalize to swe and create the worktree"
+cleanup
+
+test_case "idempotent: re-run with the worktree present is a no-op (no error, still allowed)"
+setup_repo "fix/1-foo-bar"
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "fix/1-foo-bar"
+payload=$(make_payload "swe" "task_id=1 You are SWE.")
+run_hook "$payload" "$db" >/dev/null
+out=$(run_hook "$payload" "$db")
+assert_not_contains "$out" '"permissionDecision":"deny"' "idempotent re-run must not deny"
+WT="$REPO_PATH/.claude/worktrees/1-foo-bar"
+assert_eq "yes" "$(is_registered_worktree "$REPO_PATH" "$WT" && echo yes || echo no)" "worktree must remain registered after re-run"
+# Exactly one worktree at that path (no duplicate).
+count=$(git -C "$REPO_PATH" worktree list --porcelain | grep -cE "^worktree .*/\.claude/worktrees/1-foo-bar$")
+assert_eq "1" "$count" "no duplicate worktree after idempotent re-run"
+cleanup
+
+test_case "non-swe spawn → no-op (no worktree created, never denies)"
+setup_repo "fix/1-foo-bar"
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "fix/1-foo-bar"
+payload=$(make_payload "pr-reviewer" "task_id=1 You are pr-reviewer.")
+out=$(run_hook "$payload" "$db")
+assert_not_contains "$out" '"permissionDecision":"deny"' "non-swe must never deny"
+WT="$REPO_PATH/.claude/worktrees/1-foo-bar"
+assert_eq "no" "$([ -d "$WT" ] && echo yes || echo no)" "non-swe spawn must not create a worktree"
+cleanup
+
+test_case "no task_id in prompt → no-op + allow"
+setup_repo "fix/1-foo-bar"
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "fix/1-foo-bar"
+payload=$(make_payload "swe" "You are SWE but no task id here.")
+out=$(run_hook "$payload" "$db")
+assert_not_contains "$out" '"permissionDecision":"deny"' "missing task_id must never deny"
+WT="$REPO_PATH/.claude/worktrees/1-foo-bar"
+assert_eq "no" "$([ -d "$WT" ] && echo yes || echo no)" "missing task_id must not create a worktree"
+cleanup
+
+test_case "git worktree add fails (branch missing) → allow (fail-open)"
+setup_repo "fix/1-foo-bar"
+# Drop the feature branch so 'git worktree add <branch>' fails.
+git -C "$REPO_PATH" branch -D "fix/1-foo-bar" >/dev/null 2>&1
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "fix/1-foo-bar"
+payload=$(make_payload "swe" "task_id=1 You are SWE.")
+out=$(run_hook "$payload" "$db")
+assert_not_contains "$out" '"permissionDecision":"deny"' "git-add failure must fail open (no deny)"
+WT="$REPO_PATH/.claude/worktrees/1-foo-bar"
+assert_eq "no" "$([ -d "$WT" ] && echo yes || echo no)" "failed add must not leave a registered worktree"
+cleanup
+
+test_case "bypass TMB_DISABLE_ENSURE_SWE_WORKTREE=1 → no-op"
+setup_repo "fix/1-foo-bar"
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "fix/1-foo-bar"
+payload=$(make_payload "swe" "task_id=1 You are SWE.")
+out=$(run_hook "$payload" "$db" "TMB_DISABLE_ENSURE_SWE_WORKTREE=1")
+assert_not_contains "$out" '"permissionDecision":"deny"' "bypass must never deny"
+WT="$REPO_PATH/.claude/worktrees/1-foo-bar"
+assert_eq "no" "$([ -d "$WT" ] && echo yes || echo no)" "bypass must skip worktree creation"
+cleanup
+
+test_case "TMB workspace shape: tasks.repo names a registered repo → worktree at that repo root"
+WORKSPACE=$(mktemp -d -t tmb-ensure-wt-ws-XXXX)
+INNER_REPO="$WORKSPACE/plugin"
+mkdir -p "$INNER_REPO"
+(
+  cd "$INNER_REPO" || exit 1
+  git init -q -b dev
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  echo "init" > README.md
+  git add README.md
+  git commit -qm "init"
+  git branch "fix/3-widget"
+)
+INNER_ROOT=$(git -C "$INNER_REPO" rev-parse --show-toplevel)
+WS_DB="$WORKSPACE/.claude/tmb/trajectory.db"
+mkdir -p "$(dirname "$WS_DB")"
+sqlite3 "$WS_DB" < "$PLUGIN_ROOT/mcp/trajectory-server/src/schema.sql" >/dev/null
+sqlite3 "$WS_DB" "
+  INSERT INTO repos (name, path) VALUES ('plugin', '$INNER_ROOT');
+  INSERT OR IGNORE INTO issues (id, objective, description, status, created_at, updated_at)
+    VALUES (1, 'test', 'test', 'open', datetime('now'), datetime('now'));
+  INSERT INTO tasks (id, issue_id, branch_id, title, description, status, spec_body, repo, created_at, updated_at)
+    VALUES (3, 1, 'fix/3-widget', 'task 3', 'd', 'pending', '## body', 'plugin', datetime('now'), datetime('now'));
+" >/dev/null
+REPO_PATH="$INNER_REPO"
+payload=$(make_payload "swe" "task_id=3 You are SWE.")
+out=$(run_hook "$payload" "$WS_DB")
+assert_not_contains "$out" '"permissionDecision":"deny"' "workspace-shape spawn must never deny"
+WT="$INNER_ROOT/.claude/worktrees/3-widget"
+assert_eq "yes" "$([ -d "$WT" ] && echo yes || echo no)" "worktree must be created under the named repo root"
+assert_eq "yes" "$(is_registered_worktree "$INNER_ROOT" "$WT" && echo yes || echo no)" "worktree must be registered with git"
+cleanup
+
+test_case "no DB → no-op + allow (not a TMB project)"
+setup_repo "fix/1-foo-bar"
+payload=$(make_payload "swe" "task_id=1 You are SWE.")
+out=$(run_hook "$payload" "/nonexistent/trajectory.db")
+assert_not_contains "$out" '"permissionDecision":"deny"' "missing DB must never deny"
+WT="$REPO_PATH/.claude/worktrees/1-foo-bar"
+assert_eq "no" "$([ -d "$WT" ] && echo yes || echo no)" "missing DB must not create a worktree"
+cleanup
+
+summarize


### PR DESCRIPTION
Closes GH #862 (local twin of #669). New ensure-swe-worktree.sh PreToolUse prepare step (wired into agent-spawn-dispatch.sh after the gates, non-blocking) git-worktree-adds the canonical .claude/worktrees/<slug> for tmb:swe spawns with a task_id — so swe is isolated headless + interactive at the slug the verification gate expects. Fail-open, idempotent, symlink-robust, bypass env. 20/20 + full L3 hooks 63/63. pr-reviewer PASS (validation #182).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)