### PR TITLE
📝 docs(reference): audit REFERENCE/UPGRADE/README vs current code (#870)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,6 @@ If something in `docs/` turns out to be load-bearing for bro's behavior, inline 
 | `reference/REFERENCE.md` | Where workflow state lives (trajectory DB, kuzu world model, CC config) |
 | `reference/MULTI_PLATFORM.md` | OS compatibility notes |
 | `reference/UPGRADE.md` | Plugin version migration notes |
-| `architecture/` | Design rationale (CHEATCODES, ERD, FLOWS, GIT, RESPONSIBILITIES, TYPED_RAILS, UI, WORLD_MODEL) |
+| `architecture/` | Design rationale (CHEATCODES, ERD, FLOWS, GIT, HEADLESS_ENFORCEMENT, REPO_RESOLUTION, RESPONSIBILITIES, TYPED_RAILS, UI, WORLD_MODEL) |
 | `prompt-engineering/` | DETERMINISM, ENFORCEMENT, PROMPT_ENGINEERING |
 | `contributing/` | Enum/label/naming registries (ENUMS, LABELS, NAMING) |

--- a/docs/reference/REFERENCE.md
+++ b/docs/reference/REFERENCE.md
@@ -7,7 +7,7 @@ Lookups bro hits occasionally — keep here so they don't bloat CLAUDE.md.
 - **Trajectory DB** — SQLite at `<project>/.claude/<plugin-name>/trajectory.db`. Holds the workflow audit: issues, tasks, discussions, audit, validation, plugin metadata. The `<plugin-name>` segment resolves from `CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json`'s `name` field; today that's `tmb` for both stable and RC channels, so both write to `.claude/tmb/`. Project-local, gitignored, per-developer.
 - **World model graph DB** — kuzu at `<project>/.claude/<plugin-name>/world-model.kuzu/`. Holds bro's project mental picture: Directory nodes + CONTAINS edges (more node/edge types in follow-up slices). Sibling file to the trajectory DB. See `docs/architecture/WORLD_MODEL.md`.
 - **Task specs** — `tasks.spec_body` column, fetched via `task_get(task_id)`. NOT on disk.
-- **Issue milestone** — `issues.milestone` column (nullable `TEXT`, v22 / #83). A release/grouping label bound directly to the issue row; there is no separate milestones table. See `docs/architecture/ERD.md`.
+- **Issue milestone** — `issues.milestone` column (nullable `TEXT`, added at schema v22). A release/grouping label bound directly to the issue row; there is no separate milestones table. See `docs/architecture/ERD.md`.
 - **ADRs** — `docs/trustmybot/architecture/manual/decisions/N-*.md`, hand-curated.
 - **Snapshots** — `docs/trustmybot/snapshots/<issue_id>.md`, generated via `issue_snapshot_md`.
 
@@ -20,12 +20,13 @@ Lookups bro hits occasionally — keep here so they don't bloat CLAUDE.md.
 
 ## MCP tools (full list)
 
-63 tools across these groups (full schema in `mcp/trajectory-server/src/tools/`):
+67 tools across these groups (full schema in `mcp/trajectory-server/src/tools/`):
 
-- **issues**: `issue_create`, `issue_get`, `issue_list`, `issue_close`, `issue_update_description`, `issue_resume`, `issue_get_phase`, `issue_sync_retry`
-- **tasks**: `task_create_batch`, `task_get`, `task_update_status`, `task_first_actionable`, `task_stats`
+- **issues**: `issue_create`, `issue_get`, `issue_list`, `issue_close`, `issue_link`, `issue_update_description`, `issue_resume`, `issue_get_phase`, `issue_sync_retry`
+- **tasks**: `task_create_batch`, `task_get`, `task_update_status`, `task_first_actionable`
+- **stats**: `task_stats`
 - **discussions**: `discussion_append` (verified_human gate when author='human'), `discussion_list`, `discussion_search`, `issue_get_with_discussions`
-- **roundtable**: `roundtable_create`, `roundtable_vote`, `roundtable_close`, `roundtable_finalize_decisions`, `roundtable_summarize` (state machine: collecting → awaiting_human → closed | skipped)
+- **roundtable**: `roundtable_create`, `roundtable_vote`, `roundtable_close`, `roundtable_close_with_decisions`, `roundtable_finalize_decisions`, `roundtable_summarize` (state machine: collecting → awaiting_human → closed | skipped)
 - **pr_comments**: `pr_comments_get` (gh + glab backends; bot detection via DEFAULT_BOT_PATTERNS), `pr_review_runs_list`
 - **validation**: `validation_record` (subagent_session_id required when agent='pr-reviewer'), `validation_history`
 - **world model** (bro's directory-level memory): `world_model_get` (annotated dir tree), `world_model_search` (keyword / semantic / hybrid)
@@ -33,9 +34,10 @@ Lookups bro hits occasionally — keep here so they don't bloat CLAUDE.md.
 - **config**: `config_get`, `config_list`, `config_set`
 - **scan**: `scan_run`, `repos_list`
 - **reports**: `issue_report_md`, `issue_snapshot_md`, `branch_report_md`
-- **skills** (builtin rows in the unified `cheatcodes` registry, #101): `skill_register`, `skill_promote`
-- **agents**: `agent_list`, `agent_register`
-- **composites**: `branch_id_propose`, `task_retry_batch`, `task_brief`, `bro_atomic_close`, `bro_verification_fail_record`, `headless_intent_start`, `pr_review_worktree`, `reap_and_review_prep`
+- **cheatcodes** (unified skill/agent registry): `cheatcode_list`, `cheatcode_search`, `cheatcode_install`, `cheatcode_activate`, `cheatcode_approve`, `cheatcode_vet`, `cheatcode_uninstall`
+- **skills** (builtin rows in the `cheatcodes` registry): `skill_register`, `skill_promote`
+- **agents**: `agent_list`, `agent_register`, `agent_resolve`
+- **composites**: `intent_start`, `branch_id_propose`, `task_brief`, `task_retry_batch`, `task_recover`, `bro_atomic_close`, `bro_verification_fail_record`, `headless_intent_start`, `headless_fallback_record`, `pr_review_worktree`, `reap_and_review_prep`
 - **audit**: `audit_log`, `audit_log_list`, `audit_search`
 
 ## Slash commands
@@ -53,62 +55,68 @@ Runtime location: `plugin/commands/<name>.md`.
 - `~/.claude/tmb/logs/cc.log` — CC session log (rotated to .log.1)
 - `~/.claude/tmb/logs/mcp-server.log` — MCP server tool calls
 - `~/.claude/tmb/logs/mcp-health.log` — MCP health check + hook diagnostics
-- `~/.claude/tmb/logs/issue-sync.log` — `issue_sync_active` warnings + sync errors (#132, #147)
+- `~/.claude/tmb/logs/issue-sync.log` — `issue_sync_active` warnings + sync errors
 - `~/.claude/tmb/logs/sql.log` — SQL trace (when enabled)
 - `~/.claude/tmb/l5-trajectories/<flow>/<run_id>/` — trajectory.jsonl + trajectory.db preserved per flow run (written by `l5_preserve_trajectory` in flow-helpers.sh)
 
 ## Env vars
 
 - `TMB_HEADLESS=1` — disables AskUserQuestion; bro halts per `tmb_recovery` §A
-- `TMB_DISABLE_REMOTE_SYNC=1` — overrides `issue_sync` config to off (defense-in-depth, #146)
+- `TMB_DISABLE_REMOTE_SYNC=1` — overrides `issue_sync` config to off (defense-in-depth)
 - `TRAJECTORY_DB_PATH` — pin DB path for tests/CI (overrides walk-up resolution)
 - `CLAUDE_PLUGIN_ROOT` — set by CC; resolves plugin name for path calculations
 
-## Hooks (PreToolUse / PostToolUse / SessionStart / SubagentStop / UserPromptSubmit / WorktreeCreate)
+## Hooks (SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / Stop / SubagentStop / WorktreeCreate)
 
-41 hooks under `scripts/hooks/`:
+52 hook scripts under `scripts/hooks/`, wired via `hooks/hooks.json`. The six PreToolUse-Agent gates run through a single `agent-spawn-dispatch.sh` dispatcher rather than as separate registrations.
 
 | Hook | Trigger | Purpose |
 |---|---|---|
 | `ensure-gitignore.sh` | SessionStart | Project .gitignore must exclude .claude/ |
-| `ensure-kuzu-installed.sh` | SessionStart | Lazy-install kuzu native binary for the world-model graph DB (first session after plugin install/update) |
 | `mcp-health-check.sh` | SessionStart + UserPromptSubmit (periodic) | MCP server liveness probe |
 | `deferred-tools-drift-warn.sh` | SessionStart | Warn when MCP tools on disk newer than running server |
 | `write-active-workspace-sentinel.sh` | SessionStart | Sentinel for cross-session workspace resolution |
 | `session-start-prescan.sh` | SessionStart | Inject project inventory (git state, stacks, world-model warmth) |
+| `ensure-kuzu-installed.sh` | SessionStart | Lazy-install kuzu native binary for the world-model graph DB (first session after plugin install/update) |
+| `substrate-preflight.sh` | SessionStart | Verify the trajectory DB + world-model substrates are reachable before the session proceeds |
+| `cheatcode-healthcheck.sh` | SessionStart | Check the cheatcodes registry is consistent on boot |
 | `activation-routine.sh` | UserPromptSubmit | Pre-fetch onboarded marker + pending issue for bro banner |
 | `session-log-capture.sh` | UserPromptSubmit | Track current cc.log for diagnostics |
-| `consultant-spawn-required.sh` | UserPromptSubmit | Inject domain-expert prompt → suggest consultant spawn |
+| `prompt-intent-hints.sh` | UserPromptSubmit | Route intent phrases (concerns / push / resume / reonboard / ADR / consultant / search-grounding) to the right guidance |
 | `roundtable-slash-detect.sh` | UserPromptSubmit | Detect `/roundtable` invocation for server gate |
-| `concerns-protocol-hint.sh` | UserPromptSubmit | Surface concerns-protocol guidance when concern raised |
-| `push-intent-hint.sh` | UserPromptSubmit | Inject push-gate guidance on push intent |
-| `reonboard-intent-hint.sh` | UserPromptSubmit | Route reonboard phrases to /onboard |
-| `resume-intent-hint.sh` | UserPromptSubmit | Surface pending issue on resume intent |
-| `adr-required-hint.sh` | UserPromptSubmit | Inject ADR hint on architectural changes |
 | `git-guards.sh` | PreToolUse Bash | Catches reset --hard / clean -fd / force-pushes to main |
 | `git-push-guard.sh` | PreToolUse Bash | SWE can't push; push requires passing validation_attempts |
+| `swe-boundary.sh` | PreToolUse Bash + Edit/Write | Keep SWE inside its worktree and assigned scope |
 | `no-worktree-branch-create.sh` | PreToolUse Bash | Bro creates branches; SWE can't `git worktree -b` |
+| `stay-on-base-guard.sh` | PreToolUse Bash | Block code edits / commits while sitting on the base branch |
 | `branch-up-to-date-with-remote.sh` | PreToolUse Bash | Block worktree create if branch behind origin |
 | `commit-msg-lint.sh` | PreToolUse Bash | Enforce conventional-commit subject format |
-| `require-task-spec.sh` | PreToolUse Agent | SWE spawn requires task_id + non-empty spec |
-| `require-feature-branch-active.sh` | PreToolUse Agent | Block issue/task ops without a feature branch |
-| `pr-reviewer-no-worktree.sh` | PreToolUse Agent | Prevent pr-reviewer from creating worktrees |
+| `no-remote-auth-guard.sh` | PreToolUse Bash | Block interactive remote-auth flows (gh/glab login) |
+| `remote-id-guard.sh` | PreToolUse Bash | Guard remote-identity / repo-creation operations |
+| `agent-spawn-dispatch.sh` | PreToolUse Agent | Dispatcher for the spawn gates: `require-task-spec.sh`, `require-feature-branch-active.sh`, `pr-reviewer-no-worktree.sh`, `pr-reviewer-spawn-prompt-shape.sh`, `pr-reviewer-after-atomic-close.sh`, then prepares the worktree via `ensure-swe-worktree.sh` |
+| `swe-brief-gate.sh` | PreToolUse trajectory-server + Edit/Write | SWE must have fetched its task brief before touching state or files |
+| `swe-verification-gate.sh` | PreToolUse task_update_status | Gate the SWE close transition on verification |
+| `cheatcode-install-approval.sh` | PreToolUse cheatcode_install | Require Human approval before installing a cheatcode |
 | `askuserquestion-length-lint.sh` | PreToolUse AskUserQuestion | Cap label/description lengths |
 | `roundtable-auq-shape.sh` | PreToolUse AskUserQuestion | Validate AUQ shape during roundtable awaiting_human |
 | `auq-headless-deny.sh` | PreToolUse AskUserQuestion | Deny AUQ when TMB_HEADLESS=1 |
 | `no-source-edit-from-main.sh` | PreToolUse Edit/Write | Bro can't edit source from main checkout |
+| `swe-scope-fence.sh` | PreToolUse Edit/Write | Confine SWE edits to the task's declared `files[]` scope |
 | `naming-lint.sh` | PreToolUse Edit/Write | Enforce kebab/snake/Pascal naming conventions per language |
 | `code-quality-lint.sh` | PreToolUse Edit/Write | Catch mechanical quality patterns (bare except, mutable defaults, etc.) |
 | `debug-trajectory.sh` | PreToolUse (all, debug-mode) | Persist trajectory rows when TMB_DEBUG_TRAJECTORY=1 |
-| `cleanup-worktree-on-task-close.sh` | PostToolUse task_update_status | Remove worktree on close |
+| `cleanup-worktree-on-task-close.sh` | PostToolUse task_update_status + bro_atomic_close | Remove worktree on close |
 | `roundtable-cleanup-postcheck.sh` | PostToolUse roundtable_close | Verify capture surface on close |
 | `post-task-close-rescan.sh` | PostToolUse bro_atomic_close | Background /scan to refresh the world model after close |
+| `post-atomic-close-readme.sh` | PostToolUse bro_atomic_close | Refresh directory README summaries after close |
 | `post-task-create-spawn-hint.sh` | PostToolUse task_create_batch | Remind bro to spawn SWE after task batch |
-| `swe-atomic-close.sh` | SubagentStop | Auto-close pending SWE task; capture agent_runs metrics |
-| `worktree-create.sh` | WorktreeCreate | Enforce worktree-creation rules |
 | `post-pr-comments-persist.sh` | PostToolUse pr_comments_get | Auto-persist returned PR comments as discussion rows |
-| `pr-reviewer-after-atomic-close.sh` | PreToolUse Agent | Block pr-reviewer spawn unless referenced task is closed |
-| `pr-reviewer-spawn-prompt-shape.sh` | PreToolUse Agent | Enforce §C discipline: spawn prompt must contain bare anchors, no prior-verdict shortcuts |
-| `search-grounding-hint.sh` | UserPromptSubmit | Inject hint toward *_search tools on retrieval questions |
+| `attribution-footer.sh` | PostToolUse Bash | Append co-author / session attribution to commits |
+| `clean-merged-branch.sh` | PostToolUse Bash | Prune local branches once their PR merges |
+| `close-issue-on-merge.sh` | PostToolUse Bash | Close the local issue when its PR merges |
+| `bro-turn-usage.sh` | Stop | Capture bro's per-turn token/cost usage |
+| `swe-atomic-close.sh` | SubagentStop | Auto-close pending SWE task; capture agent_runs metrics |
+| `consultant-persistence-gate.sh` | SubagentStop | Persist a consultant subagent's output before it exits |
+| `worktree-create.sh` | WorktreeCreate | Enforce worktree-creation rules |
 
 ## Schema state — see ERD.md for full table list (schema v22)

--- a/docs/reference/UPGRADE.md
+++ b/docs/reference/UPGRADE.md
@@ -78,15 +78,18 @@ The trajectory DB is per-project and unaffected by the channel switch — your d
 When the MCP server starts and finds `plugin_meta.schema_version < TARGET_SCHEMA_VERSION`:
 
 1. **Backup.** A copy is written to `<dbpath>.pre-v<TARGET>.<timestamp>.bak` next to the live DB. One backup per target version — re-opening the same DB after migration does not create additional backups.
-2. **Migrate.** Migration steps run inside a single SQLite transaction. If any step fails, the transaction rolls back and your DB is left at the pre-migration version. The backup is still there.
+2. **Migrate.** Each version-step runs inside its own SQLite transaction. If a step fails, that step's transaction rolls back and your DB is left at the last version that committed cleanly. The backup is still there.
 3. **Bump.** `plugin_meta.schema_version` updates to the new target. Subsequent boots see the new version and skip migrations.
 
-### What's in the v1 → v2 migration
+### What the migration chain does
 
-- Drops zombie tables left over from earlier refactors (`identity`, `regen_state`, `project_metadata`).
-- Adds `skills.scope` (default `'global'`).
-- Rebuilds `tasks`, `roundtables`, `roundtable_votes` if any pre-v2 columns are still present. The new schema drops a handful of columns that were either never written or constant-by-construction; the rebuild copies surviving rows into a fresh table. The pre-v7 file-level registry is dropped at v7 as part of the world-model migration.
-- Adds `agent_runs.started_at` and relaxes `completed_at` to nullable.
+Migrations are chained one version at a time — `migrateV1toV2`, `migrateV2toV3`, … up to the current target — so a DB at any older version replays every step in order to reach the target. Across the chain the steps:
+
+- Drop zombie tables left over from earlier refactors (`identity`, `regen_state`, `project_metadata`).
+- Drop the pre-v7 file-level registry as part of the world-model migration.
+- Drop the `skill_invocations` table; skill/cheatcode usage is tracked in the stream-json session log instead of the trajectory DB.
+- Rebuild `tasks`, `roundtables`, `roundtable_votes` whenever a breaking column change lands — the rebuild copies surviving rows into a fresh table.
+- Add columns as features land (e.g. `agent_runs.started_at` with nullable `completed_at`, `issues.milestone`).
 
 Row data on every workflow table is preserved.
 
@@ -170,7 +173,7 @@ You're running a plugin that's older than the DB. Two ways out:
 
 ### Migration crashed mid-step
 
-The transaction wrapping `migrateV1toV2` rolls back. Your DB stays at the old version. Common causes: filesystem full, locked DB (another CC session is running against it).
+The transaction wrapping the migration step rolls back. Your DB stays at the old version. Common causes: filesystem full, locked DB (another CC session is running against it).
 
 - Free disk space / close the other session, then restart CC. Migration re-runs from scratch.
 - The pre-migration backup is still there if you'd rather roll back: restore the `.bak` file.
@@ -195,13 +198,13 @@ If your DB has a shape neither v1 nor v2 covers (e.g. you ran the plugin from a 
 
 ## Rolling back
 
-Migrations are forward-only. There is no v2 → v1 migration. To roll back:
+Migrations are forward-only — there is no downward migration. To roll back:
 
-1. Restore the `.bak` written at the time of the v1 → v2 migration:
+1. Restore the `.bak` written just before the upgrade migration ran (`<TARGET>` is the schema version you migrated to):
    ```bash
-   cp <dbpath>.pre-v2.<timestamp>.bak <dbpath>
+   cp <dbpath>.pre-v<TARGET>.<timestamp>.bak <dbpath>
    ```
-2. Downgrade the plugin to a version that ships `schema_version=1` code.
+2. Downgrade the plugin to a version whose code targets the older `schema_version`.
 
 Any work done since the upgrade is lost — the rollback restores the DB to the pre-upgrade snapshot.
 
@@ -237,14 +240,13 @@ git push origin main --tags
 
 ### Bumping the version
 
-`bump-version.sh` keeps the four version locations in sync atomically:
+`bump-version.sh` keeps the three version manifests in sync atomically:
 
 - `.claude-plugin/plugin.json`
 - `package.json`
 - `mcp/trajectory-server/package.json`
-- The `serverLog('startup', version: '...')` literal in `mcp/trajectory-server/src/index.ts`
 
-It does **not** touch the MCP `Server({ name, version })` constructor in `index.ts` — that's the protocol-handshake version, independent of the plugin version.
+`mcp/trajectory-server/src/index.ts` derives the version at runtime by reading its own `package.json`, so the startup-log line and the MCP `Server({ name, version })` handshake both pick up the new version automatically — there is no hardcoded version literal to edit.
 
 ### Bumping the schema
 
@@ -284,7 +286,7 @@ echo '@bro check status' | claude --plugin-dir <your-plugin-checkout> -p --dange
 
 # 5. Verify the migration applied
 sqlite3 .claude/tmb/trajectory.db 'SELECT schema_version, plugin_version FROM plugin_meta;'
-ls -la .claude/tmb/trajectory.db.pre-v2.*.bak           # one backup per target version
+ls -la .claude/tmb/trajectory.db.pre-v*.bak             # one backup per target version
 sqlite3 .claude/tmb/trajectory.db "SELECT value_json FROM plugin_config WHERE key='onboarded';"
 
 # 6. Cleanup
@@ -330,9 +332,9 @@ cd "$TEST_PROJ" && git init -q && git config user.email t@t.t && git config user
   && echo init > README.md && git add . && git commit -qm init
 echo '@bro hi' | claude --plugin-dir <your-plugin-checkout> -p --dangerously-skip-permissions
 
-# Verify
-sqlite3 "$DB" 'SELECT schema_version FROM plugin_meta;'        # expect 2
-ls "$DB".pre-v2.*.bak                                          # expect backup present
+# Verify — schema_version should now match the plugin's current TARGET_SCHEMA_VERSION
+sqlite3 "$DB" 'SELECT schema_version FROM plugin_meta;'
+ls "$DB".pre-v*.bak                                            # expect backup present
 sqlite3 "$DB" "SELECT value_json FROM plugin_config WHERE key='onboarded';"   # expect "true"
 rm -rf "$TEST_PROJ"
 ```
@@ -341,5 +343,5 @@ rm -rf "$TEST_PROJ"
 
 ```bash
 # Stop CC. Restore the .bak. Downgrade plugin. Re-launch.
-cp <project>/.claude/tmb/trajectory.db.pre-v2.<timestamp>.bak <project>/.claude/tmb/trajectory.db
+cp <project>/.claude/tmb/trajectory.db.pre-v<TARGET>.<timestamp>.bak <project>/.claude/tmb/trajectory.db
 ```


### PR DESCRIPTION
Part of GH #870 (docs-accuracy gate), reference/ lane — completes the mandate. REFERENCE.md (schema_version 22, issues.milestone, 67 MCP tools, per-step migration txns, skill_invocations retired, 52 hooks/7 events, bump-version 3-manifest), UPGRADE.md (0.10.0), docs/README.md. MULTI_PLATFORM needed no edit. link-check PASS. pr-reviewer PASS (validation #190).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)