### PR TITLE
🧹 chore: generalize dev-meta leaks + add docs/architecture/PHILOSOPHY.md (#900)

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -17,4 +17,4 @@ Domain experts (security, performance, legal, and the like) are not shipped here
 
 ## How it fits
 
-These definitions are the executor and gate halves of bro's code-touching flow: bro writes a spec, dispatches `swe` to implement it, then `pr-reviewer` signs off before anything is pushed. The frontmatter tool allow-lists keep each role scoped to what it needs, and the attached skills carry the step-by-step procedures so the persona prompts stay short. Behavior is exercised by the L5/L6 chain under `tests/l5-l6/`.
+These definitions are the executor and gate halves of bro's code-touching flow: bro writes a spec, dispatches `swe` to implement it, then `pr-reviewer` signs off before anything is pushed. The frontmatter tool allow-lists keep each role scoped to what it needs, and the attached skills carry the step-by-step procedures so the persona prompts stay short.

--- a/docs/architecture/PHILOSOPHY.md
+++ b/docs/architecture/PHILOSOPHY.md
@@ -1,0 +1,33 @@
+# Design philosophy
+
+The principles behind how the TMB plugin is shaped — why the prompts are short, how the two review gates differ, and where the line sits between TMB's own development process and the runtime that ships to a user's project.
+
+## 1. Minimal prompts, cheatcode add-ons
+
+Every shipped prompt — `CLAUDE.md`, each file under `agents/`, each skill — is deliberately short. The rule is one idea per surface: an agent or skill carries exactly the one thing that makes the core TMB system work, and nothing more.
+
+Fancy depth is not baked into a core prompt. Review rubrics, multi-phase checklists, persona and style guidance, domain heuristics — all of these are add-ons. They arrive through a cheatcode: a skill, MCP toolkit, or plugin installed on demand via the discover → vet → install → hot-load pipeline (see [`CHEATCODES.md`](./CHEATCODES.md)). The core stays lean so it loads fast and reads clearly every turn; the depth attaches when a task actually calls for it.
+
+A practical test: if a paragraph in a core prompt teaches a specialized technique rather than wiring a role into the system, it belongs in a cheatcode, not the prompt.
+
+## 2. Two review perspectives
+
+The workflow has two review gates, and they look at different things.
+
+- **bro reviews at the SYSTEM level.** The question bro answers is "does this change fit the whole system?" — does it belong in this milestone, does it respect the role boundaries, does it ripple into surfaces the spec didn't name, is it the right shape of work at all.
+- **pr-reviewer reviews at the DIFF level.** The question pr-reviewer answers is "is this diff correct against its spec?" — does every named file and success criterion have a concrete change, does the verification pass, is anything out of scope.
+
+The two perspectives are complementary by design. bro can approve the intent of a change it would never read line by line; pr-reviewer can verify a diff is faithful without re-litigating whether the work should have been done. Neither gate substitutes for the other.
+
+## 3. Dev-vs-user-runtime boundary
+
+ONLY `docs/` is TMB-internal. It documents how *this project* is built and operated: the L0–L6 test harness, the `trustmybot/plugin` repository itself, GitHub milestones and labels, the rc and release-gate flow, the contributing guide, and the benchmark campaign. None of `docs/` ships to a user's project.
+
+Everything else is the shipped runtime, and it must be about THE USER'S project and fully self-contained:
+
+- `CLAUDE.md`, `agents/`, `skills/`, `commands/`, `hooks/`, `templates/`
+- the user-facing MCP server code
+
+These surfaces must never reference TMB's own development process — no harness paths, no `L1`/`L5/L6` levels, no `tests/` directories, no internal milestone or release machinery. A user installing the plugin has none of that, so a prompt or hook that cites it leaks meaningless internal context and erodes trust. When a shipped surface needs to state a rule that TMB's docs also describe, it states the rule directly rather than pointing at a `docs/` file the user does not have.
+
+The #135 and #140 cleanups enforce this boundary, sweeping dev-meta leaks out of the shipped runtime and keeping the internal references where they belong, in `docs/`.

--- a/docs/architecture/PHILOSOPHY.md
+++ b/docs/architecture/PHILOSOPHY.md
@@ -12,12 +12,12 @@ A practical test: if a paragraph in a core prompt teaches a specialized techniqu
 
 ## 2. Two review perspectives
 
-The workflow has two review gates, and they look at different things.
+The workflow has two review gates. Both read the diff line by line — what differs is the context each brings to it, and what that context does to what they catch.
 
 - **bro reviews at the SYSTEM level.** The question bro answers is "does this change fit the whole system?" — does it belong in this milestone, does it respect the role boundaries, does it ripple into surfaces the spec didn't name, is it the right shape of work at all.
 - **pr-reviewer reviews at the DIFF level.** The question pr-reviewer answers is "is this diff correct against its spec?" — does every named file and success criterion have a concrete change, does the verification pass, is anything out of scope.
 
-The two perspectives are complementary by design. bro can approve the intent of a change it would never read line by line; pr-reviewer can verify a diff is faithful without re-litigating whether the work should have been done. Neither gate substitutes for the other.
+The two perspectives are complementary because of a context asymmetry. bro carries the full picture — the plan, the decisions, the prior turns — which is what makes the system-fit call possible; but that same context biases bro toward expecting correctness, so bro can read a line for what it was *meant* to do and wave a real low-level bug through. pr-reviewer arrives with fresh memory and little of the big picture, and that freshness is the point: reading the diff cold, unprimed by intent, is what gives it the better odds of catching the local bug bro rationalizes past. Neither substitutes for the other — bro's context catches scope and ripple problems pr-reviewer can't see; pr-reviewer's fresh eyes catch correctness bugs bro's context hides.
 
 ## 3. Dev-vs-user-runtime boundary
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,6 +4,7 @@ Design rationale for how the TMB plugin is built — the schema, the workflow ga
 
 | File | Purpose |
 |---|---|
+| [`PHILOSOPHY.md`](./PHILOSOPHY.md) | The design principles behind the plugin — minimal prompts with cheatcode add-ons, the two review perspectives, and the dev-vs-user-runtime boundary |
 | [`ERD.md`](./ERD.md) | Trajectory DB entity-relationship diagram — the SQLite schema, table groups, and where the DB lives on disk |
 | [`FLOWS.md`](./FLOWS.md) | The Human → bro → SWE decision chain and the two gates (bro = task gate, pr-reviewer = push gate) |
 | [`RESPONSIBILITIES.md`](./RESPONSIBILITIES.md) | The role × tool matrix — what each shipped agent is actually instructed to do, plus server-enforced boundaries |

--- a/scripts/hooks/commit-msg-lint.sh
+++ b/scripts/hooks/commit-msg-lint.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 # PreToolUse lint on Bash for `git commit -m <msg>`. Validates the
-# Conventional-Commits-with-emoji format that the retired
-# tmb_git-conventions skill described:
+# Conventional-Commits-with-emoji format:
 #
 #   <emoji> <type>(<optional-scope>): <one-line description>
 #
 # Allowed types: feat, fix, refactor, docs, test, perf, chore, build,
-#                ci, style, revert, schema (TMB-specific for DDL changes).
+#                ci, style, revert.
 #
 # Soft-warn via `additionalContext` — does not block the commit. Bypass:
 # TMB_SKIP_COMMIT_MSG_LINT=1, or run a real `commit-msg` git hook for
@@ -54,7 +53,7 @@ VIOLATION=""
 # Conventional Commits with emoji prefix: <emoji> <type>(<scope>)?: <subject>.
 # Emoji-detection is byte-based (any UTF-8 multi-byte sequence at offset 0)
 # rather than regex-ranged so macOS grep doesn't choke on locale ranges.
-TYPES='feat|fix|refactor|docs|test|perf|chore|build|ci|style|revert|schema'
+TYPES='feat|fix|refactor|docs|test|perf|chore|build|ci|style|revert'
 
 PREFIX=$(printf '%s' "$FIRST_LINE" | awk '{print $1}')
 REST=$(printf '%s' "$FIRST_LINE" | awk '{$1=""; sub(/^[[:space:]]+/, ""); print}')

--- a/scripts/hooks/naming-lint.sh
+++ b/scripts/hooks/naming-lint.sh
@@ -4,7 +4,7 @@
 # and emits soft `additionalContext` when the basename violates the
 # language convention. Existing files are never re-named by this hook.
 #
-# Conventions (from the retired tmb_naming-conventions skill):
+# Conventions:
 #   Python (.py)   → snake_case.py
 #   TS/JS module   → kebab-case.ts / .js / .mjs / .cjs
 #   React (.tsx/.jsx) basename starting with uppercase → PascalCase.tsx

--- a/scripts/hooks/require-feature-branch-active.sh
+++ b/scripts/hooks/require-feature-branch-active.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Hook: Block SWE agent spawn when the task's branch_id does not yet exist.
-# Per docs/architecture/GIT.md, bro pre-creates <feature> without checking it
-# out (the main checkout stays on <base>; SWE's worktree owns the branch ref).
-# This gate verifies the branch exists before the worktree attaches to it.
+# bro pre-creates <feature> without checking it out (the main checkout stays
+# on <base>; SWE's worktree owns the branch ref). This gate verifies the
+# branch exists before the worktree attaches to it.
 #
 # Bypass: TMB_ALLOW_BRANCH_MISMATCH=1 (emergency hotfix scenarios).
 set -uo pipefail
@@ -67,11 +67,11 @@ else
   fi
 fi
 
-# Per GIT.md the prerequisite is that <feature> EXISTS (bro pre-created it),
-# not that the main checkout is on it — the main checkout stays on <base>.
+# The prerequisite is that <feature> EXISTS (bro pre-created it), not that the
+# main checkout is on it — the main checkout stays on <base>.
 if ! git -C "$REPO_ABS" show-ref --verify --quiet "refs/heads/$EXPECTED"; then
   jq -nc --arg id "$TASK_ID" --arg branch "$EXPECTED" --arg repo "$REPO_ABS" \
-    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: SWE spawn for task "+$id+" needs branch "+$branch+" to exist first — bro pre-creates it (\"git -C "+$repo+" branch "+$branch+" origin/<base>\") and stays on <base>; SWE'\''s worktree owns the branch. See docs/architecture/GIT.md.")}}'
+    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: SWE spawn for task "+$id+" needs branch "+$branch+" to exist first — bro pre-creates it (\"git -C "+$repo+" branch "+$branch+" origin/<base>\") and stays on <base>; SWE'\''s worktree owns the branch.")}}'
   exit 0
 fi
 

--- a/skills/tmb_docs-conventions/SKILL.md
+++ b/skills/tmb_docs-conventions/SKILL.md
@@ -5,7 +5,7 @@ description: Loaded when editing prompt files (agents, skills, CLAUDE.md, workfl
 
 # Docs Conventions — Editing Discipline
 
-Link integrity is gated at L1; this skill carries the editing judgment — what to delete, what to preserve verbatim, where the ripples go when a rename or restructure lands.
+Link integrity is checked by lint/CI; this skill carries the editing judgment — what to delete, what to preserve verbatim, where the ripples go when a rename or restructure lands.
 
 ## Docs-update expectation
 

--- a/skills/tmb_planning/SKILL.md
+++ b/skills/tmb_planning/SKILL.md
@@ -73,7 +73,7 @@ When the change does any of the following, record it as a `kind='decision'` disc
 - Names multiple unrelated surfaces in one task
 - Has external side effects (network, billing, message-sending, writes outside the worktree)
 
-Blast-radius (external side effects only): default config is the safe state (opt-in); tests run against `:memory:` only; spec requires a pre-merge `bash tests/run-all.sh` yielding zero external mutations.
+Blast-radius (external side effects only): default config is the safe state (opt-in); the task's own `verification[]` must prove zero external mutations before the change can merge.
 
 ## 5. Spawn SWE
 


### PR DESCRIPTION
Part of GH #900 (TMB-dev-meta leak remediation, from the #879 audit). **Held for review — do not auto-merge.**

Generalizes shipped-runtime leaks so they're user-project-clean:
- `tmb_planning:76` blast-radius drops `tests/run-all.sh`/`:memory:` → the task's own verification[] proves zero external mutations
- `agents/README:20` drops the L5/L6 clause; `tmb_docs-conventions:8` L1→lint/CI
- `require-feature-branch-active.sh` drops the `docs/architecture/GIT.md` citation; `commit-msg-lint.sh` drops the `schema` type; `naming-lint.sh` stale comment

Adds **`docs/architecture/PHILOSOPHY.md`** (TMB-internal): minimal-prompts/cheatcode-add-ons, the two review perspectives (bro=system / pr-reviewer=diff), and the dev-vs-user-runtime boundary.

pr-reviewer PASS (validation #210). L1 link-check + bash -n green.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)