### PR TITLE
🔒 fix(hooks): close guard bypasses + branch SQLi + deny-reason field (#1016 #1024 #1031 #1032 #1033 #1034)

### DIFF
--- a/scripts/hooks/attribution-footer.sh
+++ b/scripts/hooks/attribution-footer.sh
@@ -107,11 +107,14 @@ case "$KIND" in
     ;;
   glab-mr)
     command -v glab >/dev/null 2>&1 || exit 0
-    ORIG=$(glab mr view "$NUMBER" 2>/dev/null) || exit 0
+    # Read the RAW description via -F json (#1034). The plain `glab mr view`
+    # renders a decorated table (title/labels/etc.) — feeding that back into
+    # --description clobbered the real body with rendered chrome.
+    ORIG=$(glab mr view "$NUMBER" -F json 2>/dev/null | jq -r '.description // ""') || exit 0
     ;;
   glab-issue)
     command -v glab >/dev/null 2>&1 || exit 0
-    ORIG=$(glab issue view "$NUMBER" 2>/dev/null) || exit 0
+    ORIG=$(glab issue view "$NUMBER" -F json 2>/dev/null | jq -r '.description // ""') || exit 0
     ;;
 esac
 

--- a/scripts/hooks/cheatcode-install-approval.sh
+++ b/scripts/hooks/cheatcode-install-approval.sh
@@ -32,7 +32,7 @@ esac
 
 deny() {
   jq -nc --arg reason "$1" \
-    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":$reason}}'
+    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$reason}}'
   exit 0
 }
 

--- a/scripts/hooks/git-guards.sh
+++ b/scripts/hooks/git-guards.sh
@@ -168,9 +168,13 @@ _RULE1_FORGE=$(_rule1_match "$CMD" || true)
 if [ -n "$_RULE1_FORGE" ]; then
   if [ "$_RULE1_FORGE" = "gh" ]; then
     # --- gh pr create ---
-    if echo "$CMD" | grep -qF -- "--base ${PR_TARGET}"; then
+    # Extract the --base value and compare at a token boundary (#1032). The old
+    # `grep -qF -- "--base dev"` substring-matched `--base dev-old` / `--base
+    # development` (false OK) and `--base main` matched `--base maintenance`.
+    BASE_BRANCH=$(echo "$CMD" | grep -oE -- '--base[= ][^[:space:]]+' | head -1 | sed -E 's/--base[= ]+//' | tr -d "'\"" || true)
+    if [ -n "$BASE_BRANCH" ] && [ "$BASE_BRANCH" = "$PR_TARGET" ]; then
       :  # OK — feature → pr_target (the standard path)
-    elif [ "$PR_TARGET" = "dev" ] && echo "$CMD" | grep -qF -- "--base main"; then
+    elif [ "$PR_TARGET" = "dev" ] && [ "$BASE_BRANCH" = "main" ]; then
       # Dual-tier exception: dev → main release merge.
       HEAD_BRANCH=$(echo "$CMD" | grep -oE -- '--head[= ][^[:space:]]+' | head -1 | sed -E 's/--head[= ]+//' | tr -d "'\"" || true)
       if [ -z "$HEAD_BRANCH" ]; then
@@ -258,28 +262,29 @@ _is_force_push() {
   # --follow-tags contains no force token; --force-with-lease is a force flag.
   printf '%s' "$clause" | grep -qE '(^|[[:space:]])(--force(-with-lease)?|-f)([[:space:]]|$)'
 }
-case "$CMD" in
-  *"git push"*)
-    if _is_force_push "$CMD"; then
-      PUSH_CLAUSE=$(_push_clause "$CMD")
-      if printf '%s' "$PUSH_CLAUSE" | grep -qE '\b(origin|upstream)\s+\S+'; then
-        PUSH_TARGET=$(printf '%s' "$PUSH_CLAUSE" | grep -oE '\b(origin|upstream)\s+\S+' | awk '{print $2}')
-        if branch_is_protected "$PUSH_TARGET"; then
-          jq -nc --arg r "BLOCKED: Force push to ${PUSH_TARGET} is forbidden. This is destructive and irreversible." \
-            '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
-          exit 0
-        fi
-      else
-        BRANCH=$(cmd_branch "$CMD")
-        if [ -n "$BRANCH" ] && branch_is_protected "$BRANCH"; then
-          jq -nc --arg r "BLOCKED: Force push to ${BRANCH} is forbidden. This is destructive and irreversible." \
-            '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
-          exit 0
-        fi
-      fi
+# The outer trigger is _is_force_push itself (which extracts the push clause via
+# _push_clause and token-matches force flags with grep -qE — already whitespace
+# tolerant). The old bare `case *"git push"*` gate was literal single-space and
+# failed open on `git  push --force origin main` (#1016): the force-push branch
+# never ran, so a double-spaced force-push to a protected branch slipped through.
+if _is_force_push "$CMD"; then
+  PUSH_CLAUSE=$(_push_clause "$CMD")
+  if printf '%s' "$PUSH_CLAUSE" | grep -qE '\b(origin|upstream)\s+\S+'; then
+    PUSH_TARGET=$(printf '%s' "$PUSH_CLAUSE" | grep -oE '\b(origin|upstream)\s+\S+' | awk '{print $2}')
+    if branch_is_protected "$PUSH_TARGET"; then
+      jq -nc --arg r "BLOCKED: Force push to ${PUSH_TARGET} is forbidden. This is destructive and irreversible." \
+        '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+      exit 0
     fi
-    ;;
-esac
+  else
+    BRANCH=$(cmd_branch "$CMD")
+    if [ -n "$BRANCH" ] && branch_is_protected "$BRANCH"; then
+      jq -nc --arg r "BLOCKED: Force push to ${BRANCH} is forbidden. This is destructive and irreversible." \
+        '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+      exit 0
+    fi
+  fi
+fi
 
 # --- Rule 4: New branches must be based on latest pr_target (worktree-aware) ---
 # Remote freshness check is skipped when the repo has no origin remote or

--- a/scripts/hooks/git-push-guard.sh
+++ b/scripts/hooks/git-push-guard.sh
@@ -24,22 +24,31 @@ CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 AGENT_TYPE=$(tmb_normalize_role "$(echo "$INPUT" | jq -r '.agent_type // .subagent_type // .tool_input.subagent_type // empty' 2>/dev/null || true)")
 
 # Only fire for git push (not push --force; that's git-guards's job).
