### PR TITLE
test(l6): require task_provision not task_create_batch in 5 planning-row fixtures

### DIFF
--- a/tests/l5-l6/rows/04-first-task-hits-gate/tools-required.json
+++ b/tests/l5-l6/rows/04-first-task-hits-gate/tools-required.json
@@ -1,4 +1,4 @@
 [
   {"tool": "mcp__plugin_tmb_trajectory-server__scan_run", "skip_if_pre_state_sql": "SELECT 1 FROM audit WHERE event_type='deep_scan_completed' LIMIT 1"},
-  "mcp__plugin_tmb_trajectory-server__task_create_batch"
+  "mcp__plugin_tmb_trajectory-server__task_provision"
 ]

--- a/tests/l5-l6/rows/08-architectural-change/tools-required.json
+++ b/tests/l5-l6/rows/08-architectural-change/tools-required.json
@@ -1,5 +1,5 @@
 [
   "mcp__plugin_tmb_trajectory-server__discussion_append",
-  "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
   "Agent"
 ]

--- a/tests/l5-l6/rows/16-difficult-task/tools-required.json
+++ b/tests/l5-l6/rows/16-difficult-task/tools-required.json
@@ -1,6 +1,6 @@
 [
   "mcp__plugin_tmb_trajectory-server__issue_create",
-  "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
   "mcp__plugin_tmb_trajectory-server__discussion_append",
   "mcp__plugin_tmb_trajectory-server__audit_append"
 ]

--- a/tests/l5-l6/rows/42-typed-rails/tools-required.json
+++ b/tests/l5-l6/rows/42-typed-rails/tools-required.json
@@ -1,4 +1,4 @@
 [
-  "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
   "mcp__plugin_tmb_trajectory-server__issue_create"
 ]

--- a/tests/l5-l6/rows/92-base-branch/tools-required.json
+++ b/tests/l5-l6/rows/92-base-branch/tools-required.json
@@ -1,4 +1,4 @@
 [
-  "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
   "mcp__plugin_tmb_trajectory-server__issue_create"
 ]


### PR DESCRIPTION
Fixes L6 fixture-lag from the merged composite-rename batch. Five tools-required.json files now require task_provision (the tool tmb_planning drives) instead of the renamed task_create_batch. Test-only; pr-reviewer PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)