### PR TITLE
📝 docs(arch): revert ADR-path regression in RESPONSIBILITIES + flow-10 gaps→enforced (#883)

### DIFF
--- a/docs/architecture/FLOWS.md
+++ b/docs/architecture/FLOWS.md
@@ -257,7 +257,7 @@ flowchart TD
   INSTALL[cheatcode_install\nmarketplace/MCP path, no seed/copy\nidempotent on name+source_url\none txn: cheatcodes row + attachments + audit]
   INSTALL -->|kind=skill or skill-contributing plugin, target set| MAT{Materialize / attach — LEGO}
   INSTALL -->|kind=mcp/pure-server plugin| AUTOATT[registration IS attachment\nscript attachment rows recorded — never an orphan]
-  INSTALL -->|kind=skill, NO target| UNATT[⚠ orphan — skill bound to no agent;\nDEFECT to eliminate, not a valid path;\nmust resolve a target before install]
+  INSTALL -->|kind=skill, NO target| UNATT[hard-rejected (#883) — no resolved target,\nno install; orphan can't occur]
   MAT -->|target=bro| CMD[copy → project .claude/CLAUDE.md reference]
   MAT -->|target=other| AMD[copy global agents/&lt;target&gt;.md → .claude/agents/&lt;target&gt;.md if absent\n+ add name to skills: header — idempotent]
   CMD --> ACT
@@ -271,7 +271,7 @@ flowchart TD
   USE --> HEALTH[SessionStart cheatcode-healthcheck.sh\nreconcile status vs runtime; audit on drift]
   HEALTH --> SCANP[scan_run also discovers on-disk resources\n→ cheatcodes table, source_url='scan_discovered']
   USE -.no longer needed.-> UNINST{cheatcode_uninstall\nHuman-confirmed AUQ}
-  UNINST -->|teardown removed| REV[reverse via marketplace/MCP path\n+ DELETE cheatcodes & attachment rows\n+ de-materialize the skills: header entry ⚠\n+ audit]
+  UNINST -->|teardown removed| REV[reverse via marketplace/MCP path\n+ DELETE cheatcodes & attachment rows\n+ de-materialize the skills: header entry\n+ audit]
   UNINST -->|teardown failed — honesty gate #114| BROKEN[keep row, status → broken, audit;\nreport uninstalled:false]
   UNINST -->|absent / partial| NOOP[idempotent no-op]
 ```
@@ -289,7 +289,7 @@ flowchart TD
 - **Reconcile** — `cheatcode-healthcheck.sh` (SessionStart) checks each row's `status` against the real runtime (skill file on disk, MCP/plugin present + enabled) and audits drift. `scan_run` (flow 7) discovers on-disk resources into the table (`source_url='scan_discovered'`).
 - **Uninstall** — `cheatcode_uninstall` (Human-confirmed AUQ; not PreToolUse-gated) reverses each attachment via the marketplace/MCP path, de-materializes the `skills:` header entry, and deletes the `cheatcodes` + `cheatcode_attachments` rows in one transaction. The honesty gate (#114) keeps the row and flips `status → broken` (reporting `uninstalled:false`) when a teardown fails rather than claiming a clean removal. Absent/partial → idempotent no-op.
 
-**Known gaps (⚠ in the diagram — tracked under #766):** (1) `target` is mandatory output for skills, but `cheatcode_install` currently permits an **orphan skill** (no attachment) — a defect to fix so a skill install always ends bound to ≥1 agent (the mcp/pure-server registration-is-attachment path is exempt); (2) `cheatcode_uninstall` does not yet remove the materialized `skills:` header entry, leaving a dangling reference. Both are being smoothed so every step runs cleanly.
+**Enforcement (#883):** (1) a skill install is **hard-rejected** without a resolved target — no orphan can land (the mcp/pure-server registration-is-attachment path needs no target and is exempt); (2) `cheatcode_uninstall` de-materializes the `skills:` header entry so no dangling reference remains. Both are enforced.
 
 ---
 

--- a/docs/architecture/RESPONSIBILITIES.md
+++ b/docs/architecture/RESPONSIBILITIES.md
@@ -46,7 +46,7 @@ Source: `CLAUDE.md` (no `agents/bro.md` — bro is a persona on main Claude).
 
 1. `session-start-prescan.sh` (auto hook — inventory) → decide
 2. `branch_id_propose` MCP composite (open MCP issue + propose `branch_id`)
-3. `tmb_planning` skill — cold-start judgment + spec authoring (defaults table + ADR when the change touches `docs/architecture/`, schema, public API, or external side effects)
+3. `tmb_planning` skill — cold-start judgment + spec authoring (defaults table + ADR when the change touches `docs/trustmybot/architecture/`, schema, public API, or external side effects)
 4. **bro pre-creates the task branch** from `origin/<pr_target>` — `git fetch origin && git branch <task.branch_id> origin/<pr_target>`
 5. `task_create_batch(emit_planning_complete=true)` + spawn SWE [batched]
 6. SWE returns


### PR DESCRIPTION
Two docs/architecture corrections. (1) Reverts a regression my own docs-audit (task 209, #874) introduced: RESPONSIBILITIES.md ADR-trigger docs/architecture/ → docs/trustmybot/architecture/ (the correct user-project ADR convention — template + tasks.ts:670 + FLOWS flow 3 + tmb_planning §4 all agree). (2) FLOWS flow-10 'Known gaps' → 'Enforcement (#883)' now that the orphan-guard + uninstall-de-materialize landed (verified vs cheatcode.ts). link-check PASS. pr-reviewer PASS (validation #203).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)