-# Matches both `git push ...` and `git -C <path> push ...` forms.
+# Whitespace-tolerant, boundary-anchored detection (#1016): the old literal
+# `case` substrings failed open on `git  push` (double space), leading- or
+# newline-prefixed forms, and `bash -c "git push"` / `eval "..."` wrappers.
+# _norm_cmd strips quotes (so wrapper forms collapse to a bare command),
+# squeezes whitespace runs, pads, and rewrites shell-executor prefixes
+# (`-c `, `eval `) to a statement separator. A push is then `git [ -C <p> ]
+# push` anchored at a statement boundary (start, or after ; & |) — which
+# ignores `git push` sitting inside quoted data (grep/echo/commit -m).
+_norm_cmd() {
+  local n
+  n=$(printf '%s' "$1" | tr -d "\"'" | tr -s '[:space:]' ' ')
+  n=" $n "
+  printf '%s' "$n" | sed -E 's/ -c / ; /g; s/ eval / ; /g'
+}
+_is_git_push() {
+  printf '%s' "$1" | grep -qE '(^[[:space:]]*|[;&|][[:space:]]*)git[[:space:]]+(-C[[:space:]]+[^[:space:]]+[[:space:]]+)?push([[:space:]]|$)'
+}
+_is_force_push_cmd() {
+  printf '%s' "$1" | grep -qE 'push[^;&|]*[[:space:]](--force(-with-lease)?|-f)([[:space:]]|$)'
+}
+NCMD=$(_norm_cmd "$CMD")
 IS_PUSH=""
 IS_FORCE=""
-case "$CMD" in
-  "git push"*|"git -C "*" push"*) IS_PUSH="yes" ;;
-  *"; git push"*|*"&& git push"*|*"|| git push"*|*"| git push"*) IS_PUSH="yes" ;;
-  *"; git -C "*" push"*|*"&& git -C "*" push"*|*"|| git -C "*" push"*) IS_PUSH="yes" ;;
-esac
-case "$CMD" in
-  "git push"*"--force"*|"git push"*"-f "*) IS_FORCE="yes" ;;
-  "git -C "*" push"*"--force"*|"git -C "*" push"*"-f "*) IS_FORCE="yes" ;;
-  *"; git push"*"--force"*|*"&& git push"*"--force"*|*"|| git push"*"--force"*) IS_FORCE="yes" ;;
-  *"; git push"*"-f "*|*"&& git push"*"-f "*|*"|| git push"*"-f "*) IS_FORCE="yes" ;;
-  *"; git -C "*" push"*"--force"*|*"&& git -C "*" push"*"--force"*|*"|| git -C "*" push"*"--force"*) IS_FORCE="yes" ;;
-  *"; git -C "*" push"*"-f "*|*"&& git -C "*" push"*"-f "*|*"|| git -C "*" push"*"-f "*) IS_FORCE="yes" ;;
-esac
+_is_git_push "$NCMD" && IS_PUSH="yes"
+[ "$IS_PUSH" = "yes" ] && _is_force_push_cmd "$NCMD" && IS_FORCE="yes"
 [ "$IS_PUSH" = "yes" ] || exit 0
 [ "$IS_FORCE" = "yes" ] && exit 0
 
@@ -96,7 +105,7 @@ if [ -z "$WT_CWD" ] && [ -z "$CD_OVERRIDE" ] && \
 fi
 
 if [ "$WT_CWD" = "yes" ]; then
-  jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":"BLOCKED: push from .claude/worktrees/ is forbidden. Bro pushes from the main checkout after reaped the detached-HEAD commits via `git fetch ./.claude/worktrees/<slug> HEAD:<feature>`."}}'
+  jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: push from .claude/worktrees/ is forbidden. Bro pushes from the main checkout after reaped the detached-HEAD commits via `git fetch ./.claude/worktrees/<slug> HEAD:<feature>`."}}'
   exit 0
 fi
 
@@ -104,7 +113,7 @@ fi
 # Defense-in-depth fallback: catches non-worktree SWE pushes and cases where
 # CC #97 might strip the agent_type field from the payload.
 if [ "$AGENT_TYPE" = "swe" ]; then
-  jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":"BLOCKED: SWE must never push. Bro handles the push gate after pr-reviewer passes. Commit in your worktree and call task_update_status(completed)."}}'
+  jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: SWE must never push. Bro handles the push gate after pr-reviewer passes. Commit in your worktree and call task_update_status(completed)."}}'
   exit 0
 fi
 
@@ -112,7 +121,7 @@ fi
 # pr-reviewer renders a verdict row; the push decision belongs to bro
 # after that verdict — pr-reviewer itself must never initiate a push.
 if [ "$AGENT_TYPE" = "pr-reviewer" ]; then
-  jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":"BLOCKED: pr-reviewer must not push. The push decision belongs to bro after the verdict row. Bro reads the validation_attempts verdict and handles the push when all tasks are signed."}}'
+  jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: pr-reviewer must not push. The push decision belongs to bro after the verdict row. Bro reads the validation_attempts verdict and handles the push when all tasks are signed."}}'
   exit 0
 fi
 
@@ -223,5 +232,5 @@ Run: @bro review before push
 bro will spawn pr-reviewer for each unsigned task. On all-pass the push will proceed. On any fail bro surfaces what needs fixing."
 
 jq -nc --arg reason "$DENY_REASON" \
-  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":$reason}}'
+  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$reason}}'
 exit 0

--- a/scripts/hooks/no-remote-auth-guard.sh
+++ b/scripts/hooks/no-remote-auth-guard.sh
@@ -57,4 +57,4 @@ HAS_REMOTE=$(printf '%s' "$REMOTES_JSON" | \
 REASON="BLOCKED: No remote is configured (remotes have no URL) — TMB is operating locally. Interactive '${MATCHED_TOOL} auth login' will hang here (no TTY/network); remote/push ops are skipped. Work locally."
 
 jq -nc --arg reason "$REASON" \
-  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":$reason}}'
+  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$reason}}'

