### PR TITLE
🧪 fix(l6): de-flake 10-consultant — gate on consultant_spawn_nudged audit, not bro compliance (#865)

### DIFF
--- a/scripts/hooks/prompt-intent-hints.sh
+++ b/scripts/hooks/prompt-intent-hints.sh
@@ -47,6 +47,26 @@ emit_context() {
   exit 0
 }
 
+# Write a deterministic audit row recording that the consultant-spawn nudge
+# fired. Gates the 10-consultant L6 row on the enforcement mechanism (this row)
+# rather than bro's non-deterministic compliance with the advisory nudge.
+# Fail-open: DB/sqlite3 absent → silent skip; never blocks or crashes the hook.
+audit_consultant_spawn_nudged() {
+  local detail="$1"
+  command -v sqlite3 >/dev/null 2>&1 || return 0
+  local db
+  db=$(tmb_db_path 2>/dev/null || true)
+  [ -n "$db" ] || return 0
+  [ -f "$db" ] || return 0
+  local safe_detail
+  safe_detail=$(tmb_sql_quote "$(printf '%s' "$detail" | head -c 200)")
+  sqlite3 "$db" >/dev/null 2>&1 <<SQL || true
+INSERT INTO audit (issue_id, branch_id, from_node, event_type, summary, content_json, created_at)
+VALUES (-1, NULL, 'consultant-spawn-enforcement', 'consultant_spawn_nudged',
+        'Consultant-spawn nudge emitted: ${safe_detail}', '{}', datetime('now'));
+SQL
+}
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -180,9 +200,11 @@ EOF
   fi
 
   if [ -n "$NAMED_ROLE" ]; then
+    audit_consultant_spawn_nudged "named-role ${NAMED_ROLE}"
     CTX="[tmb consultant-spawn enforcement] The user's prompt names the \`${NAMED_ROLE}\` role. Invoke \`/tmb:agent-create ${NAMED_ROLE} <one-line restatement of the user question>\` — the command resolves the creation mode with agent_resolve, writes the agent file, registers it (the server audits the creation), and spawns the consultant in the same call. Bare \`Agent(subagent_type='${NAMED_ROLE}')\` without the command bypasses the registry; do NOT take that shortcut."
     emit_context "$CTX"
   elif [ -n "$DOMAIN" ]; then
+    audit_consultant_spawn_nudged "domain ${DOMAIN}"
     CTX="[tmb consultant-spawn enforcement] The user's prompt looks like a \`${DOMAIN}\` judgment call. Invoke \`/tmb:agent-create <role> <one-line restatement>\` with the role that fits this domain (architect / cto / pm / legal-reviewer / a custom from-scratch role). The slash command resolves the creation mode with agent_resolve, writes the agent file, registers it (the server audits the creation), and spawns the consultant. Answering directly from general knowledge bypasses the consultant gate."
     emit_context "$CTX"
   fi

--- a/tests/l3-integration/hooks/consultant-spawn-enforcement.test.sh
+++ b/tests/l3-integration/hooks/consultant-spawn-enforcement.test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# L3 tests for the consultant-spawn enforcement nudge in
+# scripts/hooks/prompt-intent-hints.sh (consultant-spawn pattern class).
+#
+# De-flake of L6 row 10-consultant (#865): when the consultant-spawn class
+# emits its domain-specialist nudge, it ALSO writes a deterministic
+# `consultant_spawn_nudged` audit row. The 10-consultant outcome.sql gates on
+# that row instead of bro's non-deterministic agent-creator compliance.
+#
+# Verifies:
+#   1. A domain-trade-off prompt (the nudge fires) writes one
+#      consultant_spawn_nudged audit row.
+#   2. A non-triggering prompt writes NO such row.
+#   3. A missing/absent DB does not crash the hook (fail-open, exit 0).
+#
+# Sandbox-isolated per #810: own tmpdir DB seeded from the real schema; never
+# touches the plugin repo working tree.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../lib/assert.sh"
+PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
+HOOK="$PLUGIN_ROOT/scripts/hooks/prompt-intent-hints.sh"
+SCHEMA="$PLUGIN_ROOT/mcp/trajectory-server/src/schema.sql"
+
+command -v sqlite3 >/dev/null 2>&1 || { echo "SKIP: sqlite3 unavailable"; exit 0; }
+command -v jq     >/dev/null 2>&1 || { echo "SKIP: jq unavailable"; exit 0; }
+
+TMPDIR_CS=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_CS"' EXIT
+cd "$TMPDIR_CS" || exit 1
+
+# Sandbox-isolation guard: never run with cwd inside the real plugin repo.
+assert_not_in_plugin_repo "$PLUGIN_ROOT"
+
+DB="$TMPDIR_CS/.claude/tmb/trajectory.db"
+mkdir -p "$(dirname "$DB")"
+sqlite3 "$DB" < "$SCHEMA" >/dev/null
+
+# Run the hook with a prompt, DB resolved via TRAJECTORY_DB_PATH override.
+# Bypass env vars all disabled so the consultant-spawn class is live.
+run_hook_with_db() {
+  local prompt="$1"
+  local payload
+  payload=$(jq -cn --arg p "$prompt" '{prompt:$p}')
+  printf '%s' "$payload" \
+    | TMB_DISABLE_CHEATCODE_INSTALL_HINT=0 \
+      TMB_DISABLE_CONSULTANT_HINT=0 \
+      TRAJECTORY_DB_PATH="$DB" \
+      bash "$HOOK" 2>&1 || true
+}
+
+nudged_count() {
+  sqlite3 "$DB" "SELECT COUNT(*) FROM audit WHERE event_type='consultant_spawn_nudged';"
+}
+
+# ========================================================
+# Case 1: domain trade-off prompt → nudge fires + audit row written
+# ========================================================
+
+test_case "domain trade-off prompt emits the consultant-spawn nudge"
+sqlite3 "$DB" "DELETE FROM audit WHERE event_type='consultant_spawn_nudged';"
+out=$(run_hook_with_db "Should we keep src/cli.py's storage in JSON or move to SQLite as the CLI scales?")
+assert_contains "$out" "consultant-spawn enforcement" "domain trade-off prompt must emit the nudge"
+
+test_case "nudge writes exactly one consultant_spawn_nudged audit row"
+assert_eq "1" "$(nudged_count)" "one audit row per nudge"
+
+test_case "audit row carries the enforcement from_node"
+ROW=$(sqlite3 -separator "|" "$DB" "SELECT from_node, event_type FROM audit WHERE event_type='consultant_spawn_nudged' LIMIT 1;")
+assert_eq "consultant-spawn-enforcement|consultant_spawn_nudged" "$ROW" "from_node + event_type correct"
+
+# ========================================================
+# Case 2: non-triggering prompt → no nudge, no audit row
+# ========================================================
+
+test_case "non-triggering prompt emits no nudge"
+sqlite3 "$DB" "DELETE FROM audit WHERE event_type='consultant_spawn_nudged';"
+out=$(run_hook_with_db "Please update the README with the new install steps")
+assert_not_contains "$out" "consultant-spawn enforcement" "benign prompt must not emit the nudge"
+
+test_case "non-triggering prompt writes no consultant_spawn_nudged audit row"
+assert_eq "0" "$(nudged_count)" "no audit row for a non-triggering prompt"
+
+# ========================================================
+# Case 3: missing DB → fail-open (no crash, exit 0, no output crash)
+# ========================================================
+
+test_case "missing DB → hook does not crash, still emits the advisory nudge"
+ec=0
+payload=$(jq -cn '{prompt:"Should we keep JSON or move to SQLite as the CLI scales?"}')
+out=$(printf '%s' "$payload" \
+  | TMB_DISABLE_CONSULTANT_HINT=0 \
+    TRAJECTORY_DB_PATH=/nonexistent-tmb-consultant-spawn.db \
+    bash "$HOOK" 2>&1) || ec=$?
+assert_eq "0" "$ec" "hook exits 0 when DB is absent"
+assert_contains "$out" "consultant-spawn enforcement" "advisory nudge still emitted with no DB"
+
+# ========================================================
+# Case 4: DB resolved via walk-up (no env var) still writes the row
+# ========================================================
+
+test_case "consultant nudge resolves DB via walk-up (no env var) and writes the row"
+WALK_ROOT=$(mktemp -d -t tmb-cs-walk-XXXX)
+WALK_DB="$WALK_ROOT/.claude/tmb/trajectory.db"
+mkdir -p "$(dirname "$WALK_DB")"
+sqlite3 "$WALK_DB" < "$SCHEMA" >/dev/null
+CHILD_DIR="$WALK_ROOT/some/nested/path"
+mkdir -p "$CHILD_DIR"
+PAYLOAD=$(jq -cn '{prompt:"Should we move from JSON to SQLite as the CLI scales?"}')
+BEFORE=$(sqlite3 "$WALK_DB" "SELECT COUNT(*) FROM audit WHERE event_type='consultant_spawn_nudged';")
+(
+  cd "$CHILD_DIR" || exit 1
+  printf '%s' "$PAYLOAD" | TMB_DISABLE_CONSULTANT_HINT=0 bash "$HOOK" >/dev/null 2>&1 || true
+)
+AFTER=$(sqlite3 "$WALK_DB" "SELECT COUNT(*) FROM audit WHERE event_type='consultant_spawn_nudged';")
+rm -rf "$WALK_ROOT"
+assert_eq "$((BEFORE + 1))" "$AFTER" "walk-up resolution writes the audit row"
+
+summarize

--- a/tests/l5-l6/rows/10-consultant/README.md
+++ b/tests/l5-l6/rows/10-consultant/README.md
@@ -15,15 +15,21 @@ The row deliberately uses a naturalistic prompt with no role name — bro must c
 | 1 | user | `@bro should we keep src/cli.py's storage in JSON or move to SQLite as the CLI scales?\n\nDon't ask questions.` |
 | → | bro | (consultant-spawn hook injects routing hint) → bro invokes `/tmb:agent-create cto` → command calls `agent_resolve` (server returns creation mode), writes the agent file, calls `agent_register(scope='project-local')` (server auto-audits `tmb_agent_created`), spawns cto via `Agent`. Single turn. |
 
+## De-flake rationale
+
+This row used to gate on a `tmb_agent_created` audit row — the load-bearing signal that bro *followed* the nudge and ran the agent-creator ceremony. That's **model behaviour**, not the enforcement mechanism: the consultant-spawn hint fires every run, but bro's compliance with the advisory nudge varies, so the gate flaked (local twin of GH #651/#865).
+
+The gate now asserts the **deterministic** signal: the `consultant-spawn` class of `prompt-intent-hints.sh` writes a `consultant_spawn_nudged` audit row whenever it emits the domain-specialist nudge. That row is written by the UserPromptSubmit hook outside the LLM's control — it fires iff the enforcement mechanism fired, independent of whether bro then complied. `tmb_agent_created` stays in the picture only as an observational note (bro's compliance), never a pass criterion.
+
 ## Pass criteria
 
 | Scorer | Asserts |
 |---|---|
-| `outcome.sql` | an `audit` row with `event_type='tmb_agent_created'` exists (load-bearing signal that the agent-creator ceremony ran). |
-| `outcome-coherence.json` | `audit WHERE event_type = 'tmb_agent_created'`: `>=1` |
+| `outcome.sql` | an `audit` row with `event_type='consultant_spawn_nudged'` exists (deterministic — the consultant-spawn enforcement nudge fired). |
+| `outcome-coherence.json` | `audit WHERE event_type = 'consultant_spawn_nudged'`: `>=1` |
 | `outcome-git.json` | `base_branch_unchanged: true` (read-only consult — no commits) |
 | `tools-required.json` | `agent_resolve`, `agent_register`, `Agent` |
 | `tools-forbidden.json` | `task_create_batch`, `validation_record` (consultants don't drive workflow state) |
 | `cost-budget.json` | Soft 200K / 600s |
 
-**Failure modes captured:** (a) bro answers the architecture question directly from general knowledge — caught by tools-required (`agent_register` + `Agent` missing); (b) bro calls `Agent(subagent='cto')` on a missing local file without running the agent-create ceremony — caught by `tmb_agent_created` audit missing.
+**Failure modes captured:** (a) the consultant-spawn pattern in `prompt-intent-hints.sh` stops matching the architecture-trade-off prompt — caught by the `consultant_spawn_nudged` audit row missing; (b) bro answers directly from general knowledge or spawns a consultant without the ceremony — caught by `tools-required` (`agent_resolve` / `agent_register` / `Agent` missing). Bro's *compliance* with the nudge (`tmb_agent_created`) is observational, not a gate.

--- a/tests/l5-l6/rows/10-consultant/outcome-coherence.json
+++ b/tests/l5-l6/rows/10-consultant/outcome-coherence.json
@@ -1,5 +1,5 @@
 {
   "expected_writes": {
-    "audit WHERE event_type = 'tmb_agent_created'": ">=1"
+    "audit WHERE event_type = 'consultant_spawn_nudged'": ">=1"
   }
 }

--- a/tests/l5-l6/rows/10-consultant/outcome.sql
+++ b/tests/l5-l6/rows/10-consultant/outcome.sql
@@ -1,12 +1,18 @@
--- 10-agent-creator-on-missing-consultant — a tmb_agent_created audit row
--- should exist (the load-bearing signal that the agent-creator ceremony ran).
+-- 10-consultant — gate on the deterministic consultant-spawn-nudge signal.
+--
+-- The prompt-intent-hints consultant-spawn class fires the domain-specialist
+-- nudge every run and writes a `consultant_spawn_nudged` audit row (the
+-- enforcement mechanism). That row is deterministic — it does not depend on
+-- whether bro complied with the advisory nudge. Gate on it.
+--
+-- De-flake of the prior `tmb_agent_created` gate: that signal depends on bro
+-- following the nudge (the agent-creator ceremony), which is model behaviour,
+-- not the enforcement mechanism — so it flaked. `tmb_agent_created` is now
+-- observational only and is NOT a pass criterion, so it is intentionally not a
+-- returned assertion row here (the scorer gates on every row this SQL emits;
+-- to keep bro's compliance non-gating it must not appear as a row).
 SELECT
   CASE WHEN COUNT(*) >= 1 THEN 1 ELSE 0 END AS pass,
-  'tmb_agent_created audit row (got ' || COUNT(*) || ', expected >=1)' AS description
+  'consultant_spawn_nudged audit row (got ' || COUNT(*) || ', expected >=1)' AS description
 FROM audit
-WHERE event_type = 'tmb_agent_created';
-
--- Note: agent_register is INSERT OR IGNORE in the server impl, so the
--- cto registry row's scope stays 'template' — the scope-update is a known
--- server-side gap, not a bro-behaviour gap. The audit row above is what
--- this scenario actually asserts.
+WHERE event_type = 'consultant_spawn_nudged';


### PR DESCRIPTION
Closes GH #865 (local twin of #651). prompt-intent-hints.sh (the real consultant-spawn nudge hook; spec's consultant-spawn-enforcement.sh was prose-only) emits a deterministic consultant_spawn_nudged audit row on its nudge-emit paths; L6 row 10-consultant's outcome.sql + outcome-coherence.json now gate on that, not the non-deterministic tmb_agent_created. Nudge logic unchanged, fail-open. New L3 test 8/8; prompt-intent-hints 55/55 no regression. pr-reviewer PASS (validation #184).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)