### PR TITLE
✏️ docs(planning): bro re-scans after an architecture-level change (#20) — HUMAN REVIEW (prompt-surface)

### DIFF
--- a/skills/tmb_planning/SKILL.md
+++ b/skills/tmb_planning/SKILL.md
@@ -96,6 +96,6 @@ After SWE returns `status=completed`, pull the work (`task_get` plus a `git diff
 3. Each `## Success Criteria` bullet is visibly met by the diff.
 4. `world_model_get` on the changed directory confirms the change landed where expected.
 
-All four pass → close with the `bro_atomic_close` composite (`close_issue_if_last_task=true` when it's the last task); the post-close hook re-scans so the world model refreshes. Then spawn pr-reviewer for the push gate — the spawn-shape hook enforces the anchors. On a reviewer FAIL: surface it, file the fix as a follow-up issue, and hold the push.
+All four pass → close with the `bro_atomic_close` composite (`close_issue_if_last_task=true` when it's the last task); the post-close hook re-scans so the world model refreshes. When the closed task was an architectural change (the cases listed under "Architectural changes" above — a new top-level module, dir, or service boundary), also call `scan_run` yourself right after `bro_atomic_close` so the world model reflects the new structure within this session; the background post-close rescan stays the safety net for ordinary changes. Then spawn pr-reviewer for the push gate — the spawn-shape hook enforces the anchors. On a reviewer FAIL: surface it, file the fix as a follow-up issue, and hold the push.
 
 If any of the four checks fails, record it with `bro_verification_fail_record` (name which check and why), leave the task open, and either retry via `task_retry` or escalate.

--- a/tests/l5-l6/l6-chain/chain-manifest.json
+++ b/tests/l5-l6/l6-chain/chain-manifest.json
@@ -52,8 +52,6 @@
       "row_dir": "rows/05/05-first-task-hits-gate",
       "partial_test": false,
       "seed_before": "seeds/before-05-first-task-hits-gate.sql",
-      "chain_setup_command": "rm -rf .claude/*/world-model.kuzu",
-      "chain_setup_note": "Make step 05 genuinely cold. seed_before deletes the deep_scan_completed audit row (SessionStart banner reports cold), but prior chain steps leave the kuzu world model populated, so world_model_get would return a WARM tree and bro could non-deterministically skip scan_run — which this step's tools-required scorer mandates. Removing the kuzu graph dir(s) at $PROJECT/.claude/<plugin>/world-model.kuzu (resolved relative to $PWD, since the runner runs this from inside $PROJECT) makes world_model_get return empty, matching the cold audit signal — bro deterministically runs /scan per the registry-cold SOP, which repopulates repos + the deep_scan_completed row for the downstream scorers. L5 standalone skips this (no prior chain populates kuzu).",
       "seed_after": null,
       "halt_on_fail": true
     },


### PR DESCRIPTION
**Prompt-surface change — for your review; do NOT auto-merge.** This is the fix for the L6 step-5 reliability question we worked through.

## Why
L6 step-5 (`05-first-task-hits-gate`) flaked in CI on the `trajectory_required: scan_run` scorer (passed locally). Root cause: **bro's decision to re-scan the world model after an architecture-level change is non-deterministic.** Building a todo CLI from an empty project creates new top-level modules (`src/`, `tests/`) — architecture-level by `tmb_planning`'s own criteria — so the world model should be refreshed. But the skill told bro the post-close rescan is *automatic*, so bro didn't consciously call `scan_run`; in CI it saw `world-model-unavailable` and inspected directly. The scorer (which checks bro's explicit tool call) failed non-deterministically.

## Change
1. **`skills/tmb_planning/SKILL.md`** — adds one positively-phrased rule to the atomic-close step: after `bro_atomic_close` of an architectural change (new top-level module / dir / service boundary), bro **also calls `scan_run` itself** so the world model reflects the new structure in-session; the background post-close rescan stays the safety net for ordinary changes.
2. **`tests/l5-l6/l6-chain/chain-manifest.json`** — reverts #26's step-05 `chain_setup_command` (the kuzu-delete was the wrong lever — it forced `world_model_get` → `unavailable`, which makes bro inspect directly and still skip `scan_run`).

The step-5 scorer is **intentionally kept** — it encodes the real desired behavior; the doctrine makes bro's decision reliable.

## Honest caveat
A prompt rule strengthens but doesn't *mathematically guarantee* determinism on a real `claude -p` step. If step-5 still flakes after this, the fallback is to enforce in code (a hook) or assert the scan *outcome* rather than the tool call — TMB's "guardrails in code" principle. This is the right first move per the design intent.

## After you merge
I'll re-validate L6 (local + CI) and re-cut rc.6 (re-tag + re-pin the rc channel, currently safely on rc.5).

Verification: 4 L1 prompt lints pass (no new negative-directive findings), manifest valid JSON, no `world-model.kuzu` ref. pr-reviewer push-gate: **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)