--- a/scripts/hooks/no-source-edit-from-main.sh
+++ b/scripts/hooks/no-source-edit-from-main.sh
@@ -56,11 +56,14 @@ fi
 if [ "$TOOL_NAME" = "Bash" ]; then
   CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
 
-  # Worktree exemption: if the command is operating inside a worktree, allow.
-  _main_bash_in_worktree() {
-    local cmd="$1"
-    case "$cmd" in
-      */.claude/worktrees/*|*.claude/worktrees/*) return 0 ;;
+  # Worktree exemption: allow only when the WRITE TARGET (destination token)
+  # lives inside a worktree — not merely because the command string mentions a
+  # worktree path anywhere (#1031). The old whole-command test exempted
+  # `sed '...' .claude/worktrees/x/agents/a.md > agents/a.md`, which reads from a
+  # worktree but WRITES a prompt surface in the main checkout.
+  _token_in_worktree() {
+    case "$1" in
+      */.claude/worktrees/*|.claude/worktrees/*) return 0 ;;
     esac
     return 1
   }
@@ -81,8 +84,10 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     return 1
   }
 
-  # _main_bash_writes_prompt_surface: destination-coupled matching.
-  # The verb/redirect operator must be adjacent to the prompt-surface path token.
+  # _main_bash_writes_prompt_surface: destination-coupled matching. The verb/
+  # redirect operator must be adjacent to the prompt-surface path token. On a
+  # match it prints the destination token (so the caller can test THAT token
+  # against the worktree exemption) and returns 0; otherwise returns 1.
   _main_bash_writes_prompt_surface() {
     local cmd="$1"
 
@@ -93,7 +98,7 @@ if [ "$TOOL_NAME" = "Bash" ]; then
         after_redir="${cmd##*>>}"
         after_redir="${after_redir#"${after_redir%%[! ]*}"}"
         local dest_tok="${after_redir%% *}"
-        _is_prompt_surface_token "$dest_tok" && return 0
+        _is_prompt_surface_token "$dest_tok" && { printf '%s' "$dest_tok"; return 0; }
         ;;
     esac
     case "$cmd" in
@@ -105,7 +110,7 @@ if [ "$TOOL_NAME" = "Bash" ]; then
             after_redir="${no_dbl##*>}"
             after_redir="${after_redir#"${after_redir%%[! ]*}"}"
             local dest_tok2="${after_redir%% *}"
-            _is_prompt_surface_token "$dest_tok2" && return 0
+            _is_prompt_surface_token "$dest_tok2" && { printf '%s' "$dest_tok2"; return 0; }
             ;;
         esac
         ;;
@@ -123,7 +128,7 @@ if [ "$TOOL_NAME" = "Bash" ]; then
           "-a "*) tee_rest="${tee_rest#-a }" ;;
         esac
         local tee_dest="${tee_rest%% *}"
-        _is_prompt_surface_token "$tee_dest" && return 0
+        _is_prompt_surface_token "$tee_dest" && { printf '%s' "$tee_dest"; return 0; }
         ;;
     esac
 
@@ -136,7 +141,7 @@ if [ "$TOOL_NAME" = "Bash" ]; then
           *"sed -i"*) after_sedi="${cmd##*sed -i}" ;;
         esac
         local sedi_file="${after_sedi##* }"
-        _is_prompt_surface_token "$sedi_file" && return 0
+        _is_prompt_surface_token "$sedi_file" && { printf '%s' "$sedi_file"; return 0; }
         ;;
     esac
 
@@ -145,7 +150,7 @@ if [ "$TOOL_NAME" = "Bash" ]; then
       *"perl -i"*)
         local after_perli="${cmd##*perl -i}"
         local perli_file="${after_perli##* }"
-        _is_prompt_surface_token "$perli_file" && return 0
+        _is_prompt_surface_token "$perli_file" && { printf '%s' "$perli_file"; return 0; }
         ;;
     esac
 
@@ -158,7 +163,7 @@ if [ "$TOOL_NAME" = "Bash" ]; then
         open_path="${open_path%\'}"
         open_path="${open_path#\"}"
         open_path="${open_path%\"}"
-        _is_prompt_surface_token "$open_path" && return 0
+        _is_prompt_surface_token "$open_path" && { printf '%s' "$open_path"; return 0; }
         ;;
     esac
 
@@ -166,15 +171,17 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     case "$cmd" in
       "cp "*|*" cp "*|"mv "*|*" mv "*|"rsync "*|*" rsync "*)
         local copy_last="${cmd##* }"
-        _is_prompt_surface_token "$copy_last" && return 0
+        _is_prompt_surface_token "$copy_last" && { printf '%s' "$copy_last"; return 0; }
         ;;
     esac
 
     return 1
   }
 
-  if ! _main_bash_in_worktree "$CMD" \
-      && _main_bash_writes_prompt_surface "$CMD"; then
+  # Exempt only when the WRITE DESTINATION is inside a worktree (#1031) — not
+  # when the command merely reads from one.
+  _BASH_DEST_TOK=$(_main_bash_writes_prompt_surface "$CMD")
+  if [ -n "$_BASH_DEST_TOK" ] && ! _token_in_worktree "$_BASH_DEST_TOK"; then
     BASH_DENY_REASON="BLOCKED: Bash write-forms targeting prompt-surface files (agents/*.md, skills/*/SKILL.md, commands/*.md, templates/*.md, CLAUDE.md, CODEX/CURSOR/GEMINI.md) are denied from the main checkout for every agent identity. Sanctioned route: spawn an SWE task (prompt_bearing=1) for intentional prompt edits. Reads (cat/grep/sed -n) are always allowed."
     jq -nc --arg reason "$BASH_DENY_REASON" '{
       hookSpecificOutput: {

--- a/scripts/hooks/post-pr-comments-persist.sh
+++ b/scripts/hooks/post-pr-comments-persist.sh
@@ -46,18 +46,38 @@ TOOL_OUTPUT=$(echo "$INPUT" | jq -r '.tool_response.content[0].text // .tool_res
 COMMENTS=$(echo "$TOOL_OUTPUT" | jq -c '.comments // [] | .[]' 2>/dev/null) || exit 0
 [ -n "$COMMENTS" ] || exit 0
 
-PR_NUMBER=$(echo "$TOOL_OUTPUT" | jq -r '.pr_number // 0' 2>/dev/null)
+# PR number: prefer the tool_input args (authoritative), fall back to the
+# tool_response payload for the harness. Integer-validated so interpolation is safe.
+PR_NUMBER=$(echo "$INPUT" | jq -r '.tool_input.pr_number // empty' 2>/dev/null)
+[ -n "$PR_NUMBER" ] || PR_NUMBER=$(echo "$TOOL_OUTPUT" | jq -r '.pr_number // empty' 2>/dev/null)
+case "$PR_NUMBER" in
+  ''|*[!0-9]*) exit 0 ;;
+esac
+
+REPO=$(echo "$INPUT" | jq -r '.tool_input.repo // empty' 2>/dev/null)
+REPO_ESC=$(printf '%s' "$REPO" | sed "s/'/''/g")
 
 NOW=$(date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
 
-# Resolve carrier issue_id: look up via plugin_config current branch → tasks → issue
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
-ISSUE_ID=""
-if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "HEAD" ]; then
-  ISSUE_ID=$(sqlite3 "$DB" \
-    "SELECT issue_id FROM tasks WHERE branch_id='${CURRENT_BRANCH}' AND status NOT IN ('closed','failed') LIMIT 1" \
-    2>/dev/null || true)
+# Resolve the carrier issue from the PR (pr_number [+ repo]) — NOT the git branch
+# (#1024). `git rev-parse --abbrev-ref HEAD` from the main checkout returns the
+# base branch (dev/main), which never matches a feature task's branch_id, so the
+# hook silently dropped every comment; worse, the branch was interpolated raw
+# into SQL (an injection sink). pr_review_runs is the pr_number-keyed link to a
+# task; PR_NUMBER is integer-validated and REPO is sed-escaped like AUTHOR/BODY.
+if [ -n "$REPO" ]; then
+  REPO_CLAUSE="AND r.repo = '${REPO_ESC}'"
+else
+  REPO_CLAUSE=""
 fi
+ISSUE_ID=$(sqlite3 "$DB" \
+  "SELECT t.issue_id
+     FROM pr_review_runs r
+     JOIN tasks t ON t.id = r.task_id
+    WHERE r.pr_number = ${PR_NUMBER} ${REPO_CLAUSE}
+      AND t.status NOT IN ('closed','failed')
+    ORDER BY r.id DESC LIMIT 1" \
+  2>/dev/null || true)
 [ -n "$ISSUE_ID" ] || exit 0
 
 echo "$COMMENTS" | while IFS= read -r comment; do

--- a/scripts/hooks/pr-reviewer-after-atomic-close.sh
+++ b/scripts/hooks/pr-reviewer-after-atomic-close.sh
@@ -56,7 +56,7 @@ if [ -z "$STATUS" ]; then
   # Distinguish DB busy from row-missing: re-probe without -readonly.
   PROBE=$(sqlite3 "$DB" "SELECT COUNT(*) FROM tasks WHERE id=${TASK_ID};" 2>/dev/null || echo "query_failed")
   if [ "$PROBE" = "query_failed" ]; then
-    jq -nc --arg id "$TASK_ID" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: DB query failed for task_id="+$id+" (DB busy?). Retry the pr-reviewer spawn once the DB lock clears.")}}'
+    jq -nc --arg id "$TASK_ID" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":("BLOCKED: DB query failed for task_id="+$id+" (DB busy?). Retry the pr-reviewer spawn once the DB lock clears.")}}'
     exit 0
   fi
   # Row missing — let pr-reviewer surface the error itself.
@@ -81,7 +81,7 @@ jq -nc --arg reason "$_DENY_REASON" '{
   hookSpecificOutput: {
     hookEventName: "PreToolUse",
     permissionDecision: "deny",
-    denyReason: $reason
+    permissionDecisionReason: $reason
   }
 }'
 exit 0

--- a/scripts/hooks/remote-id-guard.sh
+++ b/scripts/hooks/remote-id-guard.sh
@@ -115,4 +115,4 @@ $(printf '%b' "$OFFENSES")
 A bare #N in a PR body / gh issue comment resolves to remote issue N, not the local one. Use the remote id shown above. (Bypass: TMB_DISABLE_REMOTE_ID_GUARD=1.)"
 
 jq -nc --arg reason "$REASON" \
-  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":$reason}}'
+  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$reason}}'

--- a/scripts/hooks/require-feature-branch-active.sh
+++ b/scripts/hooks/require-feature-branch-active.sh
@@ -51,7 +51,7 @@ if [ -n "$REPO" ]; then
   fi
   if [ ! -d "$REPO_ABS/.git" ]; then
     jq -nc --arg id "$TASK_ID" --arg repo "$REPO" --arg path "$REPO_ABS" \
-      '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: cannot resolve repo for task "+$id+". tasks.repo="+$repo+" does not point to a git repo at "+$path+". Verify the path is correct.")}}'
+      '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":("BLOCKED: cannot resolve repo for task "+$id+". tasks.repo="+$repo+" does not point to a git repo at "+$path+". Verify the path is correct.")}}'
     exit 0
   fi
 else
@@ -62,7 +62,7 @@ else
   [ -n "$REPO_ABS" ] || REPO_ABS="$WORKSPACE_ROOT"
   if [ ! -d "$REPO_ABS/.git" ]; then
     jq -nc --arg id "$TASK_ID" \
-      '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: cannot resolve repo for task "+$id+". tasks.repo IS NULL and no single registered repo could be resolved. For a multi-repo workspace, set the task'"'"'s repo (task_create repo=<name>) so it maps to a repos row.")}}'
+      '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":("BLOCKED: cannot resolve repo for task "+$id+". tasks.repo IS NULL and no single registered repo could be resolved. For a multi-repo workspace, set the task'"'"'s repo (task_create repo=<name>) so it maps to a repos row.")}}'
     exit 0
   fi
 fi
@@ -71,7 +71,7 @@ fi
 # main checkout is on it — the main checkout stays on <base>.
 if ! git -C "$REPO_ABS" show-ref --verify --quiet "refs/heads/$EXPECTED"; then
   jq -nc --arg id "$TASK_ID" --arg branch "$EXPECTED" --arg repo "$REPO_ABS" \
-    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: SWE spawn for task "+$id+" needs branch "+$branch+" to exist first — bro pre-creates it (\"git -C "+$repo+" branch "+$branch+" origin/<base>\") and stays on <base>; SWE'\''s worktree owns the branch.")}}'
+    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":("BLOCKED: SWE spawn for task "+$id+" needs branch "+$branch+" to exist first — bro pre-creates it (\"git -C "+$repo+" branch "+$branch+" origin/<base>\") and stays on <base>; SWE'\''s worktree owns the branch.")}}'
   exit 0
 fi
 

--- a/scripts/hooks/require-task-spec.sh
+++ b/scripts/hooks/require-task-spec.sh
@@ -19,13 +19,13 @@ PROMPT=$(echo "$INPUT" | jq -r '.tool_input.prompt // empty')
 TASK_ID=$(echo "$PROMPT" | grep -oE 'task_id[=:][[:space:]]*[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
 
 if [ -z "$TASK_ID" ]; then
-  jq -nc '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",denyReason:"BLOCKED: SWE spawn requires task_id=<N> in the prompt pointing at a row in the tasks table. Route through bro (bro plans, then spawns SWE with task_id)."}}'
+  jq -nc '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:"BLOCKED: SWE spawn requires task_id=<N> in the prompt pointing at a row in the tasks table. Route through bro (bro plans, then spawns SWE with task_id)."}}'
   exit 0
 fi
 
 DB=$(tmb_db_path || true)
 if [ -z "$DB" ] || ! tmb_have_sqlite; then
-  jq -nc '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",denyReason:"BLOCKED: trajectory.db not found or sqlite3 unavailable. Cannot verify task authorization."}}'
+  jq -nc '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:"BLOCKED: trajectory.db not found or sqlite3 unavailable. Cannot verify task authorization."}}'
   exit 0
 fi
 
@@ -37,9 +37,9 @@ if [ -z "$ROW" ]; then
   SAFE_TASK_ID=$(tmb_sql_int "$TASK_ID")
   PROBE=$(sqlite3 "$DB" "SELECT COUNT(*) FROM tasks WHERE id=${SAFE_TASK_ID};" 2>/dev/null || echo "query_failed")
   if [ "$PROBE" = "query_failed" ]; then
-    jq -nc --arg id "$TASK_ID" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: DB query failed for task_id="+$id+" (DB busy?). Retry the spawn once the DB lock clears.")}}'
+    jq -nc --arg id "$TASK_ID" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":("BLOCKED: DB query failed for task_id="+$id+" (DB busy?). Retry the spawn once the DB lock clears.")}}'
   else
-    jq -nc --arg id "$TASK_ID" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: task_id="+$id+" does not exist in the tasks table.")}}'
+    jq -nc --arg id "$TASK_ID" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":("BLOCKED: task_id="+$id+" does not exist in the tasks table.")}}'
   fi
   exit 0
 fi
@@ -48,12 +48,12 @@ STATUS=$(echo "$ROW" | awk 'NR==1')
 BODY_LEN=$(echo "$ROW" | awk 'NR==2')
 
 if [ "$STATUS" != "pending" ] && [ "$STATUS" != "open" ]; then
-  jq -nc --arg id "$TASK_ID" --arg st "$STATUS" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: task_id="+$id+" has status="+$st+", expected pending or open.")}}'
+  jq -nc --arg id "$TASK_ID" --arg st "$STATUS" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":("BLOCKED: task_id="+$id+" has status="+$st+", expected pending or open.")}}'
   exit 0
 fi
 
 if [ "${BODY_LEN:-0}" -eq 0 ]; then
-  jq -nc --arg id "$TASK_ID" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: task_id="+$id+" has empty spec_body. bro must populate spec_body via task_create_batch before SWE can execute.")}}'
+  jq -nc --arg id "$TASK_ID" '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":("BLOCKED: task_id="+$id+" has empty spec_body. bro must populate spec_body via task_create_batch before SWE can execute.")}}'
   exit 0
 fi
 

--- a/scripts/hooks/swe-boundary.sh
+++ b/scripts/hooks/swe-boundary.sh
@@ -87,18 +87,25 @@ esac
 if [ "$TOOL_NAME" = "Bash" ] && [ "$SWE_CTX" = "yes" ]; then
   CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 
+  # Whitespace-tolerant, boundary-anchored push detection (#1016): the old
+  # literal `case` substrings failed open on `git  push` (double space),
+  # leading-/newline-prefixed forms, and `bash -c "git push"` / `eval "..."`
+  # wrappers. _norm_cmd strips quotes, squeezes whitespace, pads, and rewrites
+  # shell-executor prefixes (`-c `, `eval `) to a statement separator; a push is
+  # then `git [ -C <p> ] push` anchored at a statement boundary.
+  _norm_cmd() {
+    local n
+    n=$(printf '%s' "$1" | tr -d "\"'" | tr -s '[:space:]' ' ')
+    n=" $n "
+    printf '%s' "$n" | sed -E 's/ -c / ; /g; s/ eval / ; /g'
+  }
+  NCMD=$(_norm_cmd "$CMD")
   IS_PUSH=""
   IS_FORCE=""
-  case "$CMD" in
-    "git push"*|"git -C "*" push"*) IS_PUSH="yes" ;;
-    *"; git push"*|*"&& git push"*|*"|| git push"*) IS_PUSH="yes" ;;
-    *"; git -C "*" push"*|*"&& git -C "*" push"*|*"|| git -C "*" push"*) IS_PUSH="yes" ;;
-  esac
-  case "$CMD" in
-    *"--force"*|*" -f "*) IS_FORCE="yes" ;;
-  esac
+  printf '%s' "$NCMD" | grep -qE '(^[[:space:]]*|[;&|][[:space:]]*)git[[:space:]]+(-C[[:space:]]+[^[:space:]]+[[:space:]]+)?push([[:space:]]|$)' && IS_PUSH="yes"
+  printf '%s' "$NCMD" | grep -qE 'push[^;&|]*[[:space:]](--force(-with-lease)?|-f)([[:space:]]|$)' && IS_FORCE="yes"
   if [ "$IS_PUSH" = "yes" ] && [ "$IS_FORCE" != "yes" ]; then
-    jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":"BLOCKED: SWE must never push. Bro handles the push gate after pr-reviewer passes. Commit in your worktree and call task_update_status(completed)."}}'
+    jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: SWE must never push. Bro handles the push gate after pr-reviewer passes. Commit in your worktree and call task_update_status(completed)."}}'
     exit 0
   fi
 
@@ -116,7 +123,7 @@ if [ "$TOOL_NAME" = "Bash" ] && [ "$SWE_CTX" = "yes" ]; then
     *"glab mr create"*|*"glab mr merge"*|*"glab mr close"*|*"glab mr edit"*) GH_MUTATING="yes" ;;
   esac
   if [ "$GH_MUTATING" = "yes" ]; then
-    jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":"BLOCKED: SWE may not run gh/glab mutating commands (create/close/edit/merge/delete/api POST|PATCH|PUT|DELETE). Read-only gh commands (view, list, status) are allowed. Mutations go through bro."}}'
+    jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: SWE may not run gh/glab mutating commands (create/close/edit/merge/delete/api POST|PATCH|PUT|DELETE). Read-only gh commands (view, list, status) are allowed. Mutations go through bro."}}'
     exit 0
   fi
 
@@ -296,7 +303,7 @@ if [ "$TOOL_NAME" = "Bash" ] && [ "$SWE_CTX" = "yes" ]; then
       fi
     fi
     if [ "$_PB_ALLOWED" != "yes" ]; then
-      jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":"BLOCKED: SWE may not write prompt-surface files via Bash (>, >>, tee, sed -i, perl -i, python open w/a, cp/mv/rsync). Sanctioned routes: use a prompt_bearing=1 task for intentional prompt edits, or pr_monitor_worktree for reviewer experiments. Reads (cat/grep/sed -n) are always allowed."}}'
+      jq -nc '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: SWE may not write prompt-surface files via Bash (>, >>, tee, sed -i, perl -i, python open w/a, cp/mv/rsync). Sanctioned routes: use a prompt_bearing=1 task for intentional prompt edits, or pr_monitor_worktree for reviewer experiments. Reads (cat/grep/sed -n) are always allowed."}}'
       exit 0
     fi
   fi
@@ -333,7 +340,7 @@ if [ -n "$WORKTREE_ROOT" ]; then
     *)
       DENY_MSG="BLOCKED: SWE may only edit files inside its assigned worktree (${WORKTREE_ROOT}). Target '${TARGET}' is outside the worktree."
       jq -nc --arg r "$DENY_MSG" \
-        '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":$r}}'
+        '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$r}}'
       exit 0
       ;;
   esac
@@ -372,7 +379,7 @@ if [ "$IS_PROMPT_SURFACE" = "yes" ]; then
   fi
   PS_DENY_MSG="BLOCKED: SWE may not edit prompt-surface files (agents/, skills/*/SKILL.md, commands/, templates/, CLAUDE.md, CODEX/CURSOR/GEMINI.md). Target: ${TARGET}. If this task intentionally modifies agent prompts, set prompt_bearing=1 in task_create_batch."
   jq -nc --arg r "$PS_DENY_MSG" \
