### PR TITLE
test(l6): v0.10.0 alignment — forbidden +task_provision, scorer comments, 13-search seed id capture

### DIFF
--- a/tests/l5-l6/rows/01-cold-start/tools-forbidden.json
+++ b/tests/l5-l6/rows/01-cold-start/tools-forbidden.json
@@ -1,5 +1,6 @@
 [
   "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
   "mcp__plugin_tmb_trajectory-server__issue_create",
   "Agent"
 ]

--- a/tests/l5-l6/rows/02-reonboard-implicit-from-local/tools-forbidden.json
+++ b/tests/l5-l6/rows/02-reonboard-implicit-from-local/tools-forbidden.json
@@ -1,5 +1,6 @@
 [
   "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
   "mcp__plugin_tmb_trajectory-server__issue_create",
   "Agent"
 ]

--- a/tests/l5-l6/rows/03-reonboard-remote/tools-forbidden.json
+++ b/tests/l5-l6/rows/03-reonboard-remote/tools-forbidden.json
@@ -1,5 +1,6 @@
 [
   "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
   "mcp__plugin_tmb_trajectory-server__issue_create",
   "Agent"
 ]

--- a/tests/l5-l6/rows/04-first-task-hits-gate/outcome.sql
+++ b/tests/l5-l6/rows/04-first-task-hits-gate/outcome.sql
@@ -1,5 +1,5 @@
 -- 04-first-task-hits-gate — bro responds to the registry-cold gate by
--- running /scan, then plans + dispatches via task_create_batch. The
+-- running /scan, then plans + dispatches via task_provision. The
 -- prompt is a natural full-feature ask ("make a todo CLI"), so bro
 -- typically also spawns SWE + atomic-closes in the same turn — that's
 -- not exclusive with step 05 (which adds a feature on top); step 05's

