### PR TITLE
🧪 fix(l5l6): repair never-pass rows 44/45/95 + faked-pass 20 (setup/scorer, not prompts) (#872)

### DIFF
--- a/tests/l5-l6/rows/20-codebase-memory-cold-start/setup-l5.sh
+++ b/tests/l5-l6/rows/20-codebase-memory-cold-start/setup-l5.sh
@@ -8,6 +8,12 @@ PROJECT="$1"
 # shellcheck disable=SC2034
 SCENARIO_DIR="$2"
 
+# Drop the fixture-seeded deep_scan_completed audit row so the world-model-cold
+# gate genuinely fires (the onboarding-named fixture seeds one; this row tests
+# the cold path, so it must start cold).
+sqlite3 "$PROJECT/.claude/tmb/trajectory.db" \
+  "DELETE FROM audit WHERE event_type='deep_scan_completed';" >/dev/null
+
 mkdir -p "$PROJECT/src"
 echo "# placeholder" > "$PROJECT/src/existing.py"
 (cd "$PROJECT" && git add . && git commit -qm "seed existing files")

--- a/tests/l5-l6/rows/44-cheatcode-install-plugins/outcome.sql
+++ b/tests/l5-l6/rows/44-cheatcode-install-plugins/outcome.sql
@@ -3,7 +3,7 @@
 --
 -- Scope: bro installs BOTH the feature-dev and code-review plugins in local
 -- scope. The deterministic proof is (a) two cheatcode_installed audit rows,
--- (b) the two cheatcodes rows (feature-dev + code-review) written scope='local',
+-- (b) the two cheatcodes rows (feature-dev + code-review) written scope='project-local',
 -- and (c) the per-agent attachment records — feature-dev → swe, code-review →
 -- pr-reviewer. Marketplace results are stubbed via TMB_CHEATCODE_INSTALL_FIXTURE;
 -- the install/attachment SHAPE is covered by L2/L3, the per-candidate routing
@@ -19,9 +19,9 @@ UNION ALL
 
 SELECT
   CASE WHEN COUNT(*) >= 2 THEN 1 ELSE 0 END AS pass,
-  'two-cheatcodes-rows-scope-local (got ' || COUNT(*) || ')' AS description
+  'two-cheatcodes-rows-scope-project-local (got ' || COUNT(*) || ')' AS description
 FROM cheatcodes
-WHERE scope = 'local'
+WHERE scope = 'project-local'
 
 UNION ALL
 

--- a/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/setup-l5.sh
+++ b/tests/l5-l6/rows/45-cheatcode-uninstall-plugins/setup-l5.sh
@@ -8,7 +8,7 @@
 # source this setup.
 #
 # The seed mirrors exactly what a prior cheatcode_install would have written: a
-# cheatcodes row (kind='plugin', scope='local', status='installed') + its
+# cheatcodes row (kind='plugin', scope='project-local', status='installed') + its
 # per-agent attachment row, plus the cheatcode_install / cheatcode_installed
 # audit rows that carry each cheatcode_id (so bro can discover the ids to tear
 # down). cheatcode_uninstall then deletes the cheatcodes + cheatcode_attachments
@@ -25,20 +25,20 @@ NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 sqlite3 "$DB" <<SQL
 INSERT INTO cheatcodes (id, name, kind, source_url, version, trust_tier, scope, status, installed_at)
 VALUES
-  (1, 'feature-dev', 'plugin', 'https://example.test/feature-dev', '1.0.0', 'trusted', 'local', 'installed', '$NOW'),
-  (2, 'code-review', 'plugin', 'https://example.test/code-review', '1.0.0', 'trusted', 'local', 'installed', '$NOW');
+  (101, 'feature-dev', 'plugin', 'https://example.test/feature-dev', '1.0.0', 'trusted', 'project-local', 'installed', '$NOW'),
+  (102, 'code-review', 'plugin', 'https://example.test/code-review', '1.0.0', 'trusted', 'project-local', 'installed', '$NOW');
 
 INSERT INTO cheatcode_attachments (cheatcode_id, target, artifact, created_at)
 VALUES
-  (1, 'swe', 'marketplace-plugin:feature-dev', '$NOW'),
-  (2, 'pr-reviewer', 'marketplace-plugin:code-review', '$NOW');
+  (101, 'swe', 'marketplace-plugin:feature-dev', '$NOW'),
+  (102, 'pr-reviewer', 'marketplace-plugin:code-review', '$NOW');
 
 INSERT INTO audit (issue_id, branch_id, from_node, event_type, summary, content_json, created_at)
 VALUES
   (-1, NULL, 'bro', 'cheatcode_install', 'Cheatcode install: ''feature-dev'' (kind=plugin, method=marketplace)', '{"name":"feature-dev","kind":"plugin","source_url":"https://example.test/feature-dev","method":"marketplace"}', '$NOW'),
-  (-1, NULL, 'bro', 'cheatcode_installed', 'Cheatcode installed: ''feature-dev'' → cheatcode_id=1', '{"cheatcode_id":1,"name":"feature-dev","kind":"plugin","source_url":"https://example.test/feature-dev","installed":true,"attachments":[{"target":"swe","artifact":"marketplace-plugin:feature-dev"}]}', '$NOW'),
+  (-1, NULL, 'bro', 'cheatcode_installed', 'Cheatcode installed: ''feature-dev'' → cheatcode_id=101', '{"cheatcode_id":101,"name":"feature-dev","kind":"plugin","source_url":"https://example.test/feature-dev","installed":true,"attachments":[{"target":"swe","artifact":"marketplace-plugin:feature-dev"}]}', '$NOW'),
   (-1, NULL, 'bro', 'cheatcode_install', 'Cheatcode install: ''code-review'' (kind=plugin, method=marketplace)', '{"name":"code-review","kind":"plugin","source_url":"https://example.test/code-review","method":"marketplace"}', '$NOW'),
-  (-1, NULL, 'bro', 'cheatcode_installed', 'Cheatcode installed: ''code-review'' → cheatcode_id=2', '{"cheatcode_id":2,"name":"code-review","kind":"plugin","source_url":"https://example.test/code-review","installed":true,"attachments":[{"target":"pr-reviewer","artifact":"marketplace-plugin:code-review"}]}', '$NOW');
+  (-1, NULL, 'bro', 'cheatcode_installed', 'Cheatcode installed: ''code-review'' → cheatcode_id=102', '{"cheatcode_id":102,"name":"code-review","kind":"plugin","source_url":"https://example.test/code-review","installed":true,"attachments":[{"target":"pr-reviewer","artifact":"marketplace-plugin:code-review"}]}', '$NOW');
 SQL
 
 FIXTURE="$PROJECT/.tmb-cheatcode-uninstall-fixture.json"

--- a/tests/l5-l6/rows/95-anonymous-cold-restart/outcome.sql
+++ b/tests/l5-l6/rows/95-anonymous-cold-restart/outcome.sql
@@ -15,8 +15,10 @@ SELECT
   'config-keys-still-present (schema-seeded; got ' || COUNT(*) || ', expected ≥5)' AS description
 FROM plugin_config;
 
--- Bro must not write any audit events on a casual greeting.
+-- Bro reads, writes nothing on a casual greeting. The fixture seeds a
+-- deep_scan_completed audit row (world-model-warm proxy); bro must not add
+-- any NEW bro-authored audit events beyond it.
 SELECT
   CASE WHEN COUNT(*) = 0 THEN 1 ELSE 0 END AS pass,
-  'no-audit-events (got ' || COUNT(*) || ', expected 0)' AS description
-FROM audit;
+  'no-new-bro-audit-events (got ' || COUNT(*) || ', expected 0)' AS description
+FROM audit WHERE from_node = 'bro' AND event_type <> 'deep_scan_completed';


### PR DESCRIPTION
Closes GH #872. Found via the Human-requested L5 pre-seed audit. 45 (setup scope local→project-local + hardcoded id 1,2→101,102 clearing a UNIQUE collision with the 8 seeded builtins), 44 (outcome scope local→project-local), 95 (audit COUNT=0 → exclude the fixture's deep_scan_completed + from_node='bro'), 20 (setup DELETEs the seeded deep_scan row so the cold gate fires). No prompt.txt edited. Each row verified pass-or-fail on real behavior via scratch-DB + negative controls. pr-reviewer PASS (validation #188).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)