-    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":$r}}'
+    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$r}}'
   exit 0
 fi
 

--- a/scripts/hooks/swe-brief-gate.sh
+++ b/scripts/hooks/swe-brief-gate.sh
@@ -151,5 +151,5 @@ fi
 DENY_REASON="BLOCKED: SWE must call task_brief(agent='swe', task_id=${TASK_ID}) before ${TOOL_NAME:-this tool}. task_brief delivers the spec, worktree path, and decision thread in one deterministic call. Recovery: task_brief(agent='swe', task_id=${TASK_ID})"
 
 jq -nc --arg reason "$DENY_REASON" \
-  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":$reason}}'
+  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$reason}}'
 exit 0

--- a/scripts/hooks/swe-scope-fence.sh
+++ b/scripts/hooks/swe-scope-fence.sh
@@ -152,5 +152,5 @@ DIRS_LIST=$(printf '%s\n' "${ALLOWED_DIRS[@]}" | sort -u | tr '\n' ' ')
 DENY_MSG="BLOCKED (scope fence): '${REL_TARGET}' is outside this task's files[] dirs. Allowed: ${DIRS_LIST%. }. To edit files outside scope, ask bro to extend the task's typed files[] field (or file a follow-up task) — do not edit out of scope."
 
 jq -nc --arg r "$DENY_MSG" \
