### PR TITLE
✅ test(l5): multi-repo onboard+scan row asserts per-repo remotes + plugin_config cleanup (#982)

### DIFF
--- a/tests/l5-l6/rows/03/03-multirepo-onboard-scan/README.md
+++ b/tests/l5-l6/rows/03/03-multirepo-onboard-scan/README.md
@@ -1,0 +1,37 @@
+# 03-multirepo-onboard-scan
+
+**Scenario under test:** a multi-repo workspace where two sibling repos carry **distinct** git remotes — `repo-a` on GitHub, `repo-b` on GitLab. The user onboards and asks bro to scan. This is the acceptance test for the live merged behavior of:
+
+- **#979** — `scan_run` captures each repo's git remotes into `repos.remotes` (per-repo, not a single workspace-wide list).
+- **#980** — the four repo-scoped keys (`remotes`, `pr_target`, `branching_model`, `protected_branches`) are gone from `plugin_config`; the `repos` table is the sole source of truth.
+
+## Pre-state
+
+`onboarding-named` fixture (clean schema v27 — `plugin_config` already holds none of the four repo-scoped keys). `setup-l5.sh` then:
+
+- `git init`s `repo-a` and `repo-b` under the session dir, each with one commit and a distinct origin remote (`git@github.com:acme/repo-a.git` / `git@gitlab.com:acme/repo-b.git`). `git remote add` / `get-url` are pure local config, so the stubbed `git-remote-http(s)` transport helpers never fire and no network is touched.
+- Seeds the two `repos` rows with workspace-wide policy (`target_branch` + `branching_model` + `protected_branches`) and a NULL `remotes` column. The policy seed stands in for the post-AUQ `onboard_apply`, which the harness suppresses (no AskUserQuestion in test mode). `scan_run` upserts these rows by `name` and fills `remotes` **without** touching the policy columns, so the distinct per-repo remotes land while the seeded policy survives.
+
+## Turns
+
+| # | Speaker | Message |
+|---|---|---|
+| 1 | user | `/onboard` + "scan the workspace" + `Don't ask questions.` |
+| → | bro | Reads onboard state, then calls `scan_run`. Scan discovers `repo-a`/`repo-b` (plus the harness's root repo, which has no remote), reads each repo's git remotes, classifies the provider, and writes them to `repos.remotes`. |
+
+## Pass criteria
+
+| Scorer | Asserts |
+|---|---|
+| `outcome.sql` | (a) `repo-a.remotes[0]` provider=`github` non-blank url; `repo-b.remotes[0]` provider=`gitlab` non-blank url; the two URLs DISTINCT. (b) `plugin_config` holds none of the four repo-scoped keys. (c) `repo-a`+`repo-b` carry non-null `target_branch`+`branching_model`+`protected_branches`. |
+| `outcome-coherence.json` | `repos >= 2`; `tasks = 0`; no work issues; zero repo-scoped keys in `plugin_config`. |
+| `outcome-git.json` | `base_branch_unchanged: true` |
+| `tools-required.json` | `scan_run` (bro refreshed the world model). |
+| `tools-forbidden.json` | `task_create_batch`, `task_provision`, `issue_create`, `Agent`. |
+| `cost-budget.json` | Soft 150K / 600s. |
+
+**Failure modes captured:** scan writes a single shared remote list across both repos (would collapse the distinct URLs); a regression reintroduces any of the four keys into `plugin_config`; scan clobbers the per-repo policy columns.
+
+## Future extension (#992 — out of scope here)
+
+This row exercises onboard applied **workspace-wide**, so it asserts distinct per-repo **remotes** (from scan) but NOT distinct per-repo `branching_model` / `pr_target`. Per-repo distinct *policy* requires the #992 onboard skill loop (a per-repo `onboard_get_questions` / `onboard_apply` pass with the optional `repo` argument). When #992 lands, extend this row (or add a sibling) to seed two repos with different chosen branching models and assert each `repos` row keeps its own `target_branch` / `branching_model`.

--- a/tests/l5-l6/rows/03/03-multirepo-onboard-scan/cost-budget.json
+++ b/tests/l5-l6/rows/03/03-multirepo-onboard-scan/cost-budget.json
@@ -1,0 +1,5 @@
+{
+  "max_tokens_total": 150000,
+  "max_duration_ms": 600000,
+  "fail_above_max": false
+}

--- a/tests/l5-l6/rows/03/03-multirepo-onboard-scan/fixture.txt
+++ b/tests/l5-l6/rows/03/03-multirepo-onboard-scan/fixture.txt
@@ -1,0 +1,1 @@
+onboarding-named

--- a/tests/l5-l6/rows/03/03-multirepo-onboard-scan/outcome-coherence.json
+++ b/tests/l5-l6/rows/03/03-multirepo-onboard-scan/outcome-coherence.json
@@ -1,0 +1,8 @@
+{
+  "expected_writes": {
+    "repos": ">=2",
+    "tasks": "=0",
+    "issues WHERE id != -1": "=0",
+    "plugin_config WHERE key IN ('remotes','pr_target','branching_model','protected_branches')": "=0"
+  }
+}

--- a/tests/l5-l6/rows/03/03-multirepo-onboard-scan/outcome-git.json
+++ b/tests/l5-l6/rows/03/03-multirepo-onboard-scan/outcome-git.json
@@ -1,0 +1,3 @@
+{
+  "base_branch_unchanged": true
+}

--- a/tests/l5-l6/rows/03/03-multirepo-onboard-scan/outcome.sql
+++ b/tests/l5-l6/rows/03/03-multirepo-onboard-scan/outcome.sql
@@ -1,0 +1,56 @@
+-- 03-multirepo-onboard-scan — acceptance test for #979 + #980.
+-- After bro onboards + scans a 2-repo workspace with DISTINCT remotes:
+--   (a) scan_run captured each repo's git remote into repos.remotes with the
+--       correct provider, and the two repos' remote URLs are DISTINCT (#979);
+--   (b) plugin_config holds NONE of the four repo-scoped keys (#980);
+--   (c) every repos row carries non-null policy (target_branch +
+--       branching_model + protected_branches).
+
+-- (a) repo-a's remote is non-blank and classified as github.
+SELECT
+  CASE WHEN json_extract(remotes, '$[0].provider') = 'github'
+         AND length(coalesce(json_extract(remotes, '$[0].url'), '')) > 0
+       THEN 1 ELSE 0 END AS pass,
+  'repo-a remote captured as github with non-blank url (got provider=' ||
+    coalesce(json_extract(remotes, '$[0].provider'), 'NULL') ||
+    ', url=' || coalesce(json_extract(remotes, '$[0].url'), 'NULL') || ')' AS description
+FROM repos WHERE name = 'repo-a';
+
+-- (a) repo-b's remote is non-blank and classified as gitlab.
+SELECT
+  CASE WHEN json_extract(remotes, '$[0].provider') = 'gitlab'
+         AND length(coalesce(json_extract(remotes, '$[0].url'), '')) > 0
+       THEN 1 ELSE 0 END AS pass,
+  'repo-b remote captured as gitlab with non-blank url (got provider=' ||
+    coalesce(json_extract(remotes, '$[0].provider'), 'NULL') ||
+    ', url=' || coalesce(json_extract(remotes, '$[0].url'), 'NULL') || ')' AS description
+FROM repos WHERE name = 'repo-b';
+
+-- (a) the two repos' first-remote URLs are DISTINCT.
+SELECT
+  CASE WHEN a.url IS NOT NULL AND b.url IS NOT NULL AND a.url <> b.url
+       THEN 1 ELSE 0 END AS pass,
+  'repo-a and repo-b remote URLs are distinct (a=' || coalesce(a.url, 'NULL') ||
+    ', b=' || coalesce(b.url, 'NULL') || ')' AS description
+FROM
+  (SELECT json_extract(remotes, '$[0].url') AS url FROM repos WHERE name = 'repo-a') a,
+  (SELECT json_extract(remotes, '$[0].url') AS url FROM repos WHERE name = 'repo-b') b;
+
+-- (b) plugin_config holds NONE of the four repo-scoped keys.
+SELECT
+  CASE WHEN COUNT(*) = 0 THEN 1 ELSE 0 END AS pass,
+  'plugin_config has none of remotes/pr_target/branching_model/protected_branches (got ' ||
+    COUNT(*) || ' such keys)' AS description
+FROM plugin_config
+WHERE key IN ('remotes', 'pr_target', 'branching_model', 'protected_branches');
+
+-- (c) both seeded repos carry non-null policy on the repos row.
+SELECT
+  CASE WHEN COUNT(*) = 2 THEN 1 ELSE 0 END AS pass,
+  'repo-a + repo-b carry non-null target_branch + branching_model + protected_branches (got ' ||
+    COUNT(*) || '/2)' AS description
+FROM repos
+WHERE name IN ('repo-a', 'repo-b')
+  AND target_branch IS NOT NULL
+  AND branching_model IS NOT NULL
+  AND protected_branches IS NOT NULL;

--- a/tests/l5-l6/rows/03/03-multirepo-onboard-scan/prompt.txt
+++ b/tests/l5-l6/rows/03/03-multirepo-onboard-scan/prompt.txt
@@ -1,0 +1,5 @@
+/onboard
+
+After onboarding, scan the workspace so the world model picks up every repo.
+
+Don't ask questions.

--- a/tests/l5-l6/rows/03/03-multirepo-onboard-scan/script.json
+++ b/tests/l5-l6/rows/03/03-multirepo-onboard-scan/script.json
@@ -1,0 +1,5 @@
+{
+  "max_turns": 1,
+  "user_after_bro": [],
+  "terminal_pattern": "scan|repos|remote|onboard"
+}

--- a/tests/l5-l6/rows/03/03-multirepo-onboard-scan/setup-l5.sh
+++ b/tests/l5-l6/rows/03/03-multirepo-onboard-scan/setup-l5.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Multi-repo onboard+scan scenario. Seeds two git repos under the session dir
+# with DISTINCT remotes (repo-a → GitHub, repo-b → GitLab) so scan_run (#979)
+# captures per-repo remotes into repos.remotes, and asserts the four repo-scoped
+# keys never reappear in plugin_config (#980 — repos is the sole source of truth).
+#
+# `git remote add` / `git remote get-url` are pure local config — no transport —
+# so the stubbed git-remote-http(s) helpers are never invoked and no network is
+# touched. The bare TMB_TEST_REMOTE push target is irrelevant here.
+set -uo pipefail
+
+PROJECT="$1"
+# shellcheck disable=SC2034  # SCENARIO_DIR passed by runner; reserved for future use.
+SCENARIO_DIR="$2"
+
+GH_URL="git@github.com:acme/repo-a.git"
+GL_URL="git@gitlab.com:acme/repo-b.git"
+
+seed_repo() {
+  local dir="$1" remote_url="$2"
+  mkdir -p "$dir"
+  git -C "$dir" init -q -b main
+  git -C "$dir" config user.email l6@l6.test
+  git -C "$dir" config user.name "L5 Test"
+  echo "# $(basename "$dir")" > "$dir/README.md"
+  git -C "$dir" add README.md
+  git -C "$dir" commit -qm init
+  git -C "$dir" remote add origin "$remote_url"
+}
+
+seed_repo "$PROJECT/repo-a" "$GH_URL"
+seed_repo "$PROJECT/repo-b" "$GL_URL"
+
+# Pre-seed the repos rows with workspace-wide policy (target_branch +
+# branching_model + protected_branches). onboard applies policy via AskUserQuestion,
+# which the test harness suppresses, so the policy columns are seeded here to stand
+# in for the post-AUQ apply. scan_run upserts these rows by name (ON CONFLICT(name))
+# and fills repos.remotes WITHOUT touching the policy columns, so the distinct
+# per-repo remotes land while the seeded policy survives.
+sqlite3 "$PROJECT/.claude/tmb/trajectory.db" <<SQL
+INSERT INTO repos (name, path, file_count, target_branch, branching_model, protected_branches, remotes)
+VALUES
+  ('repo-a', '$PROJECT/repo-a', 1, 'main', 'github-flow', '["main"]', NULL),
+  ('repo-b', '$PROJECT/repo-b', 1, 'main', 'github-flow', '["main"]', NULL)
+ON CONFLICT(name) DO UPDATE SET
+  path = excluded.path,
+  target_branch = excluded.target_branch,
+  branching_model = excluded.branching_model,
+  protected_branches = excluded.protected_branches;
+SQL

--- a/tests/l5-l6/rows/03/03-multirepo-onboard-scan/tools-forbidden.json
+++ b/tests/l5-l6/rows/03/03-multirepo-onboard-scan/tools-forbidden.json
@@ -1,0 +1,6 @@
+[
+  "mcp__plugin_tmb_trajectory-server__task_create_batch",
+  "mcp__plugin_tmb_trajectory-server__task_provision",
+  "mcp__plugin_tmb_trajectory-server__issue_create",
+  "Agent"
+]

--- a/tests/l5-l6/rows/03/03-multirepo-onboard-scan/tools-required.json
+++ b/tests/l5-l6/rows/03/03-multirepo-onboard-scan/tools-required.json
@@ -1,0 +1,3 @@
+[
+  "mcp__plugin_tmb_trajectory-server__scan_run"
+]


### PR DESCRIPTION
Fixes #982. Acceptance test for #980 (refs #979).

## What
New L5 row `tests/l5-l6/rows/03/03-multirepo-onboard-scan/` (modeled on `03-reonboard-remote`) seeds 2 repos with distinct remotes (repo-a→github, repo-b→gitlab), runs bro onboard+scan, and asserts the live #979+#980 behavior.

## Assertions (outcome 5/5)
- repo-a/repo-b `repos.remotes` non-blank, correct provider, DISTINCT URLs.
- `plugin_config` has none of remotes/pr_target/branching_model/protected_branches.
- both repos carry non-null target_branch/branching_model/protected_branches.

Ran green (`run-l5.sh multirepo`): outcome 5/5, scan_run required, no forbidden tools, coherence + git pass. README notes the #992 per-repo-onboard-ASK distinct-policy assertion as the future extension. pr-reviewer: PASS (id=10).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)