### PR TITLE
test: add labels to L3/L4 issue_create fixtures (#903 fail-closed fallout) (#904)

### DIFF
--- a/tests/l3-integration/mcp/agent-pr-reviewer-workflow.test.mjs
+++ b/tests/l3-integration/mcp/agent-pr-reviewer-workflow.test.mjs
@@ -9,6 +9,7 @@ import { startClient, call } from './harness.mjs';
 async function seedCompletedTask(client) {
   const issue = await call(client, 'issue_create', {
     agent: 'bro', objective: 'pr test', description: 'x',
+    labels: ['Feature', 'Priority: Medium'],
   });
   assert.equal(issue.ok, true);
   const batch = await call(client, 'task_create_batch', {

--- a/tests/l3-integration/mcp/agent-swe-workflow.test.mjs
+++ b/tests/l3-integration/mcp/agent-swe-workflow.test.mjs
@@ -18,6 +18,7 @@ async function seedIssueAndTask(client) {
     agent: 'bro',
     objective: 'task for swe',
     description: 'x',
+    labels: ['Feature', 'Priority: Medium'],
   });
   assert.equal(issue.ok, true);
   const batch = await call(client, 'task_create_batch', {

--- a/tests/l3-integration/mcp/issue-update-description.test.mjs
+++ b/tests/l3-integration/mcp/issue-update-description.test.mjs
@@ -7,6 +7,7 @@ async function seedIssue(client, description = 'original description') {
     agent: 'bro',
     objective: 'backfill test issue',
     description,
+    labels: ['Feature', 'Priority: Medium'],
   });
   assert.equal(result.ok, true, `seed issue: ${JSON.stringify(result)}`);
   return result.data;

--- a/tests/l3-integration/mcp/role-matrix.test.mjs
+++ b/tests/l3-integration/mcp/role-matrix.test.mjs
@@ -58,7 +58,7 @@ test('issue_snapshot_md — bro & pr-reviewer only; consultants forbidden', asyn
   t.after(async () => { await close(); });
 
   // Seed an issue so the handler has something to snapshot.
-  const seed = await call(client, 'issue_create', { agent: 'bro', objective: 'x', description: 'y' });
+  const seed = await call(client, 'issue_create', { agent: 'bro', objective: 'x', description: 'y', labels: ['Feature', 'Priority: Medium'] });
   assert.equal(seed.ok, true, `seed issue: ${JSON.stringify(seed)}`);
   const issueId = seed.data.id;
 
@@ -76,7 +76,7 @@ test('discussion_append — workflow agents (bro/architect) can append questions
   t.after(async () => { await close(); });
 
   // Seed: architect creates an issue.
-  const issue = await call(client, 'issue_create', { agent: 'bro', objective: 'x', description: 'y' });
+  const issue = await call(client, 'issue_create', { agent: 'bro', objective: 'x', description: 'y', labels: ['Feature', 'Priority: Medium'] });
   assert.equal(issue.ok, true, `seed: ${JSON.stringify(issue)}`);
   const issueId = issue.data.id;
 
@@ -102,13 +102,13 @@ test('issue_create — bro only; architect/swe/pr-reviewer all forbidden', async
   const { client, close } = await startClient();
   t.after(async () => { await close(); });
 
-  const ok = await call(client, 'issue_create', { agent: 'bro', objective: 'planner test', description: 'd' });
+  const ok = await call(client, 'issue_create', { agent: 'bro', objective: 'planner test', description: 'd', labels: ['Feature', 'Priority: Medium'] });
   assert.equal(ok.ok, true, `bro should create issue; got ${JSON.stringify(ok)}`);
 
   // Architect normalizes to 'consultant' role; first-class roles keep their literal name.
   const expectedRole = (n) => (n === 'architect' ? 'consultant' : n);
   for (const wrongRole of ['architect', 'swe', 'pr-reviewer']) {
-    const res = await call(client, 'issue_create', { agent: wrongRole, objective: 'x', description: 'y' });
+    const res = await call(client, 'issue_create', { agent: wrongRole, objective: 'x', description: 'y', labels: ['Feature', 'Priority: Medium'] });
     assert.equal(res.ok, false, `${wrongRole} must be forbidden from issue_create`);
     assert.equal(res.error?.error, 'forbidden');
     assert.equal(res.error?.caller_role, expectedRole(wrongRole));
@@ -119,7 +119,7 @@ test('issue_close — bro only; architect/swe/pr-reviewer all forbidden', async 
   const { client, close } = await startClient();
   t.after(async () => { await close(); });
 
-  const seed = await call(client, 'issue_create', { agent: 'bro', objective: 's', description: 'd' });
+  const seed = await call(client, 'issue_create', { agent: 'bro', objective: 's', description: 'd', labels: ['Feature', 'Priority: Medium'] });
   const issueId = seed.data.id;
 
   for (const wrongRole of ['architect', 'swe', 'pr-reviewer']) {
@@ -133,7 +133,7 @@ test('task_create_batch — bro only; architect/swe/pr-reviewer all forbidden', 
   const { client, close } = await startClient();
   t.after(async () => { await close(); });
 
-  const seed = await call(client, 'issue_create', { agent: 'bro', objective: 'plan', description: 'd' });
+  const seed = await call(client, 'issue_create', { agent: 'bro', objective: 'plan', description: 'd', labels: ['Feature', 'Priority: Medium'] });
   const issueId = seed.data.id;
   const taskInput = {
     waive_scope_gate: true,
@@ -169,7 +169,7 @@ test('task_update_status — bro and swe allowed; architect/pr-reviewer forbidde
   const { client, close } = await startClient();
   t.after(async () => { await close(); });
 
-  const seed = await call(client, 'issue_create', { agent: 'bro', objective: 'plan', description: 'd' });
+  const seed = await call(client, 'issue_create', { agent: 'bro', objective: 'plan', description: 'd', labels: ['Feature', 'Priority: Medium'] });
   const batch = await call(client, 'task_create_batch', {
     agent: 'bro',
     waive_scope_gate: true, waive_scope_gate_reason: 'role-matrix test seed',
@@ -200,7 +200,7 @@ test('validation_record — pr-reviewer only; architect/bro/swe all forbidden', 
   const { client, close } = await startClient();
   t.after(async () => { await close(); });
 
-  const seed = await call(client, 'issue_create', { agent: 'bro', objective: 'plan', description: 'd' });
+  const seed = await call(client, 'issue_create', { agent: 'bro', objective: 'plan', description: 'd', labels: ['Feature', 'Priority: Medium'] });
   const batch = await call(client, 'task_create_batch', {
     agent: 'bro',
     waive_scope_gate: true, waive_scope_gate_reason: 'role-matrix test seed',

--- a/tests/l3-integration/mcp/scope-gate.test.mjs
+++ b/tests/l3-integration/mcp/scope-gate.test.mjs
@@ -20,6 +20,7 @@ test('issue_create returns a single id (no issue_string_id ghost field)', async 
     agent: 'bro',
     objective: 'smoke',
     description: 'x',
+    labels: ['Feature', 'Priority: Medium'],
   });
 
   assert.equal(result.ok, true, `issue_create: ${JSON.stringify(result)}`);
@@ -39,6 +40,7 @@ test('discussion_append chronology: answer rows have a preceding question row', 
     agent: 'bro',
     objective: 'chronology test',
     description: 'x',
+    labels: ['Feature', 'Priority: Medium'],
   });
   const issueId = issue.data.id;
 
@@ -94,6 +96,7 @@ test('task_create_batch — rejects when issue has 0 question rows and no waiver
     agent: 'bro',
     objective: 'gate test — no questions seeded',
     description: 'x',
+    labels: ['Feature', 'Priority: Medium'],
   });
   const issueId = issue.data.id;
 
@@ -125,6 +128,7 @@ test('task_create_batch — accepts when a kind=question row exists', async (t) 
     agent: 'bro',
     objective: 'gate test — questions seeded',
     description: 'x',
+    labels: ['Feature', 'Priority: Medium'],
   });
   const issueId = issue.data.id;
 
@@ -167,6 +171,7 @@ test('task_create_batch — accepts with waiver + reason ≥10 chars', async (t)
     agent: 'bro',
     objective: 'typo fix',
     description: 'x',
+    labels: ['Feature', 'Priority: Medium'],
   });
   const issueId = issue.data.id;
 
@@ -195,6 +200,7 @@ test('task_create_batch — rejects waiver with missing/short reason', async (t)
     agent: 'bro',
     objective: 'trivial',
     description: 'x',
+    labels: ['Feature', 'Priority: Medium'],
   });
   const issueId = issue.data.id;
 
@@ -250,6 +256,7 @@ test('task_create_batch — registry_cold_gate rejects when no deep_scan_complet
     agent: 'bro',
     objective: 'gated',
     description: 'gate test',
+    labels: ['Feature', 'Priority: Medium'],
   });
   assert.equal(issue.ok, true);
 
@@ -275,6 +282,7 @@ test('task_create_batch — registry_cold_gate clears after a deep_scan_complete
     agent: 'bro',
     objective: 'unlock',
     description: 'gate clear test',
+    labels: ['Feature', 'Priority: Medium'],
   });
   assert.equal(issue.ok, true);
 
@@ -315,6 +323,7 @@ test('task_create_batch — waive_registry_gate accepts an explicit reason ≥10
     agent: 'bro',
     objective: 'waive',
     description: 'waive test',
+    labels: ['Feature', 'Priority: Medium'],
   });
   assert.equal(issue.ok, true);
 
@@ -344,6 +353,7 @@ test('task_create_batch — waive_registry_gate rejects too-short reason', async
     agent: 'bro',
     objective: 'waive-bad',
     description: 'waive too short',
+    labels: ['Feature', 'Priority: Medium'],
   });
   assert.equal(issue.ok, true);
 
@@ -372,6 +382,7 @@ test('task_create_batch — intent_gate rejects when no kind=intent discussion e
     agent: 'bro',
     objective: 'intent-gate test',
     description: 'x',
+    labels: ['Feature', 'Priority: Medium'],
   });
   const issueId = issue.data.id;
 
@@ -408,6 +419,7 @@ test('task_create_batch — decision_gate rejects when no kind=decision discussi
     agent: 'bro',
     objective: 'decision-gate universal test',
     description: 'x',
+    labels: ['Feature', 'Priority: Medium'],
   });
   const issueId = issue.data.id;
 
@@ -443,6 +455,7 @@ test('task_create_batch — decision_gate clears when a kind=decision discussion
     agent: 'bro',
     objective: 'decision-gate clear test',
     description: 'x',
+    labels: ['Feature', 'Priority: Medium'],
   });
   const issueId = issue.data.id;
 
@@ -482,6 +495,7 @@ test('roundtable_create — slash-invoke gate rejects when no /roundtable was ty
     agent: 'bro',
     objective: 'roundtable gate test',
     description: 'x',
+    labels: ['Feature', 'Priority: Medium'],
   });
   const issueId = issue.data.id;
 
@@ -503,6 +517,7 @@ test('roundtable_create — slash-invoke gate clears after a /roundtable audit l
     agent: 'bro',
     objective: 'roundtable gate clear test',
     description: 'x',
+    labels: ['Feature', 'Priority: Medium'],
   });
   const issueId = issue.data.id;
 
@@ -532,6 +547,7 @@ test('roundtable_create — waive_slash_gate accepts an explicit reason ≥10 ch
     agent: 'bro',
     objective: 'waive test',
     description: 'x',
+    labels: ['Feature', 'Priority: Medium'],
   });
   const issueId = issue.data.id;
 

--- a/tests/l3-integration/mcp/search-tools.test.mjs
+++ b/tests/l3-integration/mcp/search-tools.test.mjs
@@ -16,6 +16,7 @@ async function seedIssue(client) {
     agent: 'bro',
     objective: 'search-tools test fixture',
     description: 'fixture for search integration tests',
+    labels: ['Feature', 'Priority: Medium'],
   });
   assert.equal(r.ok, true, `seed issue: ${JSON.stringify(r)}`);
   return r.data.id;

--- a/tests/l4-workflow-sim/flow-02-simple-task.test.mjs
+++ b/tests/l4-workflow-sim/flow-02-simple-task.test.mjs
@@ -21,6 +21,7 @@ test('Flow 2 — simple task: bro plans → swe completes → bro closes (no per
     agent: 'bro',
     objective: 'Add /hello endpoint',
     description: 'Single-file route, no architecture impact.',
+    labels: ['Feature', 'Priority: Medium'],
   });
   assert.equal(issue.ok, true, `issue_create: ${JSON.stringify(issue)}`);
   const issueId = issue.data.id;