--- a/tests/l5-l6/rows/05-swe-atomic-close/outcome.sql
+++ b/tests/l5-l6/rows/05-swe-atomic-close/outcome.sql
@@ -1,5 +1,5 @@
 -- 05-swe-atomic-close — covers BOTH dispatch (#14) and SubagentStop bookkeeping (#15).
--- (1) bro must spawn SWE after task_create_batch — tasks should not stay pending.
+-- (1) bro must spawn SWE after task_provision — tasks should not stay pending.
 SELECT
   CASE WHEN COUNT(*) >= 1 THEN 1 ELSE 0 END AS pass,
   'tasks created (got ' || COUNT(*) || ', expected >=1)' AS description

--- a/tests/l5-l6/rows/06-post-close-cleanup/tools-forbidden.json
+++ b/tests/l5-l6/rows/06-post-close-cleanup/tools-forbidden.json
@@ -1,5 +1,6 @@
 [
   "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
   "mcp__plugin_tmb_trajectory-server__issue_create",
   "Agent"
 ]

--- a/tests/l5-l6/rows/08-architectural-change/outcome.sql
+++ b/tests/l5-l6/rows/08-architectural-change/outcome.sql
@@ -7,7 +7,7 @@ SELECT
 FROM discussions
 WHERE kind = 'decision';
 
--- And a task lands (bro called task_create_batch successfully — gate cleared).
+-- And a task lands (bro called task_provision successfully — gate cleared).
 SELECT
   CASE WHEN COUNT(*) >= 1 THEN 1 ELSE 0 END AS pass,
   'tasks created (got ' || COUNT(*) || ', expected >=1)' AS description

--- a/tests/l5-l6/rows/10-consultant/tools-forbidden.json
+++ b/tests/l5-l6/rows/10-consultant/tools-forbidden.json
@@ -1,4 +1,5 @@
 [
   "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
   "mcp__plugin_tmb_trajectory-server__validation_record"
 ]

--- a/tests/l5-l6/rows/11-roundtable/tools-forbidden.json
+++ b/tests/l5-l6/rows/11-roundtable/tools-forbidden.json
@@ -1,3 +1,4 @@
 [
-  "mcp__plugin_tmb_trajectory-server__task_create_batch"
+  "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision"
 ]

--- a/tests/l5-l6/rows/12-issue-resume/outcome.sql
+++ b/tests/l5-l6/rows/12-issue-resume/outcome.sql
@@ -3,7 +3,7 @@
 -- dispatches SWE without re-planning.
 --
 -- The load-bearing "didn't replan" signal lives in tools-forbidden
--- (issue_create, task_create_batch). This SQL asserts the existing
+-- (issue_create, task_provision). This SQL asserts the existing
 -- count-subcommand task remains intact + was actually picked up.
 
 SELECT

--- a/tests/l5-l6/rows/12-issue-resume/tools-forbidden.json
+++ b/tests/l5-l6/rows/12-issue-resume/tools-forbidden.json
@@ -1,4 +1,5 @@
 [
   "mcp__plugin_tmb_trajectory-server__issue_create",
-  "mcp__plugin_tmb_trajectory-server__task_create_batch"
+  "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision"
 ]

--- a/tests/l5-l6/rows/13-search-grounding/setup-l5.sh
+++ b/tests/l5-l6/rows/13-search-grounding/setup-l5.sh
@@ -24,7 +24,7 @@ DB="$PROJECT/.claude/tmb/trajectory.db"
 ISSUE_ID=$(sqlite3 "$DB" \
   "SELECT id FROM issues ORDER BY id LIMIT 1;" 2>/dev/null)
 if [ -z "$ISSUE_ID" ]; then
-  sqlite3 "$DB" <<SQL
+  ISSUE_ID=$(sqlite3 "$DB" <<SQL
 INSERT INTO issues (objective, description, status, created_at, updated_at)
 VALUES (
   'Extract storage layer into backend interface',
@@ -33,12 +33,13 @@ VALUES (
   datetime('now', '-2 hours'),
   datetime('now', '-2 hours')
 );
+SELECT last_insert_rowid();
 SQL
-  ISSUE_ID=$(sqlite3 "$DB" "SELECT last_insert_rowid();")
+)
 fi
 
 # Insert the kind='decision' discussion mirroring step 08's decision body.
-sqlite3 "$DB" <<SQL
+DISCUSSION_ID=$(sqlite3 "$DB" <<SQL
 INSERT INTO discussions (issue_id, author, kind, body, created_at)
 VALUES (
   $ISSUE_ID,
@@ -47,9 +48,9 @@ VALUES (
   'Decision: extract storage into a backend interface (StorageBackend ABC) with a JsonFileBackend default implementation. Factory function selects backend at runtime. Rationale: (1) decouples command handlers from persistence detail; (2) makes SQLite swap-in a targeted change; (3) preserves back-compat for existing ~/.todo-cli/todos.json files via JsonFileBackend.',
   datetime('now', '-1 hour')
 );
+SELECT last_insert_rowid();
 SQL
-
-DISCUSSION_ID=$(sqlite3 "$DB" "SELECT last_insert_rowid();")
+)
 
 # Seed a stub embedding for the decision row so discussion_search returns it
 # deterministically without a real ONNX call. zeroblob(1536*4) = 6144 zero

--- a/tests/l5-l6/rows/13-search-grounding/tools-forbidden.json
+++ b/tests/l5-l6/rows/13-search-grounding/tools-forbidden.json
@@ -1,3 +1,4 @@
 [
-  "mcp__plugin_tmb_trajectory-server__task_create_batch"
+  "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision"
 ]

--- a/tests/l5-l6/rows/17-agent-creator/tools-forbidden.json
+++ b/tests/l5-l6/rows/17-agent-creator/tools-forbidden.json
@@ -1,5 +1,6 @@
 [
   "mcp__plugin_tmb_trajectory-server__task_update_status",
   "mcp__plugin_tmb_trajectory-server__validation_record",
-  "mcp__plugin_tmb_trajectory-server__task_create_batch"
+  "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision"
 ]

--- a/tests/l5-l6/rows/18-skill-creation/tools-forbidden.json
+++ b/tests/l5-l6/rows/18-skill-creation/tools-forbidden.json
@@ -1,4 +1,5 @@
 [
   "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
   "mcp__plugin_tmb_trajectory-server__validation_record"
 ]

--- a/tests/l5-l6/rows/20-codebase-memory-cold-start/outcome.sql
+++ b/tests/l5-l6/rows/20-codebase-memory-cold-start/outcome.sql
@@ -1,6 +1,6 @@
 -- 20-codebase-memory-cold-start (ADR 0001 — world-model rewrite of #45)
 -- Existing repo + identity present + world model cold + test mode.
--- Bro must self-fire scan_run (no Human to ask) before task_create_batch
+-- Bro must self-fire scan_run (no Human to ask) before task_provision
 -- because the server-enforced world-model-cold gate would otherwise block.
 -- After scan, planning + dispatch proceeds normally.
 

--- a/tests/l5-l6/rows/32-team-config/tools-forbidden.json
+++ b/tests/l5-l6/rows/32-team-config/tools-forbidden.json
@@ -1,4 +1,5 @@
 [
   "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
   "mcp__plugin_tmb_trajectory-server__validation_record"
 ]

--- a/tests/l5-l6/rows/33-multirepo-commit/tools-forbidden.json
+++ b/tests/l5-l6/rows/33-multirepo-commit/tools-forbidden.json
@@ -1,4 +1,5 @@
 [
   "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
   "mcp__plugin_tmb_trajectory-server__validation_record"
 ]

--- a/tests/l5-l6/rows/42-typed-rails/outcome.sql
+++ b/tests/l5-l6/rows/42-typed-rails/outcome.sql
@@ -1,4 +1,4 @@
--- 42-typed-rails (#673): a code-touching ask flows through task_create_batch.
+-- 42-typed-rails (#673): a code-touching ask flows through task_provision.
 -- The created task row must carry the typed files/verification columns, and
 -- each must hold a valid JSON array (the typed-field contract). Pre-migration
 -- markdown scraping is gone; files/verification are columns, not spec_body prose.

--- a/tests/l5-l6/rows/consultant-ad-hoc/tools-forbidden.json
+++ b/tests/l5-l6/rows/consultant-ad-hoc/tools-forbidden.json
@@ -1,4 +1,5 @@
 [
   "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
   "mcp__plugin_tmb_trajectory-server__validation_record"
 ]

--- a/tests/l5-l6/rows/misc-reonboard-redirect/tools-forbidden.json
+++ b/tests/l5-l6/rows/misc-reonboard-redirect/tools-forbidden.json
@@ -2,5 +2,6 @@
   "mcp__plugin_tmb_trajectory-server__onboard_apply",
   "mcp__plugin_tmb_trajectory-server__onboard_get_questions",
   "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
   "mcp__plugin_tmb_trajectory-server__issue_create"
 ]


### PR DESCRIPTION
Deep-review alignment batch (test-only, 21 files). A: 14 no-task tools-forbidden.json now also forbid task_provision (closes the post-rename coverage gap). B: 6 outcome.sql comments updated task_create_batch→task_provision (SQL unchanged). C: 13-search-grounding seed captures ids in the same sqlite3 call as the INSERT, fixing a last_insert_rowid()=0 orphan (foreign_key_check now clean). pr-reviewer PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)