### PR TITLE
📝 docs: v27 schema/repos reconciliation + GitHub-canonical marketplace (#1037, #1042)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,18 +1,18 @@
 {
   "name": "trustmybot",
   "metadata": {
-    "description": "LEGACY marketplace catalog — kept for backward compat. New installs should use trustmybot/marketplace (stable) or trustmybot/marketplace-rc (RC) instead. See https://gitlab.com/trustmybot/marketplace for the canonical stable channel."
+    "description": "LEGACY marketplace catalog — kept for backward compat. New installs should use trustmybot/marketplace (stable) or trustmybot/marketplace-rc (RC) instead. See https://github.com/trustmybot/plugin for the canonical stable channel."
   },
   "owner": {
     "name": "trustmybot",
-    "url": "https://gitlab.com/trustmybot"
+    "url": "https://github.com/trustmybot"
   },
   "plugins": [
     {
       "name": "tmb",
       "source": {
         "source": "url",
-        "url": "https://gitlab.com/trustmybot/plugin.git",
+        "url": "https://github.com/trustmybot/plugin.git",
         "ref": "main"
       },
       "description": "TMB multi-agent Claude Code plugin with SQLite trajectory MCP — STABLE channel (tags from main branch only)."
@@ -21,7 +21,7 @@
       "name": "tmb-rc",
       "source": {
         "source": "url",
-        "url": "https://gitlab.com/trustmybot/plugin.git",
+        "url": "https://github.com/trustmybot/plugin.git",
         "ref": "rc"
       },
       "description": "TMB release-candidate channel — points at the 'rc' branch which is fast-forwarded to whichever vX.Y.Z-rc.N tag is currently being validated. Install only if you want to test pre-release builds and tolerate breakage. Promotes to 'tmb' (main) once validated."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,23 +55,23 @@ L6 needs the `CLAUDE_CODE_OAUTH_TOKEN` repo secret; chain logs upload as a run a
 
 ## Release
 
-`scripts/maintenance/bump-version.sh <version>` keeps the version in sync across all four manifests.
+`scripts/maintenance/bump-version.sh <version>` keeps the version in sync across all three manifests.
 
 **Phase A — candidate**
 1. Land everything intended for the release on `dev` via the normal PR flow (auto-merge policy applies).
 2. Bump PR on a branch off `dev`: `bump-version.sh X.Y.Z-rc.N` + a `## vX.Y.Z-rc.N` CHANGELOG section → PR → `dev`.
 
-**Phase B — local license (the gate)**
-3. Run the full local L6 chain (`bash tests/l5-l6/run-l6-chain.sh`) on the exact `dev` tree you intend to tag. **15/15 green licenses the rc tag.** A green CI gate on a feature branch never substitutes.
+**Phase B — local pre-flight**
+3. Run the full local L6 chain (`bash tests/l5-l6/run-l6-chain.sh`) on the exact `dev` tree you intend to tag. **15/15 green clears you to cut the rc tag** — this is pre-flight to keep the tagged CI gate from going red, not the sign-off itself (that's Phase C, step 8).
 4. On any step failure: reproduce and debug with the matching L5 row (`bash tests/l5-l6/run-l5.sh <row>`), fix on `dev` through the normal flow, then **resume the chain from the failed step** (`run-l6-chain.sh --from <step>`). Iterate until the chain completes.
-5. Whether the resumed 15/15 counts as the license depends on what the fix touched:
+5. Whether the resumed 15/15 clears you to tag depends on what the fix touched:
    - Fix confined to **test fixtures, scorers, or docs** → the resumed pass stands; tag.
    - Fix touched **runtime** (`mcp/`, `scripts/hooks/`, schema, `agents/`, `skills/`, `commands/`, `CLAUDE.md`) → finish with **one full fresh chain**, because steps before the failure ran on pre-fix code and their green doesn't transfer.
 
 **Phase C — rc**
-6. Tag `vX.Y.Z-rc.N` on `dev`, push. The tag-triggered CI release-gate (L1–L4 + L6 + L0) is **re-confirmation**, not the gate. Fast-forward the `rc` branch to the tag.
+6. Tag `vX.Y.Z-rc.N` on `dev`, push — this fires the CI release-gate (L1–L4 + L6 + L0) that is the sign-off (step 8). Fast-forward the `rc` branch to the tag.
 7. **Publish to the rc channel**: run `bash scripts/publish-rc-channel.sh` — it clones `trustmybot/marketplace-rc`, points `plugins[].source.ref` at the new rc tag, writes the channel README if missing, and pushes. Installs of `tmb@trustmybot-rc` now serve the rc. (Refuses non-rc versions; verifies the tag is on origin first; idempotent; `--dry-run` previews, `--yes` skips the prompt.)
-8. The CI release-gate (L1–L4 + L6 + L0) is the gate — the automated layers are the sole sign-off; a green gate on the exact tree you tag is the license.
+8. The CI release-gate (L1–L4 + L6 + L0) on the exact tree you tag is the gate — the automated layers are the sole sign-off.
 
 **Phase D — stable**
 9. Final bump PR (`X.Y.Z`) → `dev`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ That structure earns its keep on **long-horizon, multi-task work** — a codebas
 /plugin install tmb@trustmybot
 ```
 
-Use `trustmybot/marketplace-rc` + `tmb@trustmybot-rc` for the beta channel (pre-promotion testing — tolerate occasional breakage). Pick one channel per CC install; to switch, `/plugin uninstall tmb` then add the other.
+Use `trustmybot/marketplace-rc` + `tmb@trustmybot-rc` for the rc channel (pre-promotion testing — tolerate occasional breakage). Pick one channel per CC install; to switch, `/plugin uninstall tmb` then add the other.
 
 Refresh after upstream changes: `/plugin marketplace update trustmybot`.
 

--- a/docs/architecture/FLOWS.md
+++ b/docs/architecture/FLOWS.md
@@ -10,7 +10,7 @@ All consultants (architect, cto, ceo, pm, project-local) advise but never write 
 
 | # | Flow | Trigger | Agents | DB tables touched | Distinguishing hooks |
 |---|---|---|---|---|---|
-| 1 | First contact | `onboard_state_get().first_run === true` (i.e. `plugin_config('onboarded')` absent) | bro | `plugin_config`, `audit` | `activation-routine` (auto-fire trigger) |
+| 1 | First contact | `onboard_state_get().first_run === true` (i.e. `plugin_config('onboarded')` absent) | bro | `plugin_config`, `repos`, `audit` | `activation-routine` (auto-fire trigger) |
 | 2 | **Code-touching task** (canonical) | Code change ask | bro → swe; pr-reviewer at push | `issues`, `tasks`, `discussions`, `audit` (+ `validation_attempts` at push) | `require-task-spec`, `git-push-guard`, `git-guards`, `cleanup-worktree-on-task-close` |
 | 3 | Architectural change | New boundary/module, schema, public API, external side effects | bro records a `kind=decision` discussion + blast-radius, then standard SWE flow | + `discussions(kind='decision')` | universal `decision_gate` on `task_create_batch` |
 | 4 | Agent-creator | Routing hits role not in `.claude/agents/` | bro | — (file-based outcome) | — |
@@ -35,8 +35,8 @@ Bro's `activation-routine.sh` UserPromptSubmit hook reads `plugin_config('onboar
 
 | Shape | Round 2 questions | Persisted |
 |---|---|---|
-| Local-only | (none — github-flow defaulted silently) | `plugin_config('onboarded')`, `branching_model`, derived `pr_target`, `remotes=[]`, `issue_sync='off'` |
-| Remote-tracked | Branching, PR target, Remote (multiSelect) | + `remotes` array, then a Round 3 for `issue_sync` |
+| Local-only | (none — github-flow defaulted silently) | global `plugin_config('onboarded')` + `issue_sync='off'`; per-repo `repos` rows get `branching_model`, derived `target_branch`, `protected_branches`, `remotes=[]` |
+| Remote-tracked | Branching, PR target, Remote (multiSelect) | + each repo row's `remotes` array, then a Round 3 for the global `issue_sync` |
 
 A **silent probe** (origin URL, gh/glab installed/authed) pre-selects defaults so most questions become 1-tap confirms. Local re-onboard adds the Branching question with a `Keep` option so the user can change models without first switching shape.
 

--- a/docs/architecture/GIT.md
+++ b/docs/architecture/GIT.md
@@ -38,7 +38,7 @@ Routing SWE's commits through your local branch (rather than letting SWE push st
 
 ## Per-repo branch protection + guard scoping
 
-Branch policy is **per-repo**, not global. Each registered repo's `repos` row carries its own `target_branch`, `branching_model`, and `protected_branches`; the git guards resolve the acting repo path-keyed (the command's git toplevel → matching `repos` row) and enforce that row's policy. The matching global `plugin_config` keys are a fallback used only when the resolved repo carries no per-repo value.
+Branch policy is **per-repo**, not global. Each registered repo's `repos` row carries its own `target_branch`, `branching_model`, and `protected_branches`; the git guards resolve the acting repo path-keyed (the command's git toplevel → matching `repos` row) and enforce that row's policy. The `repos` row is the sole source of truth — there is no global `plugin_config` fallback.
 
 Guard scoping is **registration-based**: a git op is enforced only when its git-root resolves to a registered `repos` row. When the command's git-root is an unregistered sibling tree, the guards no-op — TMB never enforces on a tree it doesn't manage. For a single-repo project the sole repo is the registered root, so the whole tree is guarded; `/scan` is the registration point. See [`REPO_RESOLUTION.md`](./REPO_RESOLUTION.md) for the full resolution contract.
 

--- a/docs/architecture/REPO_RESOLUTION.md
+++ b/docs/architecture/REPO_RESOLUTION.md
@@ -16,7 +16,7 @@ A name-keyed global default forced one repo to be "the" repo and made the git gu
 
 3. **git-guard scoping is registration-based.** A git op is enforced iff its git-root resolves to a registered `repos` row. When the command's git-root is an unregistered sibling tree, the guards no-op — they never enforce on a tree TMB doesn't manage. For a single-repo user project the sole repo *is* the registered root, so the whole tree is guarded as before.
 
-4. **`protected_branches` is per-repo authoritative.** `repos.protected_branches` (resolved path-keyed) wins. The global `plugin_config.protected_branches` is a fallback used only when the matched repo row carries no per-repo value.
+4. **`protected_branches` is per-repo authoritative.** `repos.protected_branches` (resolved path-keyed) is the sole source of truth; there is no global `plugin_config` fallback.
 
 5. **Single-repo fallback.** When exactly one repo is registered, resolution defaults to it. This keeps single-repo projects (the common case) working without any per-operation repo argument.
 
@@ -34,5 +34,5 @@ Implementers (MCP source and hooks) agree on one shape:
 
 - **Multi-repo workspaces work without ceremony.** Each operation resolves to its own repo by path; sibling repos coexist without one being privileged.
 - **Guards never fire on unmanaged trees.** Editing or committing in an unregistered sibling repo is allowed — TMB only enforces on trees it registered.
-- **Per-repo branch policy.** Each repo carries its own `target_branch`, `branching_model`, and `protected_branches`; the global config is a fallback, not the source of truth.
+- **Per-repo branch policy.** Each repo carries its own `target_branch`, `branching_model`, and `protected_branches` on its `repos` row — the sole source of truth, with no global fallback.
 - **`/scan` is the registration point.** A repo must be scanned to participate; this is the same step that warms the world model, so the two stay aligned.

--- a/docs/contributing/ENUMS.md
+++ b/docs/contributing/ENUMS.md
@@ -60,7 +60,7 @@ Server enforces valid transitions: `collecting → awaiting_human → closed | s
 | `github` | TMB | GitHub (github.com or GHE) |
 | `gitlab` | TMB | GitLab (gitlab.com or self-hosted) |
 
-Mirrors `plugin_config.remotes[].provider` (see [`plugin_config.remotes[].provider`](#plugin_configremotesprovider---git-host-provider-per-remote)). Only these two values are supported for issue sync. Schema enforces via `CHECK(remote_kind IN ('github','gitlab'))`.
+Mirrors `repos.remotes[].provider` (see [`repos.remotes[].provider`](#reposremotesprovider---git-host-provider-per-remote)). Only these two values are supported for issue sync. Schema enforces via `CHECK(remote_kind IN ('github','gitlab'))`.
 
 ### `discussions.kind` — narrative kind in issue discussions
 
@@ -145,13 +145,13 @@ No `CHECK` constraint — runtime reconciliation to `active`/`broken` is the hea
 
 ### `plugin_meta.schema_version` — DB schema version (integer)
 
-Currently `22`. Bumped on any breaking schema change. **NOT free-form** — every increment requires a migration step in `db.ts:runMigrations`.
+Currently `27`. Bumped on any breaking schema change. **NOT free-form** — every increment requires a migration step in `db.ts:runMigrations`.
 
 ### `agent_runs.agent_type` (open enum)
 
 Common values: `swe`, `pr-reviewer`, `architect`, `cto`, `pm`, `ceo`. Open enum — accept any string. Document the canonical values for query convenience.
 
-### `plugin_config.remotes[].provider` — git host provider per remote
+### `repos.remotes[].provider` — git host provider per remote
 
 | Value | Meaning |
 |---|---|
@@ -159,8 +159,6 @@ Common values: `swe`, `pr-reviewer`, `architect`, `cto`, `pm`, `ceo`. Open enum 
 | `gitlab` | gitlab.com or self-hosted GitLab |
 | `bitbucket` | Atlassian's git host (bitbucket.org) |
 | `codeberg` | codeberg.org (Forgejo-based public forge) |
-| `gitea` | Self-hosted Gitea instance |
-| `forgejo` | Self-hosted Forgejo instance |
 | `azuredev` | Azure DevOps (dev.azure.com) |
 | `other` | Unrecognised or custom host |
 
@@ -173,7 +171,7 @@ URL-pattern auto-detection rules:
 - `dev.azure.com` → `azuredev`
 - everything else → `other`
 
-`remotes` is a `plugin_config` key whose value is a JSON array of `{ name, provider, url }` objects (e.g. `[{ "name": "origin", "provider": "gitlab", "url": "git@gitlab.com:org/repo.git" }]`). An empty array means no remote is configured.
+`remotes` is a `repos`-table column whose value is a JSON array of `{ name, provider, url }` objects (e.g. `[{ "name": "origin", "provider": "github", "url": "git@github.com:org/repo.git" }]`). An empty array means no remote is configured.
 
 ---
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "tmb",
   "version": "0.1.1",
-  "description": "PLACEHOLDER — TMB multi-agent workflow extension for Gemini CLI (not yet implemented as of v0.7.0; placeholder for future adapter under .gemini-plugin/).",
+  "description": "PLACEHOLDER — TMB multi-agent workflow extension for Gemini CLI (not yet implemented).",
   "contextFileName": "GEMINI.md",
   "_status": "placeholder",
   "_see": "https://github.com/trustmybot/plugin/blob/main/docs/reference/MULTI_PLATFORM.md"

--- a/mcp/trajectory-server/README.md
+++ b/mcp/trajectory-server/README.md
@@ -60,6 +60,6 @@ where `<type>` is one of `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `pe
 
 ## Schema
 
-Current baseline: `TARGET_SCHEMA_VERSION = 26` (see `src/db.ts`). `schema.sql` is applied on open via `CREATE TABLE IF NOT EXISTS` semantics. On open, the stored `schema_version` is compared against `TARGET_SCHEMA_VERSION` via `db.ts:runMigrations`; if behind, a `.bak` snapshot is written before any migration runs, then migrations execute in sequence and `schema_version` is updated on success. Rollback is via the `.bak` file. Migration correctness is covered by `src/test/schema-upgrade.test.ts`.
+Current baseline: `TARGET_SCHEMA_VERSION = 27` (see `src/db.ts`). `schema.sql` is applied on open via `CREATE TABLE IF NOT EXISTS` semantics. On open, the stored `schema_version` is compared against `TARGET_SCHEMA_VERSION` via `db.ts:runMigrations`; if behind, a `.bak` snapshot is written before any migration runs, then migrations execute in sequence and `schema_version` is updated on success. Rollback is via the `.bak` file. Migration correctness is covered by `src/test/schema-upgrade.test.ts`.
 
 `plugin_meta` tracks `schema_version` + `plugin_version`. `plugin_version` is synced dynamically from `CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json` on every `TrajectoryDB` construction — fresh and existing DBs auto-update without a migration; the schema placeholder `'0.0.0'` applies only when `CLAUDE_PLUGIN_ROOT` is unset (e.g. test runs).

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,6 +12,7 @@
 #   1. Tag main HEAD as v<plugin.json version>
 #   2. Push the tag to origin
 #   3. Create the GitHub release with notes extracted from CHANGELOG.md
+#   4. Run the L5 release canary (re-clone the tag in Docker, run install-smoke)
 #
 # Idempotent + safety-checked:
 #   - Refuses to run unless current branch is `main`.
@@ -77,7 +78,7 @@ if ! grep -q "^## ${NEW_TAG} " CHANGELOG.md; then
   exit 1
 fi
 
-# The release gate is the CI release-gate (L1–L4 + L6 + L0, = local L6 13/13),
+# The release gate is the CI release-gate (L1–L4 + L6 + L0, = local L6 15/15),
 # run on the rc tag before promotion — not a manual sign-off here.
 
 confirm() {


### PR DESCRIPTION
Closes #1037. Addresses doc/wording parts of #1042 (esbuild bump deferred post-v0.10.0).

Reconciles stale docs/manifests to the v27 schema and GitHub-canonical posture:
- mcp README schema 26→27; ENUMS.md remotes→repos-table column, drop gitea/forgejo, schema_version 22→27
- REPO_RESOLUTION.md / GIT.md: remove the retired global plugin_config repo-policy fallback
- FLOWS.md flow-1: per-repo repos-row onboard persistence
- marketplace.json: canonical note + source URLs + owner.url → github.com/trustmybot
- CONTRIBUTING.md: single authoritative release gate; 'four manifests'→three
- release.sh comments 13/13→15/15 + L5 canary step; gemini pin dropped; README beta→rc

Docs/manifests only — no product source, dist/, plugin.json bump, or CHANGELOG. pr-reviewer: PASS. **Auto-merge.**