### PR TITLE
test(l6): drop stale discussion_append from 2 planning-row fixtures

### DIFF
--- a/tests/l5-l6/rows/08-architectural-change/tools-required.json
+++ b/tests/l5-l6/rows/08-architectural-change/tools-required.json
@@ -1,5 +1,4 @@
 [
-  "mcp__plugin_tmb_trajectory-server__discussion_append",
   "mcp__plugin_tmb_trajectory-server__task_provision",
   "Agent"
 ]

--- a/tests/l5-l6/rows/16-difficult-task/tools-required.json
+++ b/tests/l5-l6/rows/16-difficult-task/tools-required.json
@@ -1,6 +1,5 @@
 [
   "mcp__plugin_tmb_trajectory-server__issue_create",
   "mcp__plugin_tmb_trajectory-server__task_provision",
-  "mcp__plugin_tmb_trajectory-server__discussion_append",
   "mcp__plugin_tmb_trajectory-server__audit_append"
 ]


### PR DESCRIPTION
The planning/architectural decision now rides in task_provision decision_body, so bro no longer calls discussion_append separately in the planning flow. Removes the stale required-tool entry from 08-architectural-change and 16-difficult-task; 09-concerns-protocol intentionally keeps it (mechanism under test). Test-only; pr-reviewer PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)