### PR TITLE
📝 docs(architecture): audit ERD/CHEATCODES/RESPONSIBILITIES/WORLD_MODEL vs current schema+code (#870)

### DIFF
--- a/docs/architecture/CHEATCODES.md
+++ b/docs/architecture/CHEATCODES.md
@@ -18,8 +18,15 @@ Everything between those two judgments is a tool call, not a checklist.
 | **Detect gap (#657)** | bro spots "task needs capability X I don't have" — grab a cheatcode (`tmb_cheatcode` skill) instead of grinding it out | — |
 | **Search/rank (#657)** | — | `cheatcode_search` composite MCP tool → forks `scripts/cheatcode-search.sh` (query tiered registries + parse + deterministic ranking), returns ranked candidates + records an audit row. One call, like `scan_run`→`scan.sh`. |
 | **Vet (#658)** | bro weighs "trustworthy enough?" + AskUserQuestion | `cheatcode_vet` tool gathers reputation/security **signals** atomically (stars, age, downloads, maintainer, license, install-surface); never decides. |
-| **Install (#659)** | — (approval is the human's, not bro's) | `cheatcode_install` composite (marketplace-install path, no seeding) + **PreToolUse approval gate**: install blocked unless an explicit human-approval record exists for that candidate (mech 3). Records install in trajectory DB. |
-| **Hot-load (#660)** | — | `cheatcode_activate` tool attempts in-session load; if CC requires a restart, returns a deterministic `restart_required` verdict and the skill surfaces `claude --resume` (TMB state is in trajectory checkpoints, so resume is safe). |
+| **Approve (#659)** | — (approval is the human's, not bro's) | `cheatcode_approve` records the per-candidate human approval (a `cheatcode_approved` audit row keyed by `source_url`). The install gate fails closed until this row exists. |
+| **Install + materialize (#659)** | — | `cheatcode_install` composite (marketplace-install path, no seeding) records the `cheatcodes` + attachment rows in one transaction. Blocked by a **PreToolUse approval gate** without a `cheatcode_approve` record (mech 3). For a skill, an optional `target=<bro\|swe\|pr-reviewer\|consultant>` **materializes** the consuming agent — copies the global agent md into the project `.claude/agents/<target>.md` (or `.claude/CLAUDE.md` for bro) and adds the skill to its `skills:` frontmatter, writing the user project only. Without a target a skill-kind install returns a proposed-PR payload and writes no agent md. |
+| **Hot-load (#660)** | — | `cheatcode_activate` returns a deterministic verdict: skill-kind attachments are usable in-session (activated); plugin/MCP kinds load on the next `claude -p` cold start, returning `restart_required` + a reason. |
+| **Inspect (#112/#113)** | — | `cheatcode_list` is the read-only registry surface — every builtin + installed capability with its `status` (`installed`/`active`/`broken`), `kind`, `origin`, `scope`, `trust_tier`. The "do the cheatcodes work / which are installed" check, distinct from the discovery pipeline. |
+| **Uninstall (#676)** | — (Human-confirmed) | `cheatcode_uninstall` reverses one install by `cheatcode_id` in a single transaction (see [Teardown](#teardown--uninstall-676)). Bro-proposed + Human-confirmed (AskUserQuestion), not PreToolUse-gated. |
+
+## Scan-side discovery (#124/#846)
+
+The discover→install pipeline is the *acquisition* path. A second, passive path keeps the registry honest: `scan_run` (`scripts/scan.sh`) reconciles **locally-present** capabilities into the `cheatcodes` table after its repo/file walk — project-local skills (`.claude/skills/<name>/SKILL.md`), enabled plugins (`claude plugin list`), and configured MCP servers (`claude mcp list`, with a `~/.claude.json` `mcpServers` fallback). Each capability not already tracked by `(name, kind)` is INSERTed with `origin='installed'`, `status='installed'`, and `source_url='scan_discovered'` (distinguishing it from pipeline-installed rows), emitting a `scan_discovered` audit row. This is a SQLite write into `cheatcodes` only — it does not touch the kuzu world model (which holds Directory nodes). Best-effort and bounded: the CLI calls run under a short timeout and a missing `claude` binary degrades to the skills-only walk.
 
 ## Why these boundaries (boundary test applied)
 
@@ -89,4 +96,4 @@ Each sub-issue ships with, before merge:
 
 ## Build order
 
-#657 (search ✅) → **#676 + #677 (lifecycle design, this doc)** → #658 (vet) → #659 (install + approval gate) → #660 (hot-load). #659 and #660 are blocked until the teardown contract and attachment semantics above are settled. Each stage lands its own tools/hooks + full test stack including its L5/L6 row before the next begins.
+The pipeline shipped in stage order, each stage landing its own tools/hooks + full test stack (L1–L6 row) before the next: #657 (search) → #676/#677 (teardown + attachment contract) → #658 (vet) → #659 (approve + install + approval gate) → #660 (hot-load). The scan-side discovery path (#124/#846) layered on top once the `cheatcodes` registry was the unified catalog (#101).

--- a/docs/architecture/ERD.md
+++ b/docs/architecture/ERD.md
@@ -13,7 +13,7 @@ Tables fall in three groups (capability catalog unified into `cheatcodes` in #10
 
 The **world model** lives in a sibling kuzu graph database (`world-model.kuzu`), not in this SQLite file. See `docs/architecture/WORLD_MODEL.md`.
 
-The `skills` table is gone (#101): builtin tmb_* skills are now `origin='builtin'` rows in the unified `cheatcodes` registry, alongside the `origin='installed'` cheatcodes acquired via the install pipeline. Skill/plugin usage is no longer recorded in the trajectory DB (#118) — verification moved to the stream-json session log.
+The `skills` table folded into `cheatcodes` (#101): builtin tmb_* skills are `origin='builtin'` rows in the unified `cheatcodes` registry, alongside the `origin='installed'` cheatcodes acquired via the install pipeline. Skill/plugin usage isn't recorded in the trajectory DB (#118) — verification lives in the stream-json session log.
 
 The onboarded marker lives at `plugin_config('onboarded': true)`. Scan-side drift state rides in `audit(event_type='deep_scan_completed').content_json`; `scan_run` is the single scan-side surface.
 
@@ -54,9 +54,10 @@ erDiagram
         TEXT description
         TEXT source_url "NULL for builtin"
         TEXT file_path "set for skill kind"
+        TEXT version
         TEXT trust_tier
         TEXT scope "global|template|project-local"
-        TEXT status
+        TEXT status "installed|active|broken"
     }
 
     cheatcode_attachments {
@@ -234,7 +235,7 @@ erDiagram
 | `cheatcode_attachments` | One row per artifact an install wired (plugin manifest, MCP registration, proposed skill-frontmatter PR). FK to `cheatcodes.id` ON DELETE CASCADE so `cheatcode_uninstall` reverses exactly what was installed. |
 | `repos` | One row per discovered git repo under the session dir. Written by `scan_run` (the `/scan` slash command's MCP backend). Workspace-pattern projects (multiple inner repos under a non-git workspace dir) are first-class — `tasks.repo` references `repos.name` by convention (no FK). Carries per-repo branching config (`target_branch`, `branching_model`, `protected_branches`) — this row is the **per-repo source of truth**: guards resolve policy path-keyed from the matched `repos` row for the command's git toplevel, and unregistered repos are no-op'd. The matching global `plugin_config` keys (`target_branch`, `branching_model`, `protected_branches`) are a fallback used only when the resolved repo row carries no per-repo value. See [`REPO_RESOLUTION.md`](./REPO_RESOLUTION.md). |
 | _(world model)_ | Lives in the sibling kuzu graph DB at `<project>/.claude/tmb/world-model.kuzu/`, not in this SQLite file. Directory nodes + CONTAINS edges, populated by `scan_run` via `src/graph-db.ts`. See `docs/architecture/WORLD_MODEL.md`. |
-| `plugin_config` | KV for plugin settings (PR target, issue_sync, remotes, onboarded marker). The branch-policy keys (`branching_model`, `protected_branches`, `target_branch`) live here as a **deprecated fallback** — the per-repo `repos` row is authoritative and these are consulted only when the matched repo carries no per-repo value (see `repos` above / [`REPO_RESOLUTION.md`](./REPO_RESOLUTION.md)). See `mcp/trajectory-server/docs/CONFIG_KEYS.md` for the canonical key list. |
+| `plugin_config` | KV for plugin settings (PR target, issue_sync, remotes, onboarded marker). The branch-policy keys (`branching_model`, `protected_branches`, `target_branch`) live here as a **global fallback** — the per-repo `repos` row is authoritative and these are consulted only when the matched repo carries no per-repo value (see `repos` above / [`REPO_RESOLUTION.md`](./REPO_RESOLUTION.md)). See `mcp/trajectory-server/docs/CONFIG_KEYS.md` for the canonical key list. |
 | `plugin_meta` | Schema + plugin version. Current `schema_version=22`. `plugin_version` is seeded as `'0.0.0'` and synced dynamically from `CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json` on every `TrajectoryDB` construction — so the row always reflects the running plugin version without a migration. |
 | `agent_runs` | Per-spawn resource tracking (tokens, tool_uses, duration). Written by `swe-atomic-close.sh` SubagentStop hook. |
 | `pr_review_runs` | Per-PR monitor incremental-polling cursor (`last_fetched_at`, `last_comment_id`). Used by `/monitor` flow — `pr_comments_get` reads the cursor on entry and upserts it on exit so the next call only fetches new comments. UNIQUE index on `(pr_number, repo)`. |
@@ -260,7 +261,7 @@ erDiagram
 - **bro** (planner + task gate, CLAUDE.md persona on main Claude) — full write access for the workflow side: `onboard_state_get`/`onboard_apply` (which write `plugin_config('onboarded')`), `config_get`/`set`/`list`, `issue_create`/`get`/`resume`/`close`, `discussion_append` (kind='intent'/'note'/'question'/'answer'/'decision'), `task_create_batch`, `task_update_status` (closes tasks after verifying SWE's return), `audit_log`, `scan_run` (writes `repos` SQLite + Directory nodes / CONTAINS edges in kuzu, `deep_scan_completed` audit). Reads the world model via `world_model_get` / `world_model_search` (kuzu queries) as the cold-start navigation surface. Also reads `validation_history` to drive the retry loop (flow 8).
 - **swe** (executor, project-local subagent in worktree) — `task_get(id)` for spec → `audit_log` during work → `task_update_status('completed', commit_sha)` on success. Cannot write to `issues`, `validation_attempts`, or close tasks. Reads the world model when scoping unfamiliar parts of the codebase.
 - **pr-reviewer** (push gate, project-local subagent) — `task_get(task_id)` for spec + commit → `validation_record(task_id, attempt_n, verdict, feedback, subagent_session_id)` to sign off. Only role permitted to write `validation_attempts`. Never writes to `tasks`; the close flip stays bro's call.
-- **consultants** (architect, cto, ceo, pm, project-local domain agents) — read-only on workflow tables (`issue_get_with_discussions`, `task_get`, `validation_history`); may write `discussion_append(kind='analysis'|'concern')` to record their position. Server-rejected on `task_create_batch`, `task_update_status`, `validation_record`, `issue_create` via `requireRoles`.
+- **consultants** (architect, cto, ceo, pm, project-local domain agents) — read-only on workflow tables (`issue_get_with_discussions`, `task_get`, `validation_history`); may write `discussion_append(kind='analysis')` to record their position. Server-rejected on `task_create_batch`, `task_update_status`, `validation_record`, `issue_create` via `requireRoles`.
 
 The decision chain (Human → bro → SWE, with pr-reviewer as push gate) is structurally enforced by `requireRoles` middleware inside each `tools/*.ts` family (see `middleware/agent-scope.ts` for `requireRoles`, `AgentRole` type, and the role-by-tool matrix).
 
@@ -277,23 +278,19 @@ The decision chain (Human → bro → SWE, with pr-reviewer as push gate) is str
 
 `schema.sql` is applied on open via `CREATE TABLE IF NOT EXISTS` and `INSERT OR IGNORE`. Forward migrations run automatically in `db.ts` via `runMigrations` — one `migrateVNtoVN+1` function per version step. A `.bak` snapshot is taken before migration. See `src/test/schema-upgrade.test.ts` for per-step round-trip tests.
 
-## Capability catalog — junction-based (#2886, landed)
+## Capability catalog + per-agent cost
 
-Before #2886 the `skills` table recorded only the **catalog** of available skills, with no per-invocation history — which agent on which task invoked which skill.
+The `cheatcodes` table is the unified capability catalog (#101): a **portable catalog** that's analytics-only in the Claude Code plugin (the file system stays authoritative for loading) but **load-bearing** in the enterprise LangGraph runtime (the catalog drives execution). Same schema, two read paths.
 
-#2886 closed this gap with three table additions + one schema enrichment, designed as a **portable catalog** that's analytics-only in the Claude Code plugin (file system stays authoritative for loading) but **load-bearing** in the enterprise LangGraph runtime (the catalog drives execution). Same schema, two read paths.
+### Catalog shape
 
-### Catalog tables
-
-| New / changed | Shape | Why |
+| Column | Shape | Why |
 |---|---|---|
 | `cheatcodes.scope` | `TEXT NOT NULL DEFAULT 'project-local' CHECK (scope IN ('global','template','project-local'))` | Match `agents.scope`. Distinguish schema-seeded `tmb_*` skills (global) from `.claude/skills/<name>/SKILL.md` (project-local) and installed cheatcodes (project-local by default). |
 
 ### Bro as a first-class agent_run
 
-Before #2886 `agent_runs` only captured **subagent spawns** (SWE, pr-reviewer, consultants). Bro itself — the main process — had no row, so there was no record of bro's token cost per session/task.
-
-#2886 adds bro to `agent_runs` at **per-task granularity**: one row per bro-driven task, parallel to SWE's row. Lets you compute total task cost = bro planning + SWE execution. Recorded by composites (`task_create_batch` opens the bro row, `bro_atomic_close` writes final tokens/duration) and a PostToolUse hook that accumulates bro's tokens from `transcript_path`.
+`agent_runs` captures **subagent spawns** (SWE, pr-reviewer, consultants) *and* bro itself — the main process — at **per-task granularity**: one row per bro-driven task, parallel to SWE's row. Lets you compute total task cost = bro planning + SWE execution. The bro row is recorded by composites (`task_create_batch` opens it, `bro_atomic_close` writes final tokens/duration) and a PostToolUse hook that accumulates bro's tokens from `transcript_path`.
 
 ### How this serves both runtimes
 
@@ -318,4 +315,4 @@ GROUP BY t.id, t.branch_id;
 
 ### Implementation status
 
-Landed in #2886; the catalog was unified into `cheatcodes` in #101. The bundled tmb_* skill seed (now `origin='builtin'` rows in `cheatcodes`) is in `schema.sql` and created on DB open via `CREATE TABLE IF NOT EXISTS`. Skill/plugin usage recording was retired in #118 (the `skill_invocations` junction, its writer hook, and its MCP reader removed; v21 drops the table) — verification moved to the stream-json session log. The bro `agent_run` composite (rows opened at `task_create_batch`, finalized at `bro_atomic_close`) still tracks per-task token cost.
+The catalog is unified into `cheatcodes` (#101). The bundled tmb_* skill seed (`origin='builtin'` rows in `cheatcodes`) is in `schema.sql` and created on DB open via `CREATE TABLE IF NOT EXISTS`. Skill/plugin usage verification lives in the stream-json session log (#118), not a DB junction table. The bro `agent_run` composite (rows opened at `task_create_batch`, finalized at `bro_atomic_close`) tracks per-task token cost.

--- a/docs/architecture/RESPONSIBILITIES.md
+++ b/docs/architecture/RESPONSIBILITIES.md
@@ -46,7 +46,7 @@ Source: `CLAUDE.md` (no `agents/bro.md` — bro is a persona on main Claude).
 
 1. `session-start-prescan.sh` (auto hook — inventory) → decide
 2. `branch_id_propose` MCP composite (open MCP issue + propose `branch_id`)
-3. `tmb_planning` skill — cold-start judgment + spec authoring (defaults table + ADR when the change touches `docs/trustmybot/architecture/`, schema, public API, or external side effects)
+3. `tmb_planning` skill — cold-start judgment + spec authoring (defaults table + ADR when the change touches `docs/architecture/`, schema, public API, or external side effects)
 4. **bro pre-creates the task branch** from `origin/<pr_target>` — `git fetch origin && git branch <task.branch_id> origin/<pr_target>`
 5. `task_create_batch(emit_planning_complete=true)` + spawn SWE [batched]
 6. SWE returns
@@ -116,7 +116,7 @@ Batch in one response:
 - `task_get` (all agents)
 - `task_update_status` for `completed`/`failed` (bro owns `closed`)
 - `audit_log`
-- `discussion_append` for `kind='note'/'concern'`
+- `discussion_append` for `kind='note'`
 
 ### Hooks fired against SWE actions
 
@@ -183,7 +183,7 @@ Templates in `templates/agents/<name>.md`, instantiated per-project on demand vi
 
 Consultants **cannot write workflow state**: `task_create_batch`, `task_update_status`, `issue_create`, `issue_close`, `validation_record` all return `forbidden`.
 
-They **can write analyses**: `discussion_append(kind='analysis'|'concern')`, `audit_log`. Architect specifically also gets `issue_snapshot_md`.
+They **can write analyses**: `discussion_append(kind='analysis')`, `audit_log`. Architect specifically also gets `issue_snapshot_md`.
 
 ### Spawn pattern
 
@@ -204,5 +204,5 @@ Source of truth: `mcp/trajectory-server/src/middleware/agent-scope.ts` `requireR
 | `validation_record` | | | ✓ | |
 | `world_model_get` / `world_model_search` | ✓ | ✓ | ✓ | |
 | `onboard_*` (state_get/get_questions/apply) | ✓ | | | |
-| `discussion_append` | any kind | note/concern | any | analysis/concern |
+| `discussion_append` | any kind | note | any | analysis |
 | `audit_log`, `task_get` | ✓ | ✓ | ✓ | ✓ |

--- a/docs/architecture/WORLD_MODEL.md
+++ b/docs/architecture/WORLD_MODEL.md
@@ -33,6 +33,8 @@ Follow-up slices (post-v0.7) add `File`, `Symbol`, `IMPORTS`, `CALLS`, `DEFINES`
 
 Re-running `scan_run` is summary-preserving via MERGE — existing nodes update structural fields and refresh README-derived summaries.
 
+`scan_run` also has one SQLite side effect outside the graph: a resource-discovery pass (#124/#846) reconciles locally-present capabilities — project-local skills, enabled plugins, configured MCP servers — into the trajectory DB's `cheatcodes` table (`origin='installed'`, `source_url='scan_discovered'`). That write lands in SQLite, not kuzu; the graph itself stays Directory-nodes-only. See [`CHEATCODES.md`](./CHEATCODES.md).
+
 ## Concurrency
 
 kuzu is **single-writer**: only one process may hold the database's write lock, so a `scan_run` can collide with another opener (e.g. the SessionStart prescan warming the graph). `src/graph-db.ts` opens with bounded exponential backoff — up to 8 attempts starting at 50 ms — retrying only on a write-lock error and rethrowing any non-lock error (missing binary, corrupt file) immediately. When the retries exhaust, the open surfaces as `graph_db_open_failed`, and `scan_run` reports that distinct error rather than a phantom "scan already running" — restart the session to retry (#590/591).


### PR DESCRIPTION
Part of GH #870 (docs-accuracy gate), architecture/ lane. ERD (schema_version 22, cheatcodes version col + status annotation, issues.milestone, repos policy, FK cascades; plugin_config branch keys reframed as global-fallback), CHEATCODES (7 shipped tools, restart_required not claude --resume, scan-discovery), RESPONSIBILITIES (concern removed, ADR path docs/architecture/), WORLD_MODEL (#124 resource-discovery). FLOWS/REPO_RESOLUTION/HEADLESS_ENFORCEMENT excluded. link-check PASS. pr-reviewer PASS (validation #187).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)