### PR TITLE
📝 docs(planning): document the SWE-spawn contract in tmb_planning §5 [PROMPT — review]

### DIFF
--- a/skills/tmb_planning/SKILL.md
+++ b/skills/tmb_planning/SKILL.md
@@ -83,6 +83,15 @@ Then run the worktree hook per branch and spawn SWE per task.
 
 The batch response includes `parallel_groups` — tasks in the same group are safe to spawn in parallel.
 
+### Spawning SWE
+
+The Agent PreToolUse gates enforce a spawn contract — get all four right or the first spawn is denied:
+
+- The spawn prompt MUST contain the literal `task_id=<N>` — a bare `task_id 5` without `=` fails the gate.
+- Pre-create the feature branch before spawning: `git -C <repo> branch <branch> origin/<base>`. Required even when the task-create branch gate was waived — waiving the DB gate doesn't create the git ref.
+- The task must be `pending`/`open` with a non-empty `spec_body`.
+- The worktree is auto-created by the spawn hook — don't `EnterWorktree` manually.
+
 ## 6. Verify on SWE return + atomic close
 
 After SWE returns `status=completed`, pull the work (`task_get` plus a `git diff` of the commit) and judge it against the spec on four counts:


### PR DESCRIPTION
## ⚠️ Prompt-surface PR — for your review (not auto-merged)

Documents the SWE-spawn contract in `tmb_planning §5` (trajectory #153 / GH #919) so bro stops failing its first swe spawn each session.

**The added block (the exact text to review):**
> ### Spawning SWE
> The Agent PreToolUse gates enforce a spawn contract — get all four right or the first spawn is denied:
> - The spawn prompt MUST contain the literal `task_id=<N>` — a bare `task_id 5` without `=` fails the gate.
> - Pre-create the feature branch before spawning: `git -C <repo> branch <branch> origin/<base>`. Required even when the task-create branch gate was waived — waiving the DB gate doesn't create the git ref.
> - The task must be `pending`/`open` with a non-empty `spec_body`.
> - The worktree is auto-created by the spawn hook — don't `EnterWorktree` manually.

+9 lines, single file. No issue-number citations (per convention); §1–6 structure intact; link-check passes.

pr-reviewer PASS (validation 223) — each point independently verified against the actual `require-task-spec.sh` / `require-feature-branch-active.sh` / `ensure-swe-worktree.sh` source.

Born from hitting this denial repeatedly this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)