### PR TITLE
📝 fix(prompts): self-contained cheatcode skill + drop docs/ routes + tool-based carrier lookup (#1022, #1041)

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -2,4 +2,4 @@
 
 > **Status: not implemented.** TMB ships Claude Code only. When a Codex adapter ships under `.codex-plugin/`, this file becomes its bro-persona doctrine (the Codex equivalent of `CLAUDE.md`).
 
-Strategy and build-out plan: [`docs/reference/MULTI_PLATFORM.md`](./docs/reference/MULTI_PLATFORM.md) · adapter notes: [`.codex-plugin/README.md`](./.codex-plugin/README.md)
+Adapter notes: [`.codex-plugin/README.md`](./.codex-plugin/README.md).

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -2,4 +2,4 @@
 
 > **Status: not implemented.** TMB ships Claude Code only. When a Cursor adapter ships under `.cursor-plugin/`, this file becomes its bro-persona doctrine (the Cursor equivalent of `CLAUDE.md`).
 
-Strategy and build-out plan: [`docs/reference/MULTI_PLATFORM.md`](./docs/reference/MULTI_PLATFORM.md) · adapter notes: [`.cursor-plugin/README.md`](./.cursor-plugin/README.md)
+Adapter notes: [`.cursor-plugin/README.md`](./.cursor-plugin/README.md).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -2,4 +2,4 @@
 
 > **Status: not implemented.** TMB ships Claude Code only. When a Gemini adapter ships (manifest: `gemini-extension.json`), this file becomes its bro-persona doctrine (the Gemini equivalent of `CLAUDE.md`).
 
-Strategy and build-out plan: [`docs/reference/MULTI_PLATFORM.md`](./docs/reference/MULTI_PLATFORM.md) · adapter notes: [`.opencode/README.md`](./.opencode/README.md) covers the OpenCode sibling; Gemini build-out lives in the strategy doc.
+Adapter notes: [`.opencode/README.md`](./.opencode/README.md) covers the OpenCode sibling.

--- a/skills/tmb_cheatcode/SKILL.md
+++ b/skills/tmb_cheatcode/SKILL.md
@@ -56,4 +56,13 @@ Lead the chat with the rationale — what the cheatcode does, its tier, and the 
 
 If the Human named the agent — "install X for swe", "code-review for pr-reviewer" — use it. Otherwise infer from the cheatcode's domain: coding / test / refactor / debug → `swe`; code-review / quality → `pr-reviewer`; orchestration / routing / planning → `bro`; a consultant's domain → that consultant. Reach for AskUserQuestion only when it's genuinely ambiguous.
 
-The full lifecycle (search → vet → approve → install → materialize → activate) lives in [`docs/architecture/FLOWS.md`](../../docs/architecture/FLOWS.md) flow 10.
+## Approve, install, activate
+
+Approval is a hard gate: `cheatcode_approve` records the per-candidate Human approval, and the install PreToolUse gate fails closed without it. Rejected → stop.
+
+Once approved, `cheatcode_install` runs the marketplace/MCP path (no seed/copy), idempotent on (name, source_url), recording the `cheatcodes` row + attachments + audit in one transaction. It materializes the attachment IN THE USER PROJECT (never the plugin repo):
+
+- **skill** (or skill-contributing plugin): `target=bro` adds a reference to `.claude/CLAUDE.md`; any other target copies the global `agents/<target>.md` into `.claude/agents/<target>.md` (if absent) and adds the name to its `skills:` frontmatter. A skill with no resolved target is hard-rejected — no orphan can land.
+- **mcp / pure-server plugin**: its registration IS its attachment — no target, no `skills:` entry needed.
+
+Then `cheatcode_activate`: a skill is usable in-session immediately; an MCP/plugin returns `restart_required` and loads on the next cold start.

--- a/skills/tmb_comment-triage/SKILL.md
+++ b/skills/tmb_comment-triage/SKILL.md
@@ -20,7 +20,7 @@ Empty result → ask the Human which PR/MR number to monitor (free-text answer).
 
 Call `pr_monitor_comments_get` with the PR number.
 
-Carrier: look up the issue via `tasks.branch_id` for the current branch. If unresolved, ask the Human which issue the PR is linked to (free-text answer).
+Carrier: resolve the linked issue with `branch_report_md` for the current branch rather than reading the DB directly. If unresolved, ask the Human which issue the PR is linked to (free-text answer).
 
 ## Triage (judgment)
 


### PR DESCRIPTION
Closes #1022. Addresses items 3-5 of #1041.

**HELD FOR HUMAN REVIEW — prompt-surface change, do not auto-merge.**

- skills/tmb_cheatcode: inline the approve→install→materialize→activate lifecycle; remove the docs/architecture/FLOWS.md route (docs/ doesn't ship)
- CODEX.md / CURSOR.md / GEMINI.md: drop the docs/reference/MULTI_PLATFORM.md routes (kept shipping adapter READMEs)
- skills/tmb_comment-triage: raw tasks.branch_id lookup → branch_report_md tool call

CLAUDE.md left untouched (Human-owned). **Action for you:** add this row to the CLAUDE.md Skills table so tmb_cheatcode is discoverable outside the planning flow:
```
| A task leans on a capability the project lacks — a published skill / MCP / plugin would close the gap | `tmb_cheatcode` |
```

pr-reviewer: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)