### PR TITLE
♻️ refactor(prompts): single-source the MCP-handshake contract + trim tmb_review (#783)

### DIFF
--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -13,7 +13,7 @@ You are an independent code reviewer. Your verdict gates the push; you decide no
 
 Sign off (or fail) one task's commit against its spec. Your spawn prompt carries `task_id`, `commit_sha`, `branch_id`, and `repo` — a bro-side hook guarantees they arrive — plus your `subagent_session_id`.
 
-**MCP self-test**: open your reply to bro with one exact first line: `MCP available: yes` or `MCP available: no — honor-system fallback`. <!-- LOAD-BEARING-SAFETY: the reply-to-bro first line has no gate — bro's push-gate parser depends on this exact format -->
+**MCP self-test** (canonical contract — bro's push-gate parser and `tmb_review` read this line, so this is the one place the exact strings live): open your reply to bro with one exact first line — `MCP available: yes` or `MCP available: no — honor-system fallback`. <!-- LOAD-BEARING-SAFETY: the reply-to-bro first line has no gate — bro's push-gate parser depends on this exact format -->
 
 **Review**: load the brief via `task_brief` — it carries the spec, the commit, and the changed dirs' world-model summaries for sibling context — then diff the commit against its parent. Use `discussion_search` / `audit_search` for prior validation patterns. Apply:
 

--- a/skills/tmb_review/SKILL.md
+++ b/skills/tmb_review/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: tmb_review
-description: Review surface — pr-reviewer's qualitative phases at the push gate, bro's PR/MR comment triage flow, and bro's push-time orchestration. Loaded by pr-reviewer when scoring a task's commit, and by bro when the push hook blocks or the Human asks for review-before-push or PR comment monitoring. Self-contained — code-quality criteria + living patterns + AUQ shapes inline.
+description: Review surface — pr-reviewer's qualitative phases at the push gate, bro's PR/MR comment triage flow, and bro's push-time orchestration. Loaded by pr-reviewer when scoring a task's commit, and by bro when the push hook blocks or the Human asks for review-before-push or PR comment monitoring.
 allowed-tools: Task, Bash, mcp__plugin_tmb_trajectory-server, AskUserQuestion
 ---
 
 # Review
-
-Three review-related judgments live here.
 
 ## A. PR-reviewer protocol (push gate, loaded by pr-reviewer)
 
@@ -56,7 +54,7 @@ Public-API change reflected in user docs / type defs? Breaking change flagged in
 
 ### Writing the validation_attempts row — YOU write it yourself
 
-After producing a verdict, YOU (the pr-reviewer subagent) write the `validation_attempts` row directly, using the spawn prompt's `attempt_n`. Which path you take depends on your tool list. If `validation_record` is available, call it — the schema enforces the shape — and open your feedback with `'MCP available: yes'`. If your tools are only Read + Bash, write the row through the fallback script at `${CLAUDE_PLUGIN_ROOT}/skills/tmb_review/scripts/validation-record-fallback.sh` (`--help` shows the argument shape).
+After producing a verdict, YOU (the pr-reviewer subagent) write the `validation_attempts` row directly, using the spawn prompt's `attempt_n`. Your reply opens with the MCP self-test line per `agents/pr-reviewer.md` (the canonical contract); the availability it reports decides the write path. If `validation_record` is available, call it — the schema enforces the shape. If your tools are only Read + Bash, write the row through the fallback script at `${CLAUDE_PLUGIN_ROOT}/skills/tmb_review/scripts/validation-record-fallback.sh` (`--help` shows the argument shape).
 
 <!-- LOAD-BEARING-SAFETY: never delegate writing this row to bro. Bro impersonating pr-reviewer is a content-integrity violation — the server's validation_record tool returns forbidden for bro identity, and the auto-mode classifier blocks raw DB writes from bro as impersonation. The honor-system fallback is for YOU to write directly via the fallback script. -->
 
@@ -87,14 +85,14 @@ This loads when the push guard blocks unsigned commits, or when the Human asks t
 
 Use `subagent_type='pr-reviewer'` (no-namespace form resolves project-local override). Tasks are independent; spawn in parallel where possible.
 
-Read pr-reviewer's first response line:
-- `MCP available: yes` — the reviewer wrote `validation_record` itself.
-- `MCP available: no — honor-system fallback` — the reviewer wrote the row through the §A fallback script, which prepends the required feedback prefix itself.
+Read pr-reviewer's first response line — its MCP self-test, the canonical contract in `agents/pr-reviewer.md`:
+- availability `yes` — the reviewer wrote `validation_record` itself.
+- availability `no` — the reviewer wrote the row through the §A fallback script, which prepends the required feedback prefix itself.
 
 ### Outcomes
 
 - All-pass → `git push origin <feature>`, then `gh pr create` / `glab mr create`, surface URL. After merge, run post-merge cleanup below.
-- Any fail → surface verbatim. AUQ: `"PR-reviewer failed on N task(s). Spawn SWE to fix, or abort the push?"` options: `[Spawn SWE to fix | Abort push]`. Headless default: **Abort push**.
+- Any fail → surface verbatim. AUQ: `"PR-reviewer failed on N task(s). Spawn SWE to fix, or abort the push?"` options: `[Spawn SWE to fix | Abort push]`. No Human → `tmb_recovery` §A default.
 
 ### Post-merge cleanup
 


### PR DESCRIPTION
**HELD for your review (prompt-surface).** Part of #783. The exact `MCP available: yes/no` strings now live canonically only in agents/pr-reviewer.md; tmb_review §A+§C point to it (no triplication); self-narration trimmed; headless push-fail default→tmb_recovery §A pointer. All judgment + LOAD-BEARING comments intact; skill not split. pr-reviewer PASS (validation #193).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)