### PR TITLE
📝 docs(commands): onboard shape param + drop stale probe claim + roundtable carrier (#1020, #1041)

### DIFF
--- a/commands/onboard.md
+++ b/commands/onboard.md
@@ -10,7 +10,7 @@ Bro orchestrates an AskUserQuestion ceremony in 2-3 rounds — Round 3 runs only
 
 ## 1. Read state (one MCP call)
 
-Call `onboard_state_get(agent='bro')`. Returns `{ first_run, current, probe }`. Bro passes the probe to the server in subsequent calls; it doesn't interpret it.
+Call `onboard_state_get(agent='bro')`. Returns `{ first_run, current, probe }`. The server re-probes internally on each call, so bro never feeds the probe back — read `state.probe` only to spot a shape/remote conflict in Round 1.
 
 ## 2. Ask the questions
 
@@ -40,7 +40,7 @@ Branching model and PR target are per-repo. Enumerate repos with `repos_list(age
 
 - Call `onboard_get_questions(agent='bro', shape=<shape>, round='main', repo=<name>)`.
 - Feed the returned branching + PR-target questions into `AskUserQuestion`, framed for `<name>`.
-- Call `onboard_apply(agent='bro', repo=<name>, branching_model=<answer>, pr_target=<answer>)` — writes only that repo's row.
+- Call `onboard_apply(agent='bro', shape=<shape>, repo=<name>, branching_model=<answer>, pr_target=<answer>)` — writes only that repo's row. `shape` is required (the value resolved in Round 1).
 
 The remote/provider is git-derived (scan), not asked per repo — Round 2 asks only branching + PR target.
 
@@ -52,9 +52,9 @@ If `shape == 'remote'`, call `onboard_get_questions(agent='bro', shape='remote',
 
 ## 3. Apply (transactional)
 
-Per-repo branching + PR target are already applied in Round 2 (one `onboard_apply(repo=<name>, ...)` per repo, each writing only that repo's row).
+Per-repo branching + PR target are already applied in Round 2 (one `onboard_apply(shape=<shape>, repo=<name>, ...)` per repo, each writing only that repo's row).
 
-The final apply is workspace-level: call `onboard_apply(agent='bro', ...)` with **no** `repo` to write the global `issue_sync` answer and the `onboarded` marker. Omit `branching_model` / `pr_target` on this call so it sets only issue_sync + onboarded and leaves per-repo policy intact.
+The final apply is workspace-level: call `onboard_apply(agent='bro', shape=<shape>, ...)` with **no** `repo` to write the global `issue_sync` answer and the `onboarded` marker. `shape` is required on every apply. Omit `branching_model` / `pr_target` on this call so it sets only issue_sync + onboarded and leaves per-repo policy intact.
 
 The server accepts both option wire values and their labels. Pass `Keep "<current>"` answers by omitting that field — the server treats omission as "no change". Each apply recomputes protected branches and wraps its writes in a transaction.
 

--- a/commands/roundtable.md
+++ b/commands/roundtable.md
@@ -17,7 +17,11 @@ before proceeding.
 
 ## Phase 1 — Setup
 
-Glob `.claude/agents/` and pick the 2–4 agents whose domain bears on the topic, excluding SWE; halt if fewer than 2 are relevant. Open the round with `roundtable_create` (passing the carrier issue, topic, and participant count) and keep the returned `roundtable_id`.
+Glob `.claude/agents/` and pick the 2–4 agents whose domain bears on the topic, excluding SWE; halt if fewer than 2 are relevant.
+
+Resolve the carrier issue — the issue this roundtable's discussions and decisions attach to. If the topic already maps to an open issue, use its `issue_id`. Otherwise create a one-shot carrier with `issue_create` (title = the topic) and use the returned id; Phase 6 closes it once the roundtable ends.
+
+Open the round with `roundtable_create` (passing the carrier `issue_id`, topic, and participant count) and keep the returned `roundtable_id`.
 
 ## Phase 2 — Collect (parallel Task spawns)
 


### PR DESCRIPTION
Closes #1020. Addresses onboard/roundtable items of #1041.

**HELD FOR HUMAN REVIEW — prompt-surface change, do not auto-merge.**

- commands/onboard.md: add required `shape=<shape>` to every onboard_apply call (round-2 per-repo + final workspace apply); remove the stale 'bro passes the probe to the server' claim (server re-probes internally)
- commands/roundtable.md: document how the carrier issue_id for roundtable_create is obtained/created

pr-reviewer: PASS.