### PR TITLE
♻️ refactor(cheatcode): recover Decide-consuming-agent section (#766)

### DIFF
--- a/skills/tmb_cheatcode/SKILL.md
+++ b/skills/tmb_cheatcode/SKILL.md
@@ -54,4 +54,12 @@ AskUserQuestion(
 
 Lead the chat with the rationale — what the cheatcode does, its tier, and the surface it brings — then let the Human call it.
 
-When the install is FOR a specific agent — "install X for swe", "code-review for pr-reviewer" — pass that agent as `cheatcode_install`'s `target` so the consuming agent is materialized (`.claude/agents/<agent>.md` copied global→local with the skill added to its `skills:` header; `target=bro` materializes `.claude/CLAUDE.md` instead).
+## Decide the consuming agent
+
+`target` is the agent that will USE the cheatcode, and for a **skill** the target is mandatory — `cheatcode_install` rejects a targetless skill, so resolve it BEFORE install.
+
+If the Human named the agent — "install X for swe", "code-review for pr-reviewer" — use it. Otherwise infer from the cheatcode's domain: coding / test / refactor / debug → `swe`; code-review / quality → `pr-reviewer`; orchestration / routing / planning → `bro`; a consultant's domain → that consultant. Reach for AskUserQuestion only when it's genuinely ambiguous.
+
+Pass it as `cheatcode_install(..., target=<agent>)` — the install materializes that agent's prompt surface (mechanism in FLOWS flow 10). The one exception is a `kind=mcp` server (or pure-server plugin) — its registration is the attachment, callable by any agent, so it needs no target.
+
+The full lifecycle (search → vet → approve → install → materialize → activate) lives in [`docs/architecture/FLOWS.md`](../../docs/architecture/FLOWS.md) flow 10.


### PR DESCRIPTION
**HELD for your review.** RECOVERY: the 'Decide the consuming agent' section (target mandatory-output for skills, infer-by-domain, mcp-exempt) + the strict-DETERMINISM tighten were authored + pr-reviewed (validations #198, #200) but I failed to push them, so they were NOT in #880's merge. This restores the exact reviewed file content onto current dev — net diff is only the missing section (+9/-1). Conforms to FLOWS flow 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)