### PR TITLE
📝 docs(onboard): renumber Step/Round headings to a clean sequence (no behavior change) (#783)

### DIFF
--- a/commands/onboard.md
+++ b/commands/onboard.md
@@ -12,31 +12,35 @@ Bro orchestrates an AskUserQuestion ceremony in 2-3 rounds. All deterministic lo
 
 Bro runs `/onboard` automatically on its first message in a session if `plugin_config.onboarded` is falsy (the empty-DB heuristic). The trigger is silent: no permission gate, no "want me to onboard?" question. `/onboard` also runs on demand whenever the Human types it for later changes.
 
-## Step 1 — Read state (one MCP call)
+## 1. Read state (one MCP call)
 
 Call `onboard_state_get(agent='bro')`. Returns `{ first_run, current, probe }`. Bro passes the probe to the server in subsequent calls; it doesn't interpret it.
 
-## Round 1 — Project shape
+## 2. Ask the questions
+
+Run the AskUserQuestion ceremony in up to three rounds.
+
+### Round 1 — Project shape
 
 Call `onboard_get_questions(agent='bro', round='shape')`. Feed the returned questions into `AskUserQuestion`. When a round returns no questions, skip its AUQ.
 
 Store the answer as `shape` ∈ `{local, remote}`.
 
-## Round 2 — Multiple-choice questions (server-built AUQ)
+### Round 2 — Multiple-choice questions (server-built AUQ)
 
 Call `onboard_get_questions(agent='bro', shape=<shape>, round='main')`. Feed the returned questions into `AskUserQuestion`. When the round returns no questions, skip its AUQ and proceed to Round 3 / Apply. The server already pre-selects the right option, supplies the correct `Keep "<current>"` options on re-onboard, and disables unavailable CLI options.
 
-## Round 3 — Issue sync (remote shape only)
+### Round 3 — Issue sync (remote shape only)
 
 If `shape == 'remote'`, call `onboard_get_questions(agent='bro', shape='remote', round='sync')` and feed the returned questions into `AskUserQuestion`.
 
-## Step 4 — Apply (one MCP call, transactional)
+## 3. Apply (one MCP call, transactional)
 
 Call `onboard_apply` passing each answer. The server accepts both option wire values and their labels. Pass `Keep "<current>"` answers by omitting that field — the server treats omission as "no change". The server writes the `plugin_config.onboarded` marker, persists all config fields, recomputes protected branches, and wraps everything in a transaction.
 
 Returns `{ ok: true, applied: { onboarded: true, branching_model, pr_target, protected_branches, remotes, issue_sync } }`.
 
-## Step 5 — Confirm to the Human
+## 4. Confirm to the Human
 
 Render the `applied` payload back as a short summary — project shape, branching model, PR target, protected branches, remotes, and issue sync — then close with "Tell me what you want to work on."
 
@@ -50,7 +54,7 @@ Re-render Round 1 once. Trust the user's second answer.
 
 ## Headless mode
 
-`/onboard` is interactive by definition. If `TMB_HEADLESS=1` or AskUserQuestion errors, Step 1 (`onboard_state_get`) still runs — the halt-reply must cite the current shape. Then log `headless_reonboard_blocked` via `audit_log` (issue_id='-1') and surface: `Re-onboarding requires interactive input. Re-run with a Human in the loop, or use \`config_set\` directly if you know the values.`
+`/onboard` is interactive by definition. If `TMB_HEADLESS=1` or AskUserQuestion errors, step 1 (`onboard_state_get`) still runs — the halt-reply must cite the current shape. Then log `headless_reonboard_blocked` via `audit_log` (issue_id='-1') and surface: `Re-onboarding requires interactive input. Re-run with a Human in the loop, or use \`config_set\` directly if you know the values.`
 
 Rationale: onboarding flips policy keys that drive `git-guards.sh`. Silent fallback could break the project's git workflow with no audit trace.
 


### PR DESCRIPTION
**HELD for your review (prompt-surface command).** Your follow-up: commands/onboard.md read Step 1 → Round 1-3 → Step 4/5 (Steps 2/3 skipped). Renumbered to 1 Read state → 2 Ask the questions (Round 1/2/3 nested) → 3 Apply → 4 Confirm — labels only, content/order/behavior byte-identical. Cross-refs updated; link-check PASS. pr-reviewer PASS (validation #202).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)