-  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":$r}}'
+  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$r}}'
 exit 0

--- a/tests/l3-integration/hooks/attribution-footer.test.sh
+++ b/tests/l3-integration/hooks/attribution-footer.test.sh
@@ -127,11 +127,16 @@ run_hook "$PAYLOAD"
 assert_eq "false" "$([ -f "$EDIT_LOG" ] && echo true || echo false)" "no edit for non-Bash tool"
 
 # ── glab parity: stub glab, mr create → update ───────────────────────────────
+# `glab mr view N -F json` must return the RAW description as a JSON field (#1034)
+# — the hook parses `.description`, never the rendered `glab ... view` table.
 cat > "$STUB_DIR/glab" <<STUB
 #!/usr/bin/env bash
+BARE='$BARE_CC'
 case "\$1 \$2" in
   "mr view"|"issue view")
-    printf '%s\n\n%s' "Glab body." '$BARE_CC'
+    jq -cn --arg d "Glab body.
+
+\$BARE" '{description:\$d}'
     ;;
   "mr update"|"issue update")
     body="\${!#}"

--- a/tests/l3-integration/hooks/git-guards.test.sh
+++ b/tests/l3-integration/hooks/git-guards.test.sh
@@ -761,4 +761,55 @@ out=$( (cd "$(mktemp -d)" && echo "$(jq -cn --arg c "cd $REPO_PATH && gh pr crea
 assert_contains "$out" '"permissionDecision":"deny"' "head=feat/x (read from cd target) must block the dev→main exception"
 cleanup_repo
 
+# ---- #1032: Rule 1 --base compared at a token boundary ----------------------
+# The old `grep -qF -- "--base dev"` substring-matched a longer branch name as a
+# valid pr_target, and `--base main` matched `--base maintenance` in the dev→main
+# exception. PR_TARGET=dev (setup_glab_repo).
+
+test_case "#1032: gh pr create --base dev-old (PR_TARGET=dev) must NOT be accepted → deny"
+setup_glab_repo
+out=$(run_hook_in_repo "gh pr create --base dev-old --head feat/x --title x")
+assert_contains "$out" '"permissionDecision":"deny"' "--base dev-old must not substring-match dev"
+cleanup_repo
+
+test_case "#1032: gh pr create --base development (PR_TARGET=dev) must NOT be accepted → deny"
+setup_glab_repo
+out=$(run_hook_in_repo "gh pr create --base development --head feat/x --title x")
+assert_contains "$out" '"permissionDecision":"deny"' "--base development must not substring-match dev"
+cleanup_repo
+
+test_case "#1032: gh pr create --base dev (exact) → allow"
+setup_glab_repo
+out=$(run_hook_in_repo "gh pr create --base dev --head feat/x --title x")
+assert_not_contains "$out" '"permissionDecision":"deny"' "exact --base dev must be accepted"
+cleanup_repo
+
+test_case "#1032: dev→main exception must NOT accept --base maintenance → deny"
+setup_glab_repo
+out=$(run_hook_in_repo "gh pr create --base maintenance --head dev --title x")
+assert_contains "$out" '"permissionDecision":"deny"' "--base maintenance must not match the dev→main exception"
+cleanup_repo
+
+test_case "#1032: dev→main exception with exact --base main --head dev → allow"
+setup_glab_repo
+out=$(run_hook_in_repo "gh pr create --base main --head dev --title release")
+assert_not_contains "$out" '"permissionDecision":"deny"' "exact dev→main release merge must be allowed"
+cleanup_repo
+
+# ---- #1016: Rule 3 force-push detection is whitespace-tolerant ---------------
+# `git  push --force origin main` (double space) previously slipped past the
+# literal `case *"git push"*` gate and failed open.
+
+test_case "#1016: git  push --force origin main (double space) IS blocked"
+setup_worktree_repo
+out=$(run_hook_in_repo "git  push --force origin main")
+assert_contains "$out" '"permissionDecision":"deny"' "double-space force push to main must block"
+cleanup_repo
+
+test_case "#1016: git  push  -f origin main (double space) IS blocked"
+setup_worktree_repo
+out=$(run_hook_in_repo "git  push  -f origin main")
+assert_contains "$out" '"permissionDecision":"deny"' "double-space -f force push to main must block"
+cleanup_repo
+
 summarize

--- a/tests/l3-integration/hooks/git-push-guard.test.sh
+++ b/tests/l3-integration/hooks/git-push-guard.test.sh
@@ -473,4 +473,46 @@ out=$(run_hook_as_swe "make build || git push" "/nonexistent.db" "tmb:swe")
 assert_contains "$out" '"permissionDecision":"deny"' "|| git push must be detected as a push and blocked for SWE"
 cleanup
 
+# ----- #1016: whitespace-tolerant / wrapper-form push detection --------------
+# The old literal `case` substrings failed OPEN (exit 0, no block) on these
+# forms. The SWE-identity path gives a definitive BLOCK when IS_PUSH fires.
+
+test_case "#1016: 'git  push' (double space) — IS_PUSH triggers (SWE blocked)"
+setup_repo
+out=$(run_hook_as_swe "git  push origin main" "/nonexistent.db" "tmb:swe")
+assert_contains "$out" '"permissionDecision":"deny"' "double-space git push must not fail open"
+cleanup
+
+test_case "#1016: leading-whitespace '   git push' — IS_PUSH triggers (SWE blocked)"
+setup_repo
+out=$(run_hook_as_swe "   git push origin main" "/nonexistent.db" "tmb:swe")
+assert_contains "$out" '"permissionDecision":"deny"' "leading-whitespace git push must not fail open"
+cleanup
+
+test_case "#1016: 'bash -c \"git push origin main\"' wrapper — IS_PUSH triggers (SWE blocked)"
+setup_repo
+out=$(run_hook_as_swe 'bash -c "git push origin main"' "/nonexistent.db" "tmb:swe")
+assert_contains "$out" '"permissionDecision":"deny"' "bash -c wrapped push must not fail open"
+cleanup
+
+test_case "#1016: 'eval \"git push origin main\"' wrapper — IS_PUSH triggers (SWE blocked)"
+setup_repo
+out=$(run_hook_as_swe 'eval "git push origin main"' "/nonexistent.db" "tmb:swe")
+assert_contains "$out" '"permissionDecision":"deny"' "eval wrapped push must not fail open"
+cleanup
+
+test_case "#1016: double-space force push still delegated to git-guards (allowed here)"
+setup_repo
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "$SHA1"
+out=$(run_hook "git  push  --force origin main" "$db")
+assert_not_contains "$out" '"permissionDecision":"deny"' "double-space force push exits before the unsigned gate"
+cleanup
+
+test_case "#1016: false-positive — 'bash -c \"echo git push\"' is NOT a push"
+setup_repo
+out=$(run_hook_as_swe 'bash -c "echo git push done"' "/nonexistent.db" "tmb:swe")
+assert_not_contains "$out" '"permissionDecision":"deny"' "echo of git push inside a wrapper must not fire"
+cleanup
+
 summarize

--- a/tests/l3-integration/hooks/no-source-edit-from-main.test.sh
+++ b/tests/l3-integration/hooks/no-source-edit-from-main.test.sh
@@ -279,6 +279,22 @@ test_case "Bash write in a worktree path: pass (worktree exemption)"
 out=$(run_hook "$(bash_input 'echo "x" > .claude/worktrees/task-99/agents/swe.md')")
 assert_eq "" "$out" "worktree-targeted write passes"
 
+# ---- #1031: worktree exemption is DESTINATION-scoped, not whole-command -------
+# Reading FROM a worktree but WRITING a prompt surface in the main checkout must
+# still be denied — the old whole-command match exempted it because the string
+# merely mentioned .claude/worktrees/.
+test_case "#1031: sed reads worktree source, redirects to main-checkout prompt surface: DENIED"
+out=$(run_hook "$(bash_input "sed 's/x/y/' .claude/worktrees/task-99/agents/swe.md > agents/swe.md")")
+assert_contains "$out" '"permissionDecision":"deny"' "write to main-checkout prompt surface must block even when source is a worktree"
+
+test_case "#1031: cp from worktree source to main-checkout prompt surface: DENIED"
+out=$(run_hook "$(bash_input 'cp .claude/worktrees/task-99/agents/swe.md agents/swe.md')")
+assert_contains "$out" '"permissionDecision":"deny"' "cp destination in main checkout must block regardless of worktree source"
+
+test_case "#1031: write whose destination IS the worktree: still ALLOWED"
+out=$(run_hook "$(bash_input 'cat agents/swe.md > .claude/worktrees/task-99/agents/swe.md')")
+assert_eq "" "$out" "destination inside a worktree stays exempt"
+
 test_case "Bash redirect > to CODEX.md: DENIED"
 out=$(run_hook "$(bash_input 'echo "x" > CODEX.md')")
 assert_contains "$out" '"permissionDecision":"deny"' "redirect to CODEX.md denied"

--- a/tests/l3-integration/hooks/post-pr-comments-persist.test.sh
+++ b/tests/l3-integration/hooks/post-pr-comments-persist.test.sh
@@ -34,6 +34,9 @@ sqlite3 "$DB" "
     VALUES (1,'t','t','open',datetime('now'),datetime('now'));
   INSERT INTO tasks (id, issue_id, branch_id, title, description, status, spec_body, created_at, updated_at)
     VALUES (1,1,'fix/1-pr','t','d','open','s',datetime('now'),datetime('now'));
+  -- Carrier resolution is via pr_number → pr_review_runs → task → issue (#1024).
+  INSERT INTO pr_review_runs (pr_number, repo, last_fetched_at, task_id)
+    VALUES (42,'',datetime('now'),1),(99,'',datetime('now'),1),(77,'',datetime('now'),1);
 " >/dev/null
 
 # pr_monitor_comments_get-shaped tool result with an apostrophe in the body + author.
@@ -92,6 +95,8 @@ sqlite3 "$WALK_DB" "
     VALUES (2,'t','t','open',datetime('now'),datetime('now'));
   INSERT INTO tasks (id, issue_id, branch_id, title, description, status, spec_body, created_at, updated_at)
     VALUES (2,2,'fix/walk-pr','t','d','open','s',datetime('now'),datetime('now'));
+  INSERT INTO pr_review_runs (pr_number, repo, last_fetched_at, task_id)
+    VALUES (55,'',datetime('now'),2);
 " >/dev/null
 WALK_PAYLOAD=$(jq -cn '{
   tool_name: "pr_monitor_comments_get",
@@ -105,8 +110,8 @@ COUNT3=$(sqlite3 "$WALK_DB" "SELECT COUNT(*) FROM discussions WHERE kind='note' 
 assert_eq "1" "$COUNT3" "walk-up must find the DB and insert the comment row"
 
 # ── injection regression ──────────────────────────────────────────────────────
-# The discussions INSERT uses CURRENT_BRANCH (from git rev-parse), ISSUE_ID
-# (from DB SELECT), AUTHOR_ESC and NOTE_BODY_ESC (both escaped via sed).
+# Carrier issue_id resolves via the integer-validated pr_number (#1024, no raw
+# branch interpolation); AUTHOR_ESC and NOTE_BODY_ESC are escaped via sed.
 # We test: injection via comment body does NOT corrupt the DB.
 
 test_case "injection in comment body: treated as literal string, no SQL error"

--- a/tests/l3-integration/hooks/swe-boundary.test.sh
+++ b/tests/l3-integration/hooks/swe-boundary.test.sh
@@ -124,6 +124,19 @@ test_case "(a) SWE git push --force: NOT denied by this hook (delegated to git-g
 out=$(run_hook_swe "$(make_bash_input swe 'git push --force origin feat/my-feature')")
 assert_not_contains "$out" '"permissionDecision":"deny"' "force push should not be denied by swe-boundary (git-guards handles it)"
 
+# #1016: whitespace-tolerant / wrapper-form push detection must not fail open.
+test_case "(a) SWE 'git  push' (double space): DENIED"
+out=$(run_hook_swe "$(make_bash_input swe 'git  push origin feat/my-feature')")
+assert_contains "$out" '"permissionDecision":"deny"' "double-space SWE push must not fail open"
+
+test_case "(a) SWE 'bash -c \"git push ...\"' wrapper: DENIED"
+out=$(run_hook_swe "$(make_bash_input swe 'bash -c "git push origin feat/my-feature"')")
+assert_contains "$out" '"permissionDecision":"deny"' "wrapped SWE push must not fail open"
+
+test_case "(a) SWE 'eval \"git push ...\"' wrapper: DENIED"
+out=$(run_hook_swe "$(make_bash_input swe 'eval "git push origin feat/my-feature"')")
+assert_contains "$out" '"permissionDecision":"deny"' "eval-wrapped SWE push must not fail open"
+
 test_case "(a) bro git push: NOT denied (bro is the push agent)"
 out=$(run_hook_bro "$(make_bash_input bro 'git push origin dev')")
 assert_not_contains "$out" '"permissionDecision":"deny"' "bro push should not be denied"


### PR DESCRIPTION
Closes #1016, #1024, #1031, #1032, #1033, #1034.

Hardens safety-critical hook guards (all under scripts/hooks/ + L3 tests):
- **#1016** whitespace/wrapper-tolerant push + force-push detection (`_norm_cmd` + boundary-anchored `grep -qE`) — catches `git  push`, leading-whitespace, `bash -c`/`eval` wrappers; force-push Rule 3 drives off `_is_force_push`.
- **#1032** `--base` token-boundary compare (no more `dev-old`/`development`/`maintenance` slipping through).
- **#1024** post-pr-comments carrier resolves via `pr_number → pr_review_runs → tasks` (not the checkout branch); branch-name SQLi sink removed (escaped/parameterized).
- **#1031** no-source-edit worktree exemption tests the write **destination** token.
- **#1033** `denyReason` → `permissionDecisionReason` across the 10 enumerated hooks.
- **#1034** attribution-footer reads `.description` via `glab … view -F json`.

New L3 tests prove the bypass forms are caught. `bash tests/l3-integration/hooks/run.sh` → 63/63. pr-reviewer: PASS.

Follow-up (out of scope of #1033's list): `scripts/hooks/swe-verification-gate.sh` still uses `denyReason` — worth a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)