### PR TITLE
🐛 test: add mandatory labels to 2 workflow-sim fixtures' issue_create (#93 gate) (#894)

### DIFF
--- a/tests/l3-integration/mcp/agent-bro-planner-workflow.test.mjs
+++ b/tests/l3-integration/mcp/agent-bro-planner-workflow.test.mjs
@@ -16,6 +16,7 @@ test('bro (planner) — simple task workflow: issue → discussion → tasks →
     agent: 'bro',
     objective: 'Implement hello-world endpoint',
     description: 'Full spec: add /hello returning 200 OK with {msg:"hello"}.',
+    labels: ['Feature', 'Priority: Medium'],
   });
   assert.equal(issue.ok, true, `issue_create: ${JSON.stringify(issue)}`);
   const issueId = issue.data.id;
@@ -87,6 +88,7 @@ test('bro (planner) — difficult-task flow: issue + ADR-style discussion thread
     agent: 'bro',
     objective: 'Introduce new auth module',
     description: 'Refactor session handling into its own module with OIDC support.',
+    labels: ['Feature', 'Priority: Medium'],
   });
   assert.equal(issue.ok, true);
   const issueId = issue.data.id;

--- a/tests/l4-workflow-sim/flow-03-difficult-task.test.mjs
+++ b/tests/l4-workflow-sim/flow-03-difficult-task.test.mjs
@@ -23,6 +23,7 @@ test('Flow 3 — difficult task: Q+A discussions satisfy scope gate; decision ro
     agent: 'bro',
     objective: 'Migrate auth from session-cookie to JWT',
     description: 'Cross-cutting refactor; touches the auth module across handlers.',
+    labels: ['Feature', 'Priority: Medium'],
   });
   assert.equal(issue.ok, true);
   const issueId = issue.data.id;
@@ -116,6 +117,7 @@ test('Flow 3 negative — task creation WITHOUT scope-gate Q+A is rejected', asy
 
   const issue = await call(client, 'issue_create', {
     agent: 'bro', objective: 'Difficult thing', description: 'd',
+    labels: ['Feature', 'Priority: Medium'],
   });
   const issueId = issue.data.id;
 


### PR DESCRIPTION
Closes GH #894. agent-bro-planner-workflow.test.mjs + flow-03-difficult-task.test.mjs: added labels: ['Feature','Priority: Medium'] to the 4 issue_create calls so they satisfy the #93 validateIssueLabels gate (were failing missing_required_labels). L3 3/3 + L4 2/2 green. pr-reviewer PASS (validation #208).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)