### PR TITLE
🐛 fix(cheatcode): default-fixture-path fallback for search+vet so L6 step-4 is hermetic (#21)

### DIFF
--- a/scripts/cheatcode-search.sh
+++ b/scripts/cheatcode-search.sh
@@ -145,15 +145,26 @@ adapter_pulsemcp() {
   ' 2>/dev/null || echo '[]'
 }
 
+# Resolve the fixture path. The env var wins when set. When it is unset/empty,
+# probe the deterministic default path "$PWD/.tmb-cheatcode-fixture.json" (the
+# path the row setup-l5.sh stages in the step's CWD) and use it if present —
+# this lets the L6 chain reach the fixture even though the runner's subshell
+# export of the env var never reaches the step's `claude -p`. When neither the
+# env nor the default file is present, the live / no-fixture path is unchanged.
+SEARCH_FIXTURE_PATH="${TMB_CHEATCODE_SEARCH_FIXTURE:-}"
+if [ -z "$SEARCH_FIXTURE_PATH" ] && [ -f "$PWD/.tmb-cheatcode-fixture.json" ]; then
+  SEARCH_FIXTURE_PATH="$PWD/.tmb-cheatcode-fixture.json"
+fi
+
 # Acquire the candidate set. Fixture path (test hook) takes precedence over any
 # live lookup so CI never touches the network.
 candidates_json=""
-if [ -n "${TMB_CHEATCODE_SEARCH_FIXTURE:-}" ]; then
-  [ -f "$TMB_CHEATCODE_SEARCH_FIXTURE" ] || {
-    echo "{\"error\":\"fixture not found: $TMB_CHEATCODE_SEARCH_FIXTURE\"}" >&2
+if [ -n "$SEARCH_FIXTURE_PATH" ]; then
+  [ -f "$SEARCH_FIXTURE_PATH" ] || {
+    echo "{\"error\":\"fixture not found: $SEARCH_FIXTURE_PATH\"}" >&2
     exit 1
   }
-  candidates_json=$(cat "$TMB_CHEATCODE_SEARCH_FIXTURE")
+  candidates_json=$(cat "$SEARCH_FIXTURE_PATH")
   if ! printf '%s' "$candidates_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
     echo '{"error":"fixture is not a JSON array of candidates"}' >&2
     exit 1

--- a/scripts/cheatcode-vet.sh
+++ b/scripts/cheatcode-vet.sh
@@ -136,16 +136,27 @@ owner_repo() {
     | sed -nE 's#^https?://github\.com/([^/]+)/([^/.]+)(\.git)?/?.*$#\1/\2#p'
 }
 
+# Resolve the fixture path. The env var wins when set. When it is unset/empty,
+# probe the deterministic default path "$PWD/.tmb-cheatcode-vet-fixture.json"
+# (the path the row setup-l5.sh stages in the step's CWD) and use it if present —
+# this lets the L6 chain reach the fixture even though the runner's subshell
+# export of the env var never reaches the step's `claude -p`. When neither the
+# env nor the default file is present, the live / no-fixture path is unchanged.
+VET_FIXTURE_PATH="${TMB_CHEATCODE_VET_FIXTURE:-}"
+if [ -z "$VET_FIXTURE_PATH" ] && [ -f "$PWD/.tmb-cheatcode-vet-fixture.json" ]; then
+  VET_FIXTURE_PATH="$PWD/.tmb-cheatcode-vet-fixture.json"
+fi
+
 # Acquire signal inputs. Fixture path (test hook) takes precedence over any live
 # lookup so CI never touches the network.
 repo_json='{}'
 contents_json='[]'
-if [ -n "${TMB_CHEATCODE_VET_FIXTURE:-}" ]; then
-  [ -f "$TMB_CHEATCODE_VET_FIXTURE" ] || {
-    echo "{\"error\":\"fixture not found: $TMB_CHEATCODE_VET_FIXTURE\"}" >&2
+if [ -n "$VET_FIXTURE_PATH" ]; then
+  [ -f "$VET_FIXTURE_PATH" ] || {
+    echo "{\"error\":\"fixture not found: $VET_FIXTURE_PATH\"}" >&2
     exit 1
   }
-  fixture=$(cat "$TMB_CHEATCODE_VET_FIXTURE")
+  fixture=$(cat "$VET_FIXTURE_PATH")
   if ! printf '%s' "$fixture" | jq -e 'type == "object"' >/dev/null 2>&1; then
     echo '{"error":"fixture is not a JSON object"}' >&2
     exit 1

--- a/tests/l5-l6/rows/04/04-cheatcode-install-plugins/setup-l5.sh
+++ b/tests/l5-l6/rows/04/04-cheatcode-install-plugins/setup-l5.sh
@@ -1,21 +1,48 @@
 #!/usr/bin/env bash
-# Cheatcode-install-plugins L5 isolation: seed a deterministic marketplace-install
-# fixture and point cheatcode_install at it via TMB_CHEATCODE_INSTALL_FIXTURE so
-# no live web / real marketplace call is ever made. The fixture lives in the
-# project dir; the env export covers runners that source this setup.
+# Cheatcode-install-plugins L5 isolation: seed deterministic fixtures for the
+# whole search → vet → approve → install SOP so no live web / real marketplace
+# call is ever made. All three fixtures live in the project dir at the default
+# file-convention paths (cheatcode-search.sh / cheatcode-vet.sh probe these when
+# their env var is unset), so the chain reaches them regardless of subshell env
+# propagation; the env exports additionally cover runners that source this setup.
 #
-# Both candidates are plugin-kind. The fixture supplies attachments[] that pass
-# through verbatim — the per-agent attachment targets the install records: the
-# feature-dev plugin attaches to swe, the code-review plugin to pr-reviewer. The
-# {installed, version} object stands in for the marketplace result; the
-# cheatcodes + attachment + audit rows the install writes are computed the same
-# way regardless, so the fixture only enriches the reported version + targets. No
-# network.
+# Both candidates are plugin-kind: feature-dev (attaches to swe) and code-review
+# (attaches to pr-reviewer). The search fixture supplies both candidates so the
+# discovery step is deterministic; the vet fixture supplies the {repo, contents}
+# signal set for either candidate (plugin-kind forces a code-execution surface →
+# 'caution' tier, gating the human approval); the install fixture supplies the
+# {installed, version, attachments} marketplace result that passes through
+# verbatim. No network on any step.
 set -uo pipefail
 
 PROJECT="$1"
 # shellcheck disable=SC2034
 SCENARIO_DIR="$2"
+
+SEARCH_FIXTURE="$PROJECT/.tmb-cheatcode-fixture.json"
+cat > "$SEARCH_FIXTURE" <<'JSON'
+[
+  { "name": "feature-dev", "kind": "plugin", "source_url": "https://github.com/example-org/feature-dev",
+    "description": "feature development plugin for swe agents implementing specs", "registry": "anthropic-official", "tier": 1 },
+  { "name": "code-review", "kind": "plugin", "source_url": "https://github.com/example-org/code-review",
+    "description": "code review plugin for pr-reviewer agents gating pushes", "registry": "anthropic-official", "tier": 1 }
+]
+JSON
+
+VET_FIXTURE="$PROJECT/.tmb-cheatcode-vet-fixture.json"
+cat > "$VET_FIXTURE" <<'JSON'
+{
+  "repo": {
+    "stargazers_count": 1200,
+    "forks_count": 80,
+    "pushed_at": "2026-05-01T00:00:00Z",
+    "archived": false,
+    "license": { "spdx_id": "MIT" },
+    "owner": { "login": "example-org", "type": "Organization" }
+  },
+  "contents": ["README.md", "LICENSE", ".claude-plugin", "hooks"]
+}
+JSON
 
 FIXTURE="$PROJECT/.tmb-cheatcode-install-fixture.json"
 cat > "$FIXTURE" <<'JSON'
@@ -30,4 +57,6 @@ cat > "$FIXTURE" <<'JSON'
 }
 JSON
 
+export TMB_CHEATCODE_SEARCH_FIXTURE="$SEARCH_FIXTURE"
+export TMB_CHEATCODE_VET_FIXTURE="$VET_FIXTURE"
 export TMB_CHEATCODE_INSTALL_FIXTURE="$FIXTURE"


### PR DESCRIPTION
Closes #21. Makes L6 step-4 (`04-cheatcode-install-plugins`) hermetic so CI == local.

## Why
Step 4 flaked in CI: `cheatcode_search` returned 0 candidates because in the CI runner it hits the **live external registry** (8s curl, best-effort → empty on network failure), so bro correctly couldn't install → 0/6 scorers. Locally the registry is reachable, so it passes. `cheatcode_vet` has the same live-network exposure (GitHub API). Only the *install* step was stubbed. (Not a Docker difference — the L6 job runs directly on ubuntu-latest.)

## Fix (mirror the existing `cheatcode-uninstall.sh` precedent)
`cheatcode-uninstall.sh` is already hermetic by **file convention**: env var wins, else fall back to `$PWD/.tmb-cheatcode-*-fixture.json`. This sidesteps the chain's subshell env-propagation entirely.
1. `cheatcode-search.sh` — fallback to `$PWD/.tmb-cheatcode-fixture.json` when the env var is unset.
2. `cheatcode-vet.sh` — fallback to `$PWD/.tmb-cheatcode-vet-fixture.json`.
3. `04-cheatcode-install-plugins/setup-l5.sh` — writes all **three** fixtures (search/vet/install) to `$PROJECT`, search+vet each carrying both `feature-dev`→swe and `code-review`→pr-reviewer candidates, so the full search→vet→approve→install SOP runs from fixtures with **zero network**.

Production (no fixture file, no env) → live registry, unchanged. This removes the step-4 flake class (step-5 doctrine + step-6 parent_branch_id already merged).

## Verification
- shellcheck PASS; `bash -n` all 3
- search/vet fallbacks return fixtures with no network (rc=0); production path unchanged
- pr-reviewer push-gate: **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)