### PR TITLE
test: refresh stale session-start-prescan goldens (retired arch-docs line) (#908)

### DIFF
--- a/tests/l3-integration/hooks/fixtures/session-start-prescan.golden.txt
+++ b/tests/l3-integration/hooks/fixtures/session-start-prescan.golden.txt
@@ -2,7 +2,6 @@
 Plugin version: __VOLATILE__
 Top-level dirs: __VOLATILE__
 Stacks detected: __VOLATILE__
-Architecture docs: __VOLATILE__
 World model: __VOLATILE__
 Git branch: __VOLATILE__
 Open issues: __VOLATILE__

--- a/tests/l3-integration/hooks/hook-content-preservation.test.sh
+++ b/tests/l3-integration/hooks/hook-content-preservation.test.sh
@@ -33,7 +33,6 @@ mask_session_start_prescan() {
         -e 's/Plugin version:.*/Plugin version: __VOLATILE__/' \
         -e 's/Top-level dirs:.*/Top-level dirs: __VOLATILE__/' \
         -e 's/Stacks detected:.*/Stacks detected: __VOLATILE__/' \
-        -e 's/Architecture docs:.*/Architecture docs: __VOLATILE__/' \
         -e 's/World model:.*/World model: __VOLATILE__/' \
         -e 's/Git branch:.*/Git branch: __VOLATILE__/' \
         -e 's/Open issues:.*/Open issues: __VOLATILE__/' \

--- a/tests/l3-integration/hooks/session-start-prescan.test.sh
+++ b/tests/l3-integration/hooks/session-start-prescan.test.sh
@@ -123,9 +123,6 @@ assert_contains "$CTX" "Top-level dirs:" "Top-level dirs line present"
 test_case "stable: Stacks detected line present"
 assert_contains "$CTX" "Stacks detected:" "Stacks detected line present"
 
-test_case "stable: Architecture docs line present"
-assert_contains "$CTX" "Architecture docs:" "Architecture docs line present"
-
 test_case "stable: World model line present"
 assert_contains "$CTX" "World model:" "World model line present"
 


### PR DESCRIPTION
Closes GH #908. After #135/#140 removed the Architecture docs banner from session-start-prescan.sh, 2 L3 hook tests still expected it. Removes the stale 'Architecture docs line present' case + the dead golden line + the dead sed mask rule. All 65 hook test files pass. pr-reviewer PASS (validation 215). Last L0-L4 green-blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)