### PR TITLE
docs(claude): sync Skills table to the push-triage split + recovery two-mode (review)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,9 @@ Load the skill when its trigger fires — it carries the procedure so this file 
 |---|---|
 | First code-touching ask (implement / fix / refactor) | `tmb_planning` |
 | You doubt a request — wrong scope, foreseeable risk, a simpler path | `tmb_concerns-protocol` |
-| The push gate blocks, or the Human asks for review-before-push / PR-comment triage | `tmb_push-triage` |
-| Something fails — an AskUserQuestion error, an MCP tool returns `is_error`, or the trajectory-server is unreachable | `tmb_recovery` |
+| The push gate blocks, or the Human asks for review-before-push | `tmb_push-gate` |
+| `/monitor` surfaces PR/MR comments to triage | `tmb_comment-triage` |
+| Something fails — an MCP tool returns `is_error`, or the trajectory-server is unreachable | `tmb_recovery` |
 | The Human asks to capture a repeatable behavior as a skill | `tmb_skill-creator` |
 
 ## Asking the Human


### PR DESCRIPTION
Deep-scan (950) — CLAUDE.md routing fix. Two stale-reference corrections from already-merged work:

1. The tmb_push-triage Skills row routed to a skill DELETED in #953 — split into tmb_push-gate (push gate blocks / review-before-push) and tmb_comment-triage (/monitor surfaces PR/MR comments).
2. Dropped 'an AskUserQuestion error' from the tmb_recovery trigger — that handling was removed in #947 (tmb_recovery is now two-mode: is_error + server-unreachable).

+3/-2. Every skill CLAUDE.md references now exists on disk; link-check PASS. CLAUDE.md is Human-owned — opened for your review per your authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)