### PR TITLE
✅ test(l6): make step-5 genuinely cold — reset kuzu so the registry-cold SOP fires deterministically (#18)

### DIFF
--- a/tests/l5-l6/l6-chain/chain-manifest.json
+++ b/tests/l5-l6/l6-chain/chain-manifest.json
@@ -52,6 +52,8 @@
       "row_dir": "rows/05/05-first-task-hits-gate",
       "partial_test": false,
       "seed_before": "seeds/before-05-first-task-hits-gate.sql",
+      "chain_setup_command": "rm -rf .claude/*/world-model.kuzu",
+      "chain_setup_note": "Make step 05 genuinely cold. seed_before deletes the deep_scan_completed audit row (SessionStart banner reports cold), but prior chain steps leave the kuzu world model populated, so world_model_get would return a WARM tree and bro could non-deterministically skip scan_run — which this step's tools-required scorer mandates. Removing the kuzu graph dir(s) at $PROJECT/.claude/<plugin>/world-model.kuzu (resolved relative to $PWD, since the runner runs this from inside $PROJECT) makes world_model_get return empty, matching the cold audit signal — bro deterministically runs /scan per the registry-cold SOP, which repopulates repos + the deep_scan_completed row for the downstream scorers. L5 standalone skips this (no prior chain populates kuzu).",
       "seed_after": null,
       "halt_on_fail": true
     },


### PR DESCRIPTION
Part of #18. Fixes L6 step-5 non-determinism.

## Problem
Step 5's cold setup deleted the `deep_scan_completed` audit row (banner → cold → "run /scan") but left the kuzu world model populated, so `world_model_get` returned a **warm** tree and bro non-deterministically skipped `scan_run` — which step 5's `tools-required.json` mandates.

## Fix (test/fixture only)
Added a `chain_setup_command` to step 5 in `chain-manifest.json`: `rm -rf .claude/*/world-model.kuzu` (run from inside `$PROJECT` after `seed_before`, before bro's turn). Now both cold signals agree → bro deterministically runs `/scan` per the registry-cold SOP, which repopulates `repos` + `deep_scan_completed` for downstream scorers. No scorer weakened; `prompt.txt` untouched.

## Verification
- manifest valid JSON; `chain_setup_command` parses (`bash -n`) + shellcheck clean
- pr-reviewer push-gate: **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)