### PR TITLE
chore(release): rc.4 - fix link-check + hardcoded-name lint + bump

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.10.0-rc.3",
+  "version": "0.10.0-rc.4",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
+## v0.10.0-rc.4 — 2026-06-21
+
+Fourth release candidate for v0.10.0 — fixes two lint failures the rc.3 gate surfaced (no shipped-runtime change).
+
+### Fixed
+- **Link-check**: a moved L5 README (`rows/05/05.04-multirepo-commit`) had a relative `docs/` link that under-resolved after the family-folder move; corrected the depth.
+- **`no-hardcoded-plugin-name` lint**: exempted `scripts/publish-rc-channel.sh`, which legitimately references the `trustmybot-rc` rc-channel catalog.
+
 ## v0.10.0-rc.3 — 2026-06-21
 
 Third release candidate for v0.10.0 — test-harness, tooling, and docs polish on top of rc.2 (no shipped-runtime change; the full L6 chain re-validates 15/15 on the new layout).

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.10.0-rc.3",
+  "version": "0.10.0-rc.4",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.10.0-rc.3",
+  "version": "0.10.0-rc.4",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [

--- a/tests/l1-lint/no-hardcoded-plugin-name.sh
+++ b/tests/l1-lint/no-hardcoded-plugin-name.sh
@@ -23,6 +23,7 @@ HARDCODED_REGEX='(\.claude/tmb/|tmb-active-workspace|trustmybot-rc|=["\x27]tmb["
 EXCLUDED_FILES=(
   "scripts/lib/resolve-plugin-name.sh"
   "scripts/hooks/lib/query-task.sh"
+  "scripts/publish-rc-channel.sh"
 )
 
 EXCLUDED_LINE_PATTERNS=(

--- a/tests/l5-l6/rows/05/05.04-multirepo-commit/README.md
+++ b/tests/l5-l6/rows/05/05.04-multirepo-commit/README.md
@@ -1,6 +1,6 @@
 # 05.04-multirepo-commit
 
-**Flow under test:** path discipline in a multi-repo workspace — path-keyed repo resolution (each inner repo registered by path in the `repos` table; see [`docs/architecture/REPO_RESOLUTION.md`](../../../../docs/architecture/REPO_RESOLUTION.md)) + repo-relative indexing in the kuzu world model (graph DB per ADR 0002).
+**Flow under test:** path discipline in a multi-repo workspace — path-keyed repo resolution (each inner repo registered by path in the `repos` table; see [`docs/architecture/REPO_RESOLUTION.md`](../../../../../docs/architecture/REPO_RESOLUTION.md)) + repo-relative indexing in the kuzu world model (graph DB per ADR 0002).
 
 **Pre-state**: `onboarding-named` fixture + workspace fixture with **two sibling inner git repos**, each with a top-level `README.md` so `/scan` produces author-curated dir summaries in the kuzu graph:
 


### PR DESCRIPTION
Fixes the 2 rc.3 gate failures: (A) relative docs-link depth in the moved 05.04-multirepo-commit README; (B) exempt publish-rc-channel.sh from no-hardcoded-plugin-name (it legitimately names trustmybot-rc). Bumps to 0.10.0-rc.4. L6-irrelevant (rc.3 15/15 carries). pr-reviewer PASS; link-check + hardcoded-name + version-sync green.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)