### PR TITLE
fix(hooks): repo-rooted worktree resolution across closers + worktree-create

### DIFF
--- a/scripts/hooks/cleanup-worktree-on-task-close.sh
+++ b/scripts/hooks/cleanup-worktree-on-task-close.sh
@@ -82,11 +82,11 @@ fi
 [ -d "$REPO_ROOT/.git" ] || exit 0
 
 SLUG="${BRANCH_ID#*/}"
-# The regex tolerates both repo-rooted (legacy: <repo>/.claude/worktrees/<slug>)
-# and workspace-rooted (current: <workspace>/.claude/worktrees/<slug>) paths
-# because both end in `/.claude/worktrees/<slug>`. After all stale repo-rooted
-# worktrees are pruned (see scripts/maintenance/cleanup-stale-worktrees.sh),
-# only workspace-rooted ones remain.
+# Worktrees are created repo-rooted at <repo>/.claude/worktrees/<slug> by the
+# creators (ensure-swe-worktree.sh / MCP task_provision). `git worktree list`
+# enumerates them by git's own tracking regardless of physical location, so the
+# slug-suffix match below locates the worktree by its `/.claude/worktrees/<slug>`
+# tail without assuming any particular root.
 WORKTREE_PATH=$(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | awk -v slug="$SLUG" '
   /^worktree / {
     wt = substr($0, 10);

--- a/scripts/hooks/swe-atomic-close.sh
+++ b/scripts/hooks/swe-atomic-close.sh
@@ -28,8 +28,6 @@ PLUGIN_NAME=$(tmb_resolve_plugin_name)
 . "$SCRIPT_DIR/lib/query-task.sh" 2>/dev/null || true
 # shellcheck source=scripts/hooks/lib/normalize-role.sh disable=SC1091
 . "$SCRIPT_DIR/lib/normalize-role.sh" 2>/dev/null || true
-# shellcheck source=scripts/hooks/lib/resolve-workspace.sh disable=SC1091
-. "$SCRIPT_DIR/lib/resolve-workspace.sh" 2>/dev/null || true
 
 mkdir -p "${HOME}/.claude/${PLUGIN_NAME}/logs" 2>/dev/null || true
 
@@ -240,29 +238,29 @@ fi
 
 # Derive the worktree path: slug = everything after the last '/' in branch_id.
 SLUG="${BRANCH##*/}"
-# Resolve workspace root via shared lib (dirname×3 of DB).
-# In a workspace-above-repo layout (repo at <ws>/plugin, worktrees at
-# <ws>/.claude/worktrees) REPO_ROOT points into the inner repo while
-# worktrees live at the workspace root one level up.
-WS_ROOT=""
-if command -v tmb_workspace_root >/dev/null 2>&1 && [ -n "$DB" ]; then
-  WS_ROOT=$(tmb_workspace_root "$DB" || true)
-fi
-# Sentinel fallback: subagents that inherit cwd=~ and lack env vars.
-if [ -n "$WS_ROOT" ] && [ ! -d "${WS_ROOT}/.claude/worktrees/${SLUG}" ]; then
+# Resolve the worktree from the TASK'S REPO, repo-rooted, mirroring the creators
+# (ensure-swe-worktree.sh / MCP task_provision) and swe-verification-gate.sh:
+# the worktree lives at <repoRoot>/.claude/worktrees/<slug>. REPO_ROOT was
+# resolved above from tasks.repo → repos.path (single-repo: repo == workspace).
+WT_PATH="${REPO_ROOT}/.claude/worktrees/${SLUG}"
+
+# Sentinel fallback: subagents that inherit cwd=~ and lack env vars use the
+# active-workspace sentinel written by the plugin at launch time. The sentinel
+# names the workspace root; the worktree still hangs off the repo subdir, so
+# join the resolved TASK_REPO (single-repo: the workspace root is the repo).
+if [ ! -d "$WT_PATH" ]; then
   _SENTINEL="${HOME}/.claude/${PLUGIN_NAME}-active-workspace"
   if [ -f "$_SENTINEL" ]; then
     _WS_SENTINEL=$(head -1 "$_SENTINEL" 2>/dev/null || true)
-    if [ -n "$_WS_SENTINEL" ] && [ -d "${_WS_SENTINEL}/.claude/worktrees/${SLUG}" ]; then
-      WS_ROOT="$_WS_SENTINEL"
+    if [ -n "$_WS_SENTINEL" ]; then
+      for _cand in "${_WS_SENTINEL}/${TASK_REPO}" "$_WS_SENTINEL"; do
+        if [ -n "$_cand" ] && [ -d "${_cand}/.claude/worktrees/${SLUG}" ]; then
+          WT_PATH="${_cand}/.claude/worktrees/${SLUG}"
+          break
+        fi
+      done
     fi
   fi
-fi
-# Fall back to REPO_ROOT if WS_ROOT is empty (preserves previous behavior).
-if [ -n "$WS_ROOT" ]; then
-  WT_PATH="${WS_ROOT}/.claude/worktrees/${SLUG}"
-else
-  WT_PATH="${REPO_ROOT}/.claude/worktrees/${SLUG}"
 fi
 
 # Read the SWE's worktree HEAD.

--- a/scripts/hooks/worktree-create.sh
+++ b/scripts/hooks/worktree-create.sh
@@ -24,8 +24,11 @@
 # The worktree attaches to the named branch so SWE's commits advance the branch
 # ref directly and pushes carry the commits.
 #
-# Worktree path: <workspace_root>/.claude/worktrees/<slug>
-# where slug strips the <type>/ prefix (fix/123-foo → 123-foo).
+# Worktree path: <repo_root>/.claude/worktrees/<slug>
+# where slug strips the <type>/ prefix (fix/123-foo → 123-foo). Repo-rooted to
+# match the creators (ensure-swe-worktree.sh / MCP task_provision) and the
+# closers, so a repo nested under the launch workspace (e.g. TMB/plugin under
+# TMB) resolves to one canonical path everywhere.
 #
 # Resolves <repo> relative to the workspace root (dir containing
 # .claude/<plugin>/trajectory.db), found via tmb_db_path walk-up.
@@ -106,7 +109,7 @@ if [ "$TASK_COUNT" = "0" ]; then
   # No matching task — single-repo fallback (repos.path), else workspace root.
   REPO_ABS=$(tmb_repo_single_path "$DB_PATH" 2>/dev/null || true)
   [ -n "$REPO_ABS" ] || REPO_ABS="$WORKSPACE_ROOT"
-  WORKTREE_PATH="$WORKSPACE_ROOT/.claude/worktrees/$SLUG"
+  WORKTREE_PATH="$REPO_ABS/.claude/worktrees/$SLUG"
 else
   REPO=$(sqlite3 "$DB_PATH" \
     "SELECT COALESCE(repo,'') FROM tasks WHERE branch_id='$SAFE_BRANCH' LIMIT 1;" \
@@ -117,7 +120,7 @@ else
   REPO_ABS=$(tmb_repo_resolve_path "$DB_PATH" "$REPO" 2>/dev/null || true)
   [ -n "$REPO_ABS" ] || REPO_ABS="$WORKSPACE_ROOT"
 
-  WORKTREE_PATH="$WORKSPACE_ROOT/.claude/worktrees/$SLUG"
+  WORKTREE_PATH="$REPO_ABS/.claude/worktrees/$SLUG"
 fi
 
 # If the resolved repo isn't a git work tree, fail loudly

--- a/scripts/maintenance/cleanup-stale-worktrees.sh
+++ b/scripts/maintenance/cleanup-stale-worktrees.sh
@@ -1,66 +1,16 @@
 #!/usr/bin/env bash
-# One-time cleanup: remove repo-rooted SWE worktrees left over from before
-# #110 Phase 3 moved them to workspace-rooted paths. Idempotent — safe to
-# re-run; no-ops once all stale worktrees are gone.
+# No-op. Repo-rooted SWE worktrees (<repo>/.claude/worktrees/<slug>) are the
+# CANONICAL layout — created by ensure-swe-worktree.sh / MCP task_provision and
+# resolved by every closer. This script once pruned them as "stale" during the
+# (now-reversed) #110 Phase 3 migration toward workspace-rooted paths; running
+# that pruning today would delete LIVE worktrees, so it is intentionally inert.
 #
 # Usage:
 #   bash scripts/maintenance/cleanup-stale-worktrees.sh
 #
-# Removes:
-#   - <repo>/.claude/worktrees/<slug>/ directories whose worktree refs point
-#     to merged commits (i.e. their branches no longer exist or are merged
-#     into the configured pr_target).
-#   - The corresponding entries from <repo>/.git/worktrees/.
-#
-# Does NOT touch:
-#   - Worktrees with active uncommitted changes
-#   - Worktrees on branches that don't exist locally (pre-existing user state)
-#   - Workspace-rooted worktrees (those are current; not stale)
+# Removes: nothing. Exits 0.
 
 set -euo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
-  echo "Error: not in a git repo"
-  exit 1
-}
-
-WORKTREES_DIR="$REPO_ROOT/.claude/worktrees"
-[ -d "$WORKTREES_DIR" ] || {
-  echo "No $WORKTREES_DIR — nothing to clean"
-  exit 0
-}
-
-echo "Scanning $WORKTREES_DIR for stale repo-rooted worktrees..."
-
-removed=0
-git -C "$REPO_ROOT" worktree list --porcelain | awk '/^worktree / {print substr($0, 10)}' | \
-while IFS= read -r wt_path; do
-  # Only act on worktrees inside <repo>/.claude/worktrees/
-  case "$wt_path" in
-    "$WORKTREES_DIR"/*) ;;
-    *) continue ;;
-  esac
-
-  # Skip if the worktree has uncommitted changes
-  if [ -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)" ]; then
-    echo "  SKIP $wt_path — uncommitted changes"
-    continue
-  fi
-
-  echo "  REMOVE $wt_path"
-  git -C "$REPO_ROOT" worktree remove --force "$wt_path" 2>/dev/null || {
-    echo "    git worktree remove failed; manual cleanup may be needed"
-    continue
-  }
-  removed=$((removed + 1))
-done
-
-# Prune any leftover .git/worktrees/ entries
-git -C "$REPO_ROOT" worktree prune
-echo "Pruned dangling worktree refs"
-
-# Final tidy: remove the worktrees dir if it's empty
-if [ -d "$WORKTREES_DIR" ] && [ -z "$(ls -A "$WORKTREES_DIR" 2>/dev/null)" ]; then
-  rmdir "$WORKTREES_DIR"
-  echo "Removed empty $WORKTREES_DIR"
-fi
+echo "cleanup-stale-worktrees: no-op — repo-rooted worktrees are canonical (the #110 Phase 3 migration was reversed); nothing to clean."
+exit 0

--- a/tests/l3-integration/hooks/cleanup-worktree-on-task-close.test.sh
+++ b/tests/l3-integration/hooks/cleanup-worktree-on-task-close.test.sh
@@ -105,7 +105,7 @@ out=$(run_hook "$(input 'mcp__plugin_tmb-rc_trajectory-server__task_update_statu
 [ ! -d "$REPO/.claude/worktrees/bar" ] || { echo "FAIL: rc-channel match didn't fire"; exit 1; }
 echo "  rc-channel tool name handled"
 
-test_case "TMB workspace shape: workspace-rooted DB + tasks.repo=null + single-repo fallback → worktree removed"
+test_case "#169 nested-repo shape: workspace DB + tasks.repo=plugin + repo-rooted worktree → worktree removed"
 WORKSPACE_TMP=$(mktemp -d -t tmb-ws-XXXX)
 INNER="$WORKSPACE_TMP/plugin"
 mkdir -p "$INNER"
@@ -121,20 +121,24 @@ WS_DB="$WORKSPACE_TMP/.claude/tmb/trajectory.db"
 mkdir -p "$(dirname "$WS_DB")"
 sqlite3 "$WS_DB" "
   CREATE TABLE tasks (id INTEGER PRIMARY KEY, branch_id TEXT NOT NULL, repo TEXT, status TEXT);
-  INSERT INTO tasks (id, branch_id, repo, status) VALUES (20, 'fix/ws-test', NULL, 'completed');
+  INSERT INTO tasks (id, branch_id, repo, status) VALUES (20, 'fix/ws-test', 'plugin', 'completed');
 "
 sqlite3 "$WS_DB" "
   CREATE TABLE repos (name TEXT PRIMARY KEY, path TEXT NOT NULL, target_branch TEXT, protected_branches TEXT);
   INSERT INTO repos (name, path) VALUES ('plugin', '$INNER_ROOT');
 "
+# Worktree is REPO-ROOTED under the inner repo (canonical), not at the workspace root.
+NESTED_WT="$INNER_ROOT/.claude/worktrees/ws-test"
 git -C "$INNER" branch fix/ws-test HEAD
-git -C "$INNER" worktree add -q "$WORKSPACE_TMP/.claude/worktrees/ws-test" fix/ws-test
-[ -d "$WORKSPACE_TMP/.claude/worktrees/ws-test" ] || { echo "FAIL: worktree not created"; exit 1; }
+git -C "$INNER" worktree add -q "$NESTED_WT" fix/ws-test
+[ -d "$NESTED_WT" ] || { echo "FAIL: worktree not created"; exit 1; }
+# The pre-migration workspace-rooted path must NOT exist in the repo-rooted world.
+[ ! -d "$WORKSPACE_TMP/.claude/worktrees/ws-test" ] || { echo "FAIL: unexpected workspace-rooted worktree"; exit 1; }
 out=$(echo "$(input 'mcp__plugin_tmb_trajectory-server__task_update_status' 'bro' 'closed' 20)" \
   | TRAJECTORY_DB_PATH="$WS_DB" bash "$HOOK" 2>&1 || true)
-assert_contains "$out" 'cleaned up worktree' "TMB workspace shape: worktree should be cleaned up"
-[ ! -d "$WORKSPACE_TMP/.claude/worktrees/ws-test" ] || { echo "FAIL: worktree still present in TMB workspace shape"; exit 1; }
-echo "  TMB workspace-rooted worktree removed successfully"
+assert_contains "$out" 'cleaned up worktree' "nested-repo shape: worktree should be cleaned up"
+[ ! -d "$NESTED_WT" ] || { echo "FAIL: repo-rooted worktree still present in nested-repo shape"; exit 1; }
+echo "  nested-repo repo-rooted worktree removed successfully"
 rm -rf "$WORKSPACE_TMP"
 cd "$REPO"
 

--- a/tests/l3-integration/hooks/swe-atomic-close.test.sh
+++ b/tests/l3-integration/hooks/swe-atomic-close.test.sh
@@ -837,17 +837,23 @@ txfirst_status_601=$(sqlite3 "$TXFIRST_DB" "SELECT status FROM tasks WHERE id=60
 assert_eq "pending" "$txfirst_status_601" "task 601 untouched when transcript resolves task 600"
 
 # ========================================================
-# Workspace-above-repo layout: DB two levels above the repo.
-# Reproduces the completion deadlock: WT at <ws>/.claude/worktrees/<slug>,
-# repo at <ws>/inner-repo (REPO_ROOT != WS_ROOT).
+# Nested-repo layout (#169): workspace=$WS, repo=$WS/plugin, repos.path=$WS/plugin,
+# tasks.repo='plugin'. The worktree is REPO-ROOTED at
+# $WS/plugin/.claude/worktrees/<slug>, NOT $WS/.claude/worktrees/<slug>.
+# Pre-fix (WS_ROOT-primary) the hook resolved the workspace path and could not
+# locate the worktree → task stuck pending. This case must fail against the
+# pre-fix code and pass with the repo-rooted resolver.
 # ========================================================
 
-echo '--- Test: workspace-above-repo: worktree at WS_ROOT, not REPO_ROOT → auto-completed ---'
+echo '--- Test: nested-repo: worktree repo-rooted under <ws>/plugin → auto-completed ---'
 
-WS_ROOT_DIR="$TMPDIR/ws-above"
-INNER_REPO="$WS_ROOT_DIR/inner-repo"
+WS_ROOT_DIR="$TMPDIR/nested-ws"
+INNER_REPO="$WS_ROOT_DIR/plugin"
 WS_DB="$WS_ROOT_DIR/.claude/tmb/trajectory.db"
-WS_WT="$WS_ROOT_DIR/.claude/worktrees/ws-task"
+# Repo-rooted worktree: hangs off the inner repo, NOT the workspace root.
+WS_WT="$INNER_REPO/.claude/worktrees/ws-task"
+# Workspace-rooted path that the pre-fix code would (wrongly) look for.
+WS_WRONG_WT="$WS_ROOT_DIR/.claude/worktrees/ws-task"
 
 mkdir -p "$INNER_REPO"
 mkdir -p "$(dirname "$WS_DB")"
@@ -858,6 +864,7 @@ git -C "$INNER_REPO" config user.name t
 echo base > "$INNER_REPO/base.txt"
 git -C "$INNER_REPO" add .
 git -C "$INNER_REPO" commit -qm "base"
+INNER_REPO_ROOT=$(git -C "$INNER_REPO" rev-parse --show-toplevel)
 
 sqlite3 "$WS_DB" "
   CREATE TABLE tasks (
@@ -900,16 +907,17 @@ sqlite3 "$WS_DB" "
     key TEXT PRIMARY KEY,
     value_json TEXT NOT NULL DEFAULT '\"\"'
   );
-  INSERT INTO tasks (id, branch_id, parent_branch_id, status, updated_at)
-    VALUES (700, 'fix/ws-task', 'dev', 'pending', datetime('now', '+1 second'));
+  INSERT INTO repos (name, path) VALUES ('plugin', '$INNER_REPO_ROOT');
+  INSERT INTO tasks (id, branch_id, parent_branch_id, status, repo, updated_at)
+    VALUES (700, 'fix/ws-task', 'dev', 'pending', 'plugin', datetime('now', '+1 second'));
   INSERT INTO plugin_config (key, value_json) VALUES ('pr_target', '\"dev\"');
 "
 
-# Worktree lives at the WS root, not inside the inner repo.
+# Worktree is REPO-ROOTED inside the inner repo (the canonical layout).
 git -C "$INNER_REPO" branch fix/ws-task HEAD
 git -C "$INNER_REPO" worktree add -q "$WS_WT" fix/ws-task
 
-# SWE commits in the workspace-level worktree.
+# SWE commits in the repo-rooted worktree.
 (cd "$WS_WT" && echo "$RANDOM" >> ws-work.txt && git add ws-work.txt && git commit -qm "feat: ws work")
 WS_WT_HEAD=$(git -C "$WS_WT" rev-parse HEAD)
 
@@ -917,12 +925,17 @@ ws_swe_input() {
   jq -n '{agent_type: "tmb:swe", hook_event_name: "SubagentStop"}'
 }
 
-test_case "workspace-above-repo: worktree at WS_ROOT → pending task auto-completed (deadlock fix)"
+test_case "nested-repo: repo-rooted worktree under <ws>/plugin → no workspace-rooted path exists"
+# The workspace-rooted path the pre-fix code targeted must NOT exist, so a hook
+# that resolves it would fail to auto-close.
+if [ ! -d "$WS_WRONG_WT" ]; then _pass; else _fail "workspace-rooted path unexpectedly exists: $WS_WRONG_WT"; fi
+
+test_case "nested-repo: repo-rooted worktree → pending task auto-completed (#169 repo-rooted resolver)"
 out=$(run_hook_in_dir "$INNER_REPO" "$(ws_swe_input)" "$WS_DB")
 assert_eq "" "$out" "no additionalContext on auto-close"
 ws_status=$(sqlite3 "$WS_DB" "SELECT status FROM tasks WHERE id=700;")
-assert_eq "completed" "$ws_status" "task 700 auto-closed via workspace-root worktree path"
+assert_eq "completed" "$ws_status" "task 700 auto-closed via repo-rooted worktree path"
 ws_sha=$(sqlite3 "$WS_DB" "SELECT commit_sha FROM tasks WHERE id=700;")
-assert_eq "$WS_WT_HEAD" "$ws_sha" "commit_sha written from WS_ROOT worktree HEAD"
+assert_eq "$WS_WT_HEAD" "$ws_sha" "commit_sha written from repo-rooted worktree HEAD"
 
 summarize

--- a/tests/l3-integration/hooks/worktree-create.test.sh
+++ b/tests/l3-integration/hooks/worktree-create.test.sh
@@ -123,7 +123,7 @@ case "$no_match_path" in
   *)   _fail "stdout is not an absolute path: '$no_match_path'" ;;
 esac
 assert_contains "$no_match_path" '777-nomatch' "path contains slug"
-NOMATCH_WT="$WORKSPACE/.claude/worktrees/777-nomatch"
+NOMATCH_WT="$INNER_ROOT/.claude/worktrees/777-nomatch"
 if [ -d "$NOMATCH_WT" ]; then _pass; else _fail "worktree not created at $NOMATCH_WT"; fi
 
 test_case "no-match + single-repo fallback: branch auto-created when missing"
@@ -133,7 +133,7 @@ case "$autocreate_path" in
   /*)  _pass "stdout is absolute path" ;;
   *)   _fail "stdout is not an absolute path: '$autocreate_path'" ;;
 esac
-AUTOCREATE_WT="$WORKSPACE/.claude/worktrees/666-autocreate"
+AUTOCREATE_WT="$INNER_ROOT/.claude/worktrees/666-autocreate"
 if [ -d "$AUTOCREATE_WT" ]; then _pass; else _fail "worktree not created at $AUTOCREATE_WT"; fi
 if git -C "$INNER_REPO" show-ref --verify --quiet "refs/heads/feat/666-autocreate" 2>/dev/null; then
   _pass "branch auto-created in inner repo"
@@ -158,7 +158,7 @@ case "$no_repo_path" in
   *)   _fail "stdout is not an absolute path: '$no_repo_path'" ;;
 esac
 assert_contains "$no_repo_path" '456-no-repo' "path contains slug"
-if [ -d "$WORKSPACE/.claude/worktrees/456-no-repo" ]; then _pass; else _fail "worktree not created"; fi
+if [ -d "$INNER_ROOT/.claude/worktrees/456-no-repo" ]; then _pass; else _fail "worktree not created"; fi
 
 test_case "branch matching task with repo set: stdout is bare absolute path"
 task_path=$(echo "$(input_event 'fix/123-with-repo')" | bash "$HOOK" 2>/dev/null)
@@ -169,17 +169,17 @@ esac
 assert_not_contains "$task_path" '"continue"' "stdout must not contain JSON"
 assert_contains "$task_path" '123-with-repo' "path contains slug"
 
-WORKTREE_PATH="$WORKSPACE/.claude/worktrees/123-with-repo"
+WORKTREE_PATH="$INNER_ROOT/.claude/worktrees/123-with-repo"
 if [ -d "$WORKTREE_PATH" ]; then
   _pass
 else
   _fail "worktree directory not created at $WORKTREE_PATH"
 fi
 
-test_case "worktree path is workspace-rooted, not repo-rooted, when workspace != repo"
-REPO_ROOTED_PATH="$INNER_REPO/.claude/worktrees/123-with-repo"
-if [ -d "$REPO_ROOTED_PATH" ]; then
-  _fail "worktree must NOT be created inside inner repo at $REPO_ROOTED_PATH"
+test_case "#169: worktree path is repo-rooted (inside the inner repo), not workspace-rooted, when workspace != repo"
+WS_ROOTED_PATH="$WORKSPACE/.claude/worktrees/123-with-repo"
+if [ -d "$WS_ROOTED_PATH" ]; then
+  _fail "worktree must NOT be created at the workspace root $WS_ROOTED_PATH — it is repo-rooted"
 else
   _pass
 fi
@@ -284,7 +284,7 @@ sqlite3 "$MR_DB" "
 "
 git -C "$MR_REPO" branch fix/330-subdir HEAD
 
-MR_WT="$MR_WORKSPACE/.claude/worktrees/330-subdir"
+MR_WT="$MR_REPO_ROOT/.claude/worktrees/330-subdir"
 
 test_case "#330: multi-repo (session dir is parent of repo subdir): bare path on stdout"
 mr_path=$(echo "$(input_event 'fix/330-subdir')" | TRAJECTORY_DB_PATH="$MR_DB" bash "$HOOK" 2>/dev/null)
@@ -296,14 +296,17 @@ assert_not_contains "$mr_path" '"continue"' "stdout must not contain JSON"
 assert_contains "$mr_path" '330-subdir' "path contains slug"
 if [ -d "$MR_WT" ]; then _pass; else _fail "worktree not created at $MR_WT"; fi
 
+test_case "#330/#169: stdout path is exactly the repo-rooted worktree path (fails pre-fix)"
+assert_eq "$MR_WT" "$mr_path" "hook must emit the repo-rooted path, not the workspace-rooted one"
+
 test_case "#330: subdir-repo worktree HEAD is on the named branch"
 MR_HB=$(git -C "$MR_WT" rev-parse --abbrev-ref HEAD 2>/dev/null)
 if [ "$MR_HB" = "fix/330-subdir" ]; then _pass; else _fail "expected HEAD on fix/330-subdir, got '$MR_HB'"; fi
 
-test_case "#330: worktree is workspace-rooted (not inside inner repo)"
-MR_INNER_WT="$MR_REPO/.claude/worktrees/330-subdir"
-if [ -d "$MR_INNER_WT" ]; then
-  _fail "worktree must NOT be created inside inner repo at $MR_INNER_WT"
+test_case "#330/#169: worktree is repo-rooted (inside the inner repo, not at the workspace root)"
+MR_WS_WT="$MR_WORKSPACE/.claude/worktrees/330-subdir"
+if [ -d "$MR_WS_WT" ]; then
+  _fail "worktree must NOT be created at the workspace root $MR_WS_WT — it is repo-rooted"
 else
   _pass
 fi


### PR DESCRIPTION
Reverses the incomplete Phase-3 workspace-rooted migration: all worktree-path resolution is now repo-rooted, matching the creators. Fixes swe-atomic-close.sh + worktree-create.sh DB branch, neutralizes the cleanup-stale-worktrees pruner, adds nested-repo L3 cases (verified failing pre-fix). Single-repo unchanged. pr-reviewer PASS; L3 hook tests 58/58, 42/42, 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)