--- a/tests/l4-workflow-sim/flow-06-push-gate.test.mjs
+++ b/tests/l4-workflow-sim/flow-06-push-gate.test.mjs
@@ -24,6 +24,7 @@ test('Flow 6 — push gate: bro closes → unsigned commits → pr-reviewer sign
   // Setup: 2 closed tasks ready to push (simulating Flow 2 already ran twice)
   const issue = await call(client, 'issue_create', {
     agent: 'bro', objective: 'Two things', description: 'd',
+    labels: ['Feature', 'Priority: Medium'],
   });
   const issueId = issue.data.id;
 
@@ -106,7 +107,7 @@ test('Flow 6 fail-path — pr-reviewer FAIL verdict triggers retry signal in nex
   const { client, close } = await startClient();
   t.after(async () => { await close(); });
 
-  const issue = await call(client, 'issue_create', { agent: 'bro', objective: 'X', description: 'd' });
+  const issue = await call(client, 'issue_create', { agent: 'bro', objective: 'X', description: 'd', labels: ['Feature', 'Priority: Medium'] });
   const issueId = issue.data.id;
   const batch = await call(client, 'task_create_batch', {
     agent: 'bro', issue_id: issueId,

--- a/tests/l4-workflow-sim/flow-08-swe-retry.test.mjs
+++ b/tests/l4-workflow-sim/flow-08-swe-retry.test.mjs
@@ -12,7 +12,7 @@ import assert from 'node:assert/strict';
 import { startClient, call } from '../l3-integration/mcp/harness.mjs';
 
 async function setupClosedTask(client, branch, sha) {
-  const issue = await call(client, 'issue_create', { agent: 'bro', objective: 'X', description: 'd' });
+  const issue = await call(client, 'issue_create', { agent: 'bro', objective: 'X', description: 'd', labels: ['Feature', 'Priority: Medium'] });
   const issueId = issue.data.id;
   const batch = await call(client, 'task_create_batch', {
     agent: 'bro', issue_id: issueId,

--- a/tests/l4-workflow-sim/flow-09-anonymous-cold-restart.test.mjs
+++ b/tests/l4-workflow-sim/flow-09-anonymous-cold-restart.test.mjs
@@ -39,6 +39,7 @@ test('Flow 09b — Bro forbidden from validation_record (issue #96 server enforc
     agent: 'bro',
     objective: 'Verify role enforcement',
     description: 'Confirm validation_record rejects non-pr-reviewer callers.',
+    labels: ['Feature', 'Priority: Medium'],
   });
   assert.equal(issue.ok, true);
 
@@ -93,6 +94,7 @@ test('Flow 09c — Bro task-gate uses audit_log(bro_verification_pass), not vali
     agent: 'bro',
     objective: 'Verify bro_verification_pass audit event',
     description: 'Bro must record its task-gate verdict in audit, not in validation_attempts.',
+    labels: ['Feature', 'Priority: Medium'],
   });
   const issueId = issue.data.id;
 

--- a/tests/l4-workflow-sim/flow-10-roundtable-composite.test.mjs
+++ b/tests/l4-workflow-sim/flow-10-roundtable-composite.test.mjs
@@ -22,6 +22,7 @@ test('Flow 10 — roundtable_close_with_decisions composite: create→vote→com
     agent: 'bro',
     objective: 'Decide on new architecture approach',
     description: 'Roundtable composite test carrier.',
+    labels: ['Feature', 'Priority: Medium'],
   });
   assert.equal(issue.ok, true, `issue_create: ${JSON.stringify(issue)}`);
   const issueId = issue.data.id;


### PR DESCRIPTION
Closes GH #904. Adds labels: ['Feature','Priority: Medium'] to 35 issue_create calls across tests/l3-integration/mcp + tests/l4-workflow-sim that lacked them after #903 made the label gate fail-closed. Labels added to failure-expecting calls too, so each asserted error stays the intended one. L3 70/0, L4 flows green, zero missing_required_labels. pr-reviewer PASS (validation 213). (The 6 pre-existing L1 lint fails are fixed separately in #905.)

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)