### PR TITLE
📝 docs: retire stale arch-docs/ADR design from FLOWS/RESPONSIBILITIES/REFERENCE (#889)

### DIFF
--- a/docs/architecture/FLOWS.md
+++ b/docs/architecture/FLOWS.md
@@ -12,7 +12,7 @@ All consultants (architect, cto, ceo, pm, project-local) advise but never write 
 |---|---|---|---|---|---|
 | 1 | First contact | `onboard_state_get().first_run === true` (i.e. `plugin_config('onboarded')` absent) | bro | `plugin_config`, `audit` | `activation-routine` (auto-fire trigger) |
 | 2 | **Code-touching task** (canonical) | Code change ask | bro → swe; pr-reviewer at push | `issues`, `tasks`, `discussions`, `audit` (+ `validation_attempts` at push) | `require-task-spec`, `git-push-guard`, `git-guards`, `cleanup-worktree-on-task-close` |
-| 3 | Architectural change | Touches `docs/trustmybot/architecture/`, schema, public API, external side effects | bro authors ADR + decision audit, then standard SWE flow | + `discussions(kind='decision')`; ADR file lands at `docs/trustmybot/architecture/manual/decisions/N-*.md` | `adr-required-hint`, universal `decision_gate` on `task_create_batch` |
+| 3 | Architectural change | New boundary/module, schema, public API, external side effects | bro records a `kind=decision` discussion + blast-radius, then standard SWE flow | + `discussions(kind='decision')` | universal `decision_gate` on `task_create_batch` |
 | 4 | Agent-creator | Routing hits role not in `.claude/agents/` | bro | — (file-based outcome) | — |
 | 5 | Skill creation | Recurring pattern needs encoding | bro | `skills` (registered via `skill_register`) | — |
 | 6 | Push gate / PR review | `git push` to protected branch | bro → pr-reviewer (one per unsigned task, parallel) | `validation_attempts` | `git-push-guard` |
@@ -120,11 +120,9 @@ sequenceDiagram
 
 ## 3. Architectural change (Δ vs flow 2)
 
-Same chain as flow 2, plus: before `task_create_batch`, bro co-authors an ADR and applies the blast-radius checklist. The universal decision gate still requires a `kind='decision'` row regardless of flow.
+Same chain as flow 2, plus: before `task_create_batch`, bro records a `kind=decision` discussion and applies the blast-radius checklist. The universal decision gate requires a `kind='decision'` row regardless of flow.
 
-- Skills: `tmb_planning` triggers the architectural ceremony when the change touches `docs/trustmybot/architecture/`, schema, public API, or has external side effects (see SKILL.md §"Architectural changes").
-- Hook: `adr-required-hint.sh` (UserPromptSubmit) detects architectural intent (`switch to clerk`, `migrate to postgres`, etc.) and injects an advisory pointing at the ADR template + the blast-radius checklist.
-- ADR file lands at `docs/trustmybot/architecture/manual/decisions/N-*.md` (template: `templates/docs-trustmybot/architecture/manual/decisions/0001-example.md`).
+- Skills: `tmb_planning` triggers the architectural ceremony when the change introduces a new boundary/module, touches schema or public API, or has external side effects (see SKILL.md §"Architectural changes").
 - For human-driven deliberation, the user enters Claude Code's native plan mode (Shift+Tab) — bro doesn't run a bespoke Q+A loop. The `kind='decision'` row captures the outcome.
 - Bro's V1/V2/V3 verification after SWE returns is unchanged — never skipped, even for architectural changes.
 

--- a/docs/architecture/RESPONSIBILITIES.md
+++ b/docs/architecture/RESPONSIBILITIES.md
@@ -46,7 +46,7 @@ Source: `CLAUDE.md` (no `agents/bro.md` — bro is a persona on main Claude).
 
 1. `session-start-prescan.sh` (auto hook — inventory) → decide
 2. `branch_id_propose` MCP composite (open MCP issue + propose `branch_id`)
-3. `tmb_planning` skill — cold-start judgment + spec authoring (defaults table + ADR when the change touches `docs/trustmybot/architecture/`, schema, public API, or external side effects)
+3. `tmb_planning` skill — cold-start judgment + spec authoring (defaults table + a `kind=decision` discussion when the change is architectural: new boundary/module, public API, schema, strategic stack, external side effects)
 4. **bro pre-creates the task branch** from `origin/<pr_target>` — `git fetch origin && git branch <task.branch_id> origin/<pr_target>`
 5. `task_create_batch(emit_planning_complete=true)` + spawn SWE [batched]
 6. SWE returns

--- a/docs/reference/REFERENCE.md
+++ b/docs/reference/REFERENCE.md
@@ -8,7 +8,7 @@ Lookups bro hits occasionally — keep here so they don't bloat CLAUDE.md.
 - **World model graph DB** — kuzu at `<project>/.claude/<plugin-name>/world-model.kuzu/`. Holds bro's project mental picture: Directory nodes + CONTAINS edges (more node/edge types in follow-up slices). Sibling file to the trajectory DB. See `docs/architecture/WORLD_MODEL.md`.
 - **Task specs** — `tasks.spec_body` column, fetched via `task_get(task_id)`. NOT on disk.
 - **Issue milestone** — `issues.milestone` column (nullable `TEXT`, added at schema v22). A release/grouping label bound directly to the issue row; there is no separate milestones table. See `docs/architecture/ERD.md`.
-- **ADRs** — `docs/trustmybot/architecture/manual/decisions/N-*.md`, hand-curated.
+- **Architectural decisions** — recorded as `kind=decision` discussions in the trajectory DB.
 - **Snapshots** — `docs/trustmybot/snapshots/<issue_id>.md`, generated via `issue_snapshot_md`.
 
 ## Other docs


### PR DESCRIPTION
Part of GH #889 (retire docs/trustmybot/architecture pre-world-model design). FLOWS flow-3 + RESPONSIBILITIES:49 + REFERENCE:11 now frame an architectural change as a kind=decision discussion + blast-radius (no markdown ADR, no arch-docs-folder trigger; adr-required-hint bullet dropped — the hook is gone; decision_gate kept). grep trustmybot/architecture = 0; link-check PASS. pr-reviewer PASS (validation #204).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)