### PR TITLE
♻️ refactor(prompts): de-proceduralize skill-creator + strip B-grade self-narration (#783)

### DIFF
--- a/commands/agent-create.md
+++ b/commands/agent-create.md
@@ -1,6 +1,6 @@
 ---
 name: agent-create
-description: Create or copy an agent into the project's .claude/agents/ directory and (optionally) spawn it on a consultant question. Self-contained — routing/enforcement comes from this command body + the prompt-intent-hints routing hook.
+description: Create or copy an agent into the project's .claude/agents/ directory and (optionally) spawn it on a consultant question.
 argument-hint: <kebab-case agent name> [optional consultant question]
 ---
 

--- a/commands/onboard.md
+++ b/commands/onboard.md
@@ -1,5 +1,5 @@
 ---
-description: Configure or change identity, branching model, PR target, remotes, and issue-sync. Server-driven — bro orchestrates AskUserQuestion rounds; the MCP `onboard_*` tools own every if/else branch (probe, Keep options, derived defaults, transactional persistence).
+description: Configure or change identity, branching model, PR target, remotes, and issue-sync. Server-driven — bro orchestrates AskUserQuestion rounds.
 argument-hint: (none)
 allowed-tools: AskUserQuestion, mcp__plugin_tmb_trajectory-server__onboard_state_get, mcp__plugin_tmb_trajectory-server__onboard_get_questions, mcp__plugin_tmb_trajectory-server__onboard_apply, mcp__plugin_tmb_trajectory-server__audit_log
 ---

--- a/skills/tmb_concerns-protocol/SKILL.md
+++ b/skills/tmb_concerns-protocol/SKILL.md
@@ -6,15 +6,6 @@ allowed-tools: Task, mcp__plugin_tmb_trajectory-server__discussion_append, mcp__
 
 # concerns-protocol
 
-## When invoked
-
-You receive a Human request. Before you act on it, you notice one of:
-
-- The proposed scope is larger or smaller than the request implies (waste or under-delivery).
-- The request fights an existing system constraint you can see (architecture, perf, doctrine).
-- A simpler approach would deliver the same outcome with less risk.
-- You've seen this pattern fail in this codebase before (recall via `discussion_search` if unsure — ranked snippets, not a full dump).
-
 ## Protocol
 
 Two paths, pick by the type of doubt:

--- a/skills/tmb_recovery/SKILL.md
+++ b/skills/tmb_recovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tmb_recovery
-description: Bro's response when something fails — AskUserQuestion errors / TMB_HEADLESS=1 (use the documented per-skill default + audit), MCP tool returns is_error=true (halt + surface, don't silently proceed), or the trajectory-server is unreachable (degraded sqlite3 readonly fallback). Loaded reactively on the first failure of a session. Self-contained — defaults table + tool list inline.
+description: Bro's response when something fails — AskUserQuestion errors / TMB_HEADLESS=1 (use the documented per-skill default + audit), MCP tool returns is_error=true (halt + surface, don't silently proceed), or the trajectory-server is unreachable (degraded sqlite3 readonly fallback). Loaded reactively on the first failure of a session.
 allowed-tools: Bash(skills/tmb_recovery/scripts/bro-sqlite-readonly.sh:*), mcp__plugin_tmb_trajectory-server__headless_fallback_record, mcp__plugin_tmb_trajectory-server__audit_log, mcp__plugin_tmb_trajectory-server__discussion_append
 ---
 

--- a/skills/tmb_skill-creator/SKILL.md
+++ b/skills/tmb_skill-creator/SKILL.md
@@ -6,21 +6,15 @@ allowed-tools: Read, Write, Edit, Glob, Bash, AskUserQuestion, mcp__plugin_tmb_t
 
 # Skill Creator
 
-Add a new capability to a project's agents without editing their body. **Lego rule**: agent files are immutable identity; skills are additive capabilities.
-
-## When to invoke
-
-- Bro detects a project needs a new skill (e.g. Python-stack swe needs a Python-specific verification checklist that the default `tmb_swe-checklist` doesn't cover).
-- Human asks bro to teach an agent a behavior (`@bro teach swe to also run mypy as part of verification`).
-- A consultant flagged a project lacks a skill needed for a domain.
+Add a new capability to a project's agents without editing their body.
 
 If the original ask depended on the new skill being in place, bro holds it until the skill exists + is attached + approved.
 
-## Step 1 — Discover the gap
+## Discover the gap
 
 Ask three questions in one AskUserQuestion batch: (1) what to call the skill — propose 1–3 names from context, lowercase with hyphens; (2) which agents to attach it to — list from `.claude/agents/`; (3) when it activates — always or path-scoped.
 
-## Step 2 — Draft
+## Draft
 
 Author at `<project>/.claude/skills/<name>/SKILL.md` using this frontmatter template:
 
@@ -38,22 +32,12 @@ allowed-tools: <optional, comma-separated — restricts tools the skill can invo
 
 **Skill structure**: keep flat (single SKILL.md). Anthropic-style splits (SKILL.md + reference.md + forms.md + scripts/) sound clean but tax bro in headless mode — every extra file is another Read when bro can't ask the Human. Inline lookup tables and AUQ shapes; bundle scripts only when truly executable.
 
-## Step 3 — Pre-write lint
-
-Run `${CLAUDE_PLUGIN_ROOT}/scripts/prompt-author-lint.sh <draft-path>`. Surface findings via AUQ; the user picks accept/decline per finding.
-
-## Step 4 — Show and ask
-
-Present the full drafted file in a fenced code block. Ask:
+Then run `${CLAUDE_PLUGIN_ROOT}/scripts/prompt-author-lint.sh <draft-path>`, surface findings via AUQ (user picks accept/decline per finding), and present the full drafted file in a fenced code block. Ask:
 > Do you want me to (a) write this skill at `.claude/skills/<name>/SKILL.md`, AND (b) extend the `skills:` frontmatter array of <agent-list> to include `<name>`? (yes / revise / no)
 
-## Step 5 — Write on approval
+## Write on approval
 
-Register the name first with `skill_register` — the server validates and reserves it, surfacing collisions (see **Hard rules**) before anything lands on disk. Then write the skill file at `<project>/.claude/skills/<name>/SKILL.md`, append the new name to each attach-list agent's `skills:` array (and only that array), and re-read both the skill file and the touched frontmatter to confirm the edits landed.
-
-## Step 6 — Log + report
-
-If there's no open issue (free-floating skill creation — common), create one with `issue_create` scoping the creation. Then record an audit event noting the skill was created and which agents carry it, and tell the Human in one line: skill landed at `<path>`; attached to `<agents>`.
+`skill_register` the name, then write the skill file, append the new name to each attach-list agent's `skills:` array (and only that array), and re-read both to confirm the edits landed. If there's no open issue (free-floating skill creation — common), `issue_create` one scoping it. Record an audit event noting the skill and its carrying agents, and tell the Human in one line: skill landed at `<path>`; attached to `<agents>`.
 
 ## Hard rules
 


### PR DESCRIPTION
**HELD for your review (prompt-surface).** Part of #783. tmb_skill-creator: collapsed server-enforced Steps 3-6 sequencing (every operative action + the verbatim approval prompt + ≤80-line rule survive), cut Lego-rule concept-selling + When-to-invoke restatement. tmb_concerns-protocol/recovery/onboard/agent-create: stripped frontmatter-restatement/self-narration. All 5 LOAD-BEARING-SAFETY comments preserved (count-verified). pr-reviewer PASS (validation #194).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)