### PR TITLE
✅ test(l3): enforce summarize + sandbox HOME + real-script drive + repos-row seeds (#1015, #1038)

### DIFF
--- a/tests/l1-lint/test-summarize-present.sh
+++ b/tests/l1-lint/test-summarize-present.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Lint: every tests/l3-integration/hooks/*.test.sh that sources lib/assert.sh
+# must call `summarize`. assert.sh's _fail only bumps a counter and returns 0;
+# summarize is the sole function that returns non-zero on a failed assertion.
+# A file that sources assert.sh but never calls summarize exits 0 even when its
+# assertions FAIL, so its guard is unenforced (#1015).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+FAIL=0
+CHECKED=0
+
+for t in tests/l3-integration/hooks/*.test.sh; do
+  [ -f "$t" ] || continue
+  grep -q 'lib/assert.sh' "$t" || continue
+  CHECKED=$((CHECKED + 1))
+  if ! grep -Eq '(^|[^A-Za-z_])summarize([^A-Za-z_]|$)' "$t"; then
+    printf "test-summarize-present: sources assert.sh but never calls summarize: %s\n" "$t" >&2
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+if [ "$FAIL" -gt 0 ] || [ "$CHECKED" -eq 0 ]; then
+  [ "$CHECKED" -eq 0 ] && printf "test-summarize-present: matched 0 files — glob wrong?\n" >&2
+  printf "test-summarize-present: FAIL\n"
+  exit 1
+fi
+printf "test-summarize-present: %d assert-sourcing test files checked, all call summarize.\n" "$CHECKED"

--- a/tests/l3-integration/hooks/activation-routine.test.sh
+++ b/tests/l3-integration/hooks/activation-routine.test.sh
@@ -155,3 +155,5 @@ test_case "bro trigger but DB doesn't exist: silent no-op (graceful first-activa
 rm -f "$DB"
 out=$(run_hook "$(input '@bro hi')")
 assert_eq "" "$out" "no output when DB missing"
+
+summarize

--- a/tests/l3-integration/hooks/agent-spawn-dispatch.test.sh
+++ b/tests/l3-integration/hooks/agent-spawn-dispatch.test.sh
@@ -155,68 +155,28 @@ assert_eq "" "$out" "silent no-op for non-Agent tool"
 
 # ----- tests: context union -------------------------------------------------
 
-test_case "context union: dispatcher merges additionalContext from stub hooks"
-# Validate the union path by pointing at a temp hook directory with a stub
-# hook that emits additionalContext rather than a deny.
+test_case "context union: real dispatcher merges additionalContext from gate hooks"
+# Drive the REAL dispatcher (copied verbatim) against stub gate hooks named
+# exactly as the dispatcher expects. SCRIPT_DIR resolves to the temp dir, so the
+# shipped union logic is exercised — no reimplemented dispatcher.
 TMPDIR=$(mktemp -d)
 STUB_HOOKS_DIR="$TMPDIR/hooks"
 mkdir -p "$STUB_HOOKS_DIR"
+cp "$DISPATCHER" "$STUB_HOOKS_DIR/agent-spawn-dispatch.sh"
 
-# Stub hook A: emits additionalContext "part-A"
-cat > "$STUB_HOOKS_DIR/hook-a.sh" <<'EOF'
+# First and last gate in the dispatcher's fixed order emit additionalContext;
+# the union must carry both, separated.
+cat > "$STUB_HOOKS_DIR/require-task-spec.sh" <<'EOF'
 #!/usr/bin/env bash
 jq -nc '{hookSpecificOutput:{hookEventName:"PreToolUse",additionalContext:"part-A"}}'
 EOF
-chmod +x "$STUB_HOOKS_DIR/hook-a.sh"
-
-# Stub hook B: emits additionalContext "part-B"
-cat > "$STUB_HOOKS_DIR/hook-b.sh" <<'EOF'
+cat > "$STUB_HOOKS_DIR/pr-reviewer-after-atomic-close.sh" <<'EOF'
 #!/usr/bin/env bash
 jq -nc '{hookSpecificOutput:{hookEventName:"PreToolUse",additionalContext:"part-B"}}'
 EOF
-chmod +x "$STUB_HOOKS_DIR/hook-b.sh"
+chmod +x "$STUB_HOOKS_DIR/require-task-spec.sh" "$STUB_HOOKS_DIR/pr-reviewer-after-atomic-close.sh"
 
-# Stub dispatcher referencing only the two stubs (not the real hooks).
-cat > "$STUB_HOOKS_DIR/test-dispatch.sh" <<'DISPATCH'
-#!/usr/bin/env bash
-set -uo pipefail
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-INPUT=$(cat 2>/dev/null) || exit 0
-command -v jq >/dev/null 2>&1 || exit 0
-HOOKS=("$SCRIPT_DIR/hook-a.sh" "$SCRIPT_DIR/hook-b.sh")
-CONTEXT_PARTS=()
-for hook in "${HOOKS[@]}"; do
-  [ -x "$hook" ] || continue
-  OUT=$(printf '%s' "$INPUT" | bash "$hook" 2>/dev/null) || true
-  [ -n "$OUT" ] || continue
-  DECISION=$(printf '%s' "$OUT" | jq -r '.hookSpecificOutput.permissionDecision // ""' 2>/dev/null)
-  if [ "$DECISION" = "deny" ]; then
-    printf '%s\n' "$OUT"
-    exit 0
-  fi
-  CTX=$(printf '%s' "$OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
-  [ -n "$CTX" ] && CONTEXT_PARTS+=("$CTX")
-done
-if [ "${#CONTEXT_PARTS[@]}" -gt 0 ]; then
-  MERGED=""
-  for part in "${CONTEXT_PARTS[@]}"; do
-    if [ -n "$MERGED" ]; then
-      MERGED="${MERGED}
-
----
-
-${part}"
-    else
-      MERGED="$part"
-    fi
-  done
-  jq -nc --arg ctx "$MERGED" '{hookSpecificOutput:{hookEventName:"PreToolUse",additionalContext:$ctx}}'
-fi
-exit 0
-DISPATCH
-chmod +x "$STUB_HOOKS_DIR/test-dispatch.sh"
-
-out=$(printf '{}' | bash "$STUB_HOOKS_DIR/test-dispatch.sh" 2>/dev/null || true)
+out=$(printf '{}' | bash "$STUB_HOOKS_DIR/agent-spawn-dispatch.sh" 2>/dev/null || true)
 assert_contains "$out" "part-A" "first context part present"
 assert_contains "$out" "part-B" "second context part present"
 assert_contains "$out" "additionalContext" "result wrapped in additionalContext"
@@ -224,62 +184,27 @@ rm -rf "$TMPDIR"
 
 # ----- tests: deny short-circuits context collection -----------------------
 
-test_case "deny in first hook short-circuits; second hook context not emitted"
+test_case "deny in first gate short-circuits real dispatcher; later context not emitted"
 TMPDIR=$(mktemp -d)
 STUB_HOOKS_DIR="$TMPDIR/hooks"
 mkdir -p "$STUB_HOOKS_DIR"
+cp "$DISPATCHER" "$STUB_HOOKS_DIR/agent-spawn-dispatch.sh"
 
-cat > "$STUB_HOOKS_DIR/deny-hook.sh" <<'EOF'
+# First gate denies; a later gate emits context that must never be reached.
+cat > "$STUB_HOOKS_DIR/require-task-spec.sh" <<'EOF'
 #!/usr/bin/env bash
 jq -nc '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",denyReason:"BLOCKED: first hook denied"}}'
 EOF
-chmod +x "$STUB_HOOKS_DIR/deny-hook.sh"
-
-cat > "$STUB_HOOKS_DIR/context-hook.sh" <<'EOF'
+cat > "$STUB_HOOKS_DIR/require-feature-branch-active.sh" <<'EOF'
 #!/usr/bin/env bash
 jq -nc '{hookSpecificOutput:{hookEventName:"PreToolUse",additionalContext:"should-not-appear"}}'
 EOF
-chmod +x "$STUB_HOOKS_DIR/context-hook.sh"
+chmod +x "$STUB_HOOKS_DIR/require-task-spec.sh" "$STUB_HOOKS_DIR/require-feature-branch-active.sh"
 
-cat > "$STUB_HOOKS_DIR/test-dispatch.sh" <<'DISPATCH'
-#!/usr/bin/env bash
-set -uo pipefail
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-INPUT=$(cat 2>/dev/null) || exit 0
-command -v jq >/dev/null 2>&1 || exit 0
-HOOKS=("$SCRIPT_DIR/deny-hook.sh" "$SCRIPT_DIR/context-hook.sh")
-CONTEXT_PARTS=()
-for hook in "${HOOKS[@]}"; do
-  [ -x "$hook" ] || continue
-  OUT=$(printf '%s' "$INPUT" | bash "$hook" 2>/dev/null) || true
-  [ -n "$OUT" ] || continue
-  DECISION=$(printf '%s' "$OUT" | jq -r '.hookSpecificOutput.permissionDecision // ""' 2>/dev/null)
-  if [ "$DECISION" = "deny" ]; then
-    printf '%s\n' "$OUT"
-    exit 0
-  fi
-  CTX=$(printf '%s' "$OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
-  [ -n "$CTX" ] && CONTEXT_PARTS+=("$CTX")
-done
-if [ "${#CONTEXT_PARTS[@]}" -gt 0 ]; then
-  MERGED=""
-  for part in "${CONTEXT_PARTS[@]}"; do
-    [ -n "$MERGED" ] && MERGED="${MERGED}
-
----
-
-${part}" || MERGED="$part"
-  done
-  jq -nc --arg ctx "$MERGED" '{hookSpecificOutput:{hookEventName:"PreToolUse",additionalContext:$ctx}}'
-fi
-exit 0
-DISPATCH
-chmod +x "$STUB_HOOKS_DIR/test-dispatch.sh"
-
-out=$(printf '{}' | bash "$STUB_HOOKS_DIR/test-dispatch.sh" 2>/dev/null || true)
+out=$(printf '{}' | bash "$STUB_HOOKS_DIR/agent-spawn-dispatch.sh" 2>/dev/null || true)
 assert_contains "$out" '"permissionDecision":"deny"' "deny present"
 assert_contains "$out" "first hook denied" "deny reason from first hook"
-assert_not_contains "$out" "should-not-appear" "second hook context not emitted"
+assert_not_contains "$out" "should-not-appear" "later gate context not emitted"
 rm -rf "$TMPDIR"
 
 summarize

--- a/tests/l3-integration/hooks/branch-up-to-date-with-remote.test.sh
+++ b/tests/l3-integration/hooks/branch-up-to-date-with-remote.test.sh
@@ -29,8 +29,6 @@ mkdir -p .claude/tmb
 DB="$WORK/.claude/tmb/trajectory.db"
 _REPO_REALPATH=$(git rev-parse --show-toplevel)
 sqlite3 "$DB" "
-  CREATE TABLE plugin_config (key TEXT PRIMARY KEY, value_json TEXT NOT NULL DEFAULT '');
-  INSERT INTO plugin_config (key, value_json) VALUES ('pr_target', '\"main\"');
   CREATE TABLE IF NOT EXISTS repos (
     name              TEXT PRIMARY KEY,
     path              TEXT    NOT NULL,
@@ -40,7 +38,7 @@ sqlite3 "$DB" "
     branching_model   TEXT,
     protected_branches TEXT
   );
-  INSERT INTO repos (name, path) VALUES ('fixture', '$_REPO_REALPATH');
+  INSERT INTO repos (name, path, target_branch) VALUES ('fixture', '$_REPO_REALPATH', 'main');
 "
 export TRAJECTORY_DB_PATH="$DB"
 
@@ -117,7 +115,7 @@ git init -q -b main "$SIB"
   echo x > b.txt && git add b.txt && git commit -qm advance && git push -q origin main
 )
 _SIB_REAL=$(git -C "$SIB" rev-parse --show-toplevel)
-sqlite3 "$DB" "INSERT INTO repos (name, path) VALUES ('sib', '$_SIB_REAL');"
+sqlite3 "$DB" "INSERT INTO repos (name, path, target_branch) VALUES ('sib', '$_SIB_REAL', 'main');"
 
 test_case "multi-repo: 'cd <sibling> && git worktree add <stale>' resolves the SIBLING and blocks"
 # Still cd'd in \$WORK (the first repo); the cd prefix must redirect to \$SIB.

--- a/tests/l3-integration/hooks/bro-turn-usage.test.sh
+++ b/tests/l3-integration/hooks/bro-turn-usage.test.sh
@@ -105,7 +105,9 @@ assert_eq "0" "$tokens_safe" "corrupt input must be coerced to 0 by printf '%d'"
 #   - no double-counting (A + B == total)
 
 TMPDIR_MT=$(mktemp -d)
-trap 'rm -rf "$TMPDIR_MT"' EXIT
+# Combined trap: a second `trap ... EXIT` replaces the first, so clean both
+# tmpdirs here (otherwise TMPDIR_BTU would leak).
+trap 'rm -rf "$TMPDIR_BTU" "$TMPDIR_MT"' EXIT
 MT_DB="$TMPDIR_MT/trajectory.db"
 MT_T1="$TMPDIR_MT/transcript1.jsonl"
 MT_T2="$TMPDIR_MT/transcript2.jsonl"

--- a/tests/l3-integration/hooks/cheatcode-healthcheck.test.sh
+++ b/tests/l3-integration/hooks/cheatcode-healthcheck.test.sh
@@ -21,7 +21,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
 HOOK="$PLUGIN_ROOT/scripts/hooks/cheatcode-healthcheck.sh"
 
-command -v sqlite3 >/dev/null 2>&1 || { printf "SKIP sqlite3 not found\n"; exit 0; }
+command -v sqlite3 >/dev/null 2>&1 || { printf "FAIL sqlite3 not found — required dependency for this security-gate test\n"; exit 1; }
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT

--- a/tests/l3-integration/hooks/cheatcode-install.test.sh
+++ b/tests/l3-integration/hooks/cheatcode-install.test.sh
@@ -14,7 +14,7 @@ PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/cheatcode-install.sh"
 HOOK="$PLUGIN_ROOT/scripts/hooks/cheatcode-install-approval.sh"
 
-command -v jq >/dev/null 2>&1 || { printf "SKIP jq not found\n"; exit 0; }
+command -v jq >/dev/null 2>&1 || { printf "FAIL jq not found — required dependency for this security-gate test\n"; exit 1; }
 
 WORKSPACE=$(mktemp -d)
 trap 'rm -rf "$WORKSPACE"' EXIT
@@ -186,10 +186,8 @@ if [ "$rc" -ne 0 ]; then _pass; else _fail "expected non-zero exit on bad kind";
 # Part B — PreToolUse approval gate (fail closed).
 # ---------------------------------------------------------------------------
 if ! command -v sqlite3 >/dev/null 2>&1; then
-  printf "SKIP sqlite3 not found — approval-gate cases skipped\n"
-  summarize
-  printf "PASS cheatcode-install\n"
-  exit 0
+  printf "FAIL sqlite3 not found — required dependency for the approval-gate cases\n"
+  exit 1
 fi
 
 WS="$WORKSPACE/ws"

--- a/tests/l3-integration/hooks/cheatcode-search.test.sh
+++ b/tests/l3-integration/hooks/cheatcode-search.test.sh
@@ -8,7 +8,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/cheatcode-search.sh"
 
-command -v jq >/dev/null 2>&1 || { printf "SKIP jq not found\n"; exit 0; }
+command -v jq >/dev/null 2>&1 || { printf "FAIL jq not found — required dependency for this security-gate test\n"; exit 1; }
 
 WORKSPACE=$(mktemp -d)
 trap 'rm -rf "$WORKSPACE"' EXIT

--- a/tests/l3-integration/hooks/cheatcode-uninstall.test.sh
+++ b/tests/l3-integration/hooks/cheatcode-uninstall.test.sh
@@ -12,7 +12,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/cheatcode-uninstall.sh"
 
-command -v jq >/dev/null 2>&1 || { printf "SKIP jq not found\n"; exit 0; }
+command -v jq >/dev/null 2>&1 || { printf "FAIL jq not found — required dependency for this security-gate test\n"; exit 1; }
 
 WORKSPACE=$(mktemp -d)
 trap 'rm -rf "$WORKSPACE"' EXIT

--- a/tests/l3-integration/hooks/cheatcode-vet.test.sh
+++ b/tests/l3-integration/hooks/cheatcode-vet.test.sh
@@ -8,7 +8,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/cheatcode-vet.sh"
 
-command -v jq >/dev/null 2>&1 || { printf "SKIP jq not found\n"; exit 0; }
+command -v jq >/dev/null 2>&1 || { printf "FAIL jq not found — required dependency for this security-gate test\n"; exit 1; }
 
 WORKSPACE=$(mktemp -d)
 trap 'rm -rf "$WORKSPACE"' EXIT

--- a/tests/l3-integration/hooks/cleanup-worktree-on-task-close.test.sh
+++ b/tests/l3-integration/hooks/cleanup-worktree-on-task-close.test.sh
@@ -182,11 +182,11 @@ assert_eq "" "$out" "non-bro agent must be silent no-op for bro_atomic_close"
 [ -d "$REPO/.claude/worktrees/atomic2" ] || { echo "FAIL: worktree removed for non-bro agent"; exit 1; }
 
 # ---- #559: per-repo HEAD-reset target resolution -----------------------------
-# Set up plugin_config + repos table in the main DB for these cases.
+# Set up the repos table in the main DB for these cases. The hook resolves the
+# reset target from repos.target_branch (the sole source), defaulting to 'dev'
+# when the column is NULL.
 _REPO_REALPATH=$(git -C "$REPO" rev-parse --show-toplevel)
 sqlite3 "$DB" "
-  CREATE TABLE IF NOT EXISTS plugin_config (key TEXT PRIMARY KEY, value_json TEXT, updated_at TEXT);
-  INSERT OR REPLACE INTO plugin_config (key, value_json, updated_at) VALUES ('pr_target', '\"dev\"', datetime('now'));
   CREATE TABLE IF NOT EXISTS repos (
     name              TEXT PRIMARY KEY,
     path              TEXT NOT NULL,
@@ -215,7 +215,7 @@ AFTER_HEAD=$(git -C "$REPO" rev-parse --abbrev-ref HEAD)
 [ "$AFTER_HEAD" = "main" ] || { echo "FAIL: HEAD is '$AFTER_HEAD', expected 'main'"; exit 1; }
 echo "  HEAD reset to main (per-repo target_branch honored)"
 
-test_case "#559: registered repo with NULL target_branch → falls back to global pr_target='dev'"
+test_case "#559: registered repo with NULL target_branch → falls back to the default 'dev'"
 sqlite3 "$DB" "INSERT OR REPLACE INTO repos (name, path, target_branch) VALUES ('fixture', '${_REPO_REALPATH}', NULL);"
 git -C "$REPO" branch fix/per-repo-null HEAD
 git -C "$REPO" worktree add -q .claude/worktrees/per-repo-null fix/per-repo-null
@@ -228,7 +228,7 @@ out=$(echo "$(input 'mcp__plugin_tmb_trajectory-server__task_update_status' 'bro
 assert_contains "$out" 'cleaned up worktree' "worktree removed"
 AFTER_HEAD=$(git -C "$REPO" rev-parse --abbrev-ref HEAD)
 [ "$AFTER_HEAD" = "dev" ] || { echo "FAIL: HEAD is '$AFTER_HEAD', expected 'dev'"; exit 1; }
-echo "  HEAD reset to dev (global pr_target fallback honored)"
+echo "  HEAD reset to dev (NULL target_branch default fallback honored)"
 
 test_case "#559: TMB_KEEP_HEAD_ON_CLOSE=1 still skips the reset"
 sqlite3 "$DB" "INSERT OR REPLACE INTO repos (name, path, target_branch) VALUES ('fixture', '${_REPO_REALPATH}', 'main');"

--- a/tests/l3-integration/hooks/close-issue-on-merge.test.sh
+++ b/tests/l3-integration/hooks/close-issue-on-merge.test.sh
@@ -18,7 +18,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
 HOOK="$PLUGIN_ROOT/scripts/hooks/close-issue-on-merge.sh"
 
-command -v sqlite3 >/dev/null 2>&1 || { echo "SKIP: sqlite3 unavailable"; exit 0; }
+command -v sqlite3 >/dev/null 2>&1 || { echo "FAIL: sqlite3 unavailable — required dependency for this security-gate test"; exit 1; }
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT

--- a/tests/l3-integration/hooks/consultant-spawn-enforcement.test.sh
+++ b/tests/l3-integration/hooks/consultant-spawn-enforcement.test.sh
@@ -23,8 +23,8 @@ PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
 HOOK="$PLUGIN_ROOT/scripts/hooks/prompt-intent-hints.sh"
 SCHEMA="$PLUGIN_ROOT/mcp/trajectory-server/src/schema.sql"
 
-command -v sqlite3 >/dev/null 2>&1 || { echo "SKIP: sqlite3 unavailable"; exit 0; }
-command -v jq     >/dev/null 2>&1 || { echo "SKIP: jq unavailable"; exit 0; }
+command -v sqlite3 >/dev/null 2>&1 || { echo "FAIL: sqlite3 unavailable — required dependency for this security-gate test"; exit 1; }
+command -v jq     >/dev/null 2>&1 || { echo "FAIL: jq unavailable — required dependency for this security-gate test"; exit 1; }
 
 TMPDIR_CS=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_CS"' EXIT

--- a/tests/l3-integration/hooks/ensure-gitignore.test.sh
+++ b/tests/l3-integration/hooks/ensure-gitignore.test.sh
@@ -58,3 +58,5 @@ before_md5=$(md5 -q "$REPO/.gitignore" 2>/dev/null || md5sum "$REPO/.gitignore" 
 run_in_repo "$REPO" >/dev/null
 after_md5=$(md5 -q "$REPO/.gitignore" 2>/dev/null || md5sum "$REPO/.gitignore" | awk '{print $1}')
 assert_eq "$before_md5" "$after_md5" "matches both .claude/ and .claude variants"
+
+summarize

--- a/tests/l3-integration/hooks/ensure-kuzu-installed.test.sh
+++ b/tests/l3-integration/hooks/ensure-kuzu-installed.test.sh
@@ -107,18 +107,30 @@ assert_not_contains "$out" "error" "partial install path does not emit error"
 # node_modules. We verify: exit 0 and (if a package manager is present)
 # the additionalContext notice is emitted.
 # ──────────────────────────────────────────────────────────────
-test_case "full-install path exits 0 and emits notice or silent"
-MCP_DIR_8="$TMPDIR_EK/mcp8/trajectory-server"
+test_case "full-install path emits kuzu additionalContext notice (deterministic)"
+# NOTE: the hook resolves MCP_DIR as $CLAUDE_PLUGIN_ROOT/mcp/trajectory-server,
+# so the fixture must nest under mcp/ or the hook exits early at the -d check
+# (the old mcp8/trajectory-server layout never reached this path — a tautology).
+MCP_DIR_8="$TMPDIR_EK/mcp8/mcp/trajectory-server"
 mkdir -p "$MCP_DIR_8"
 echo '{"name":"traj","dependencies":{"kuzu":"*"}}' > "$MCP_DIR_8/package.json"
 PLUGIN_ROOT_8="$TMPDIR_EK/mcp8"
+# Curated PATH exposing only grep + jq (and bash to run the hook), deliberately
+# omitting bun/npm so the hook takes the deterministic "no package manager"
+# branch — it emits an additionalContext advisory instead of backgrounding a
+# real network install (isolation: no stray process, no package-cache writes).
+STUB_PATH_8="$TMPDIR_EK/stubpath8"
+mkdir -p "$STUB_PATH_8"
+for tool in bash grep jq; do
+  src=$(command -v "$tool") && ln -sf "$src" "$STUB_PATH_8/$tool"
+done
 exit_code=0
-out=$(echo "" | CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT_8" bash "$HOOK" 2>&1) || exit_code=$?
+out=$(echo "" | env -i HOME="$HOME" PATH="$STUB_PATH_8" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT_8" bash "$HOOK" 2>&1) || exit_code=$?
 assert_exit_code "0" "$exit_code" "full-install path exits 0"
-# If a package manager is present the notice will be emitted; if not, a different
-# notice is emitted. Either way: ok=true and contains additionalContext.
-if [ -n "$out" ]; then
-  assert_contains "$out" "additionalContext" "full-install path emits additionalContext"
-fi
+# Unconditional (anti-no-op): the full-install path always emits an
+# additionalContext notice. A no-op replacement of the hook would emit nothing
+# and fail these. Not guarded by [ -n "$out" ].
+assert_contains "$out" '"additionalContext"' "full-install path emits additionalContext notice"
+assert_contains "$out" "kuzu" "full-install notice names the kuzu install"
 
 summarize

--- a/tests/l3-integration/hooks/git-push-guard-bro-skip-detection.test.sh
+++ b/tests/l3-integration/hooks/git-push-guard-bro-skip-detection.test.sh
@@ -70,9 +70,14 @@ insert_closed_task() {
 
 set_pr_target() {
   local db="$1" target="$2"
+  # Register the repo with a target_branch so git-push-guard resolves the base
+  # via the repos table (the sole source) — the retired plugin_config.pr_target
+  # key is no longer read.
+  local root
+  root=$(git -C "$REPO_PATH" rev-parse --show-toplevel)
   sqlite3 "$db" "
-    INSERT OR REPLACE INTO plugin_config (key, value_json)
-      VALUES ('pr_target', '\"$target\"');
+    INSERT OR REPLACE INTO repos (name, path, target_branch)
+      VALUES ('fixture', '$root', '$target');
   " >/dev/null
 }
 

--- a/tests/l3-integration/hooks/hook-content-preservation.test.sh
+++ b/tests/l3-integration/hooks/hook-content-preservation.test.sh
@@ -73,6 +73,10 @@ mask_mcp_health_check() {
 # ---------------------------------------------------------------------------
 
 TMPDIR_ROOT=$(mktemp -d)
+# Sandbox HOME so hooks (mcp-health-check et al.) touch a throwaway state/log
+# dir, never the developer's real ~/.claude/tmb.
+export HOME="$TMPDIR_ROOT/home"
+mkdir -p "$HOME"
 trap 'rm -rf "$TMPDIR_ROOT"' EXIT
 
 # --- session-start-prescan setup ---

--- a/tests/l3-integration/hooks/mcp-health-check.test.sh
+++ b/tests/l3-integration/hooks/mcp-health-check.test.sh
@@ -19,6 +19,10 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
 HOOK="$PLUGIN_ROOT/scripts/hooks/mcp-health-check.sh"
 
+# Sandbox HOME so the hook reads/writes its state + log under a throwaway dir,
+# never the developer's real ~/.claude/tmb.
+export HOME="$(mktemp -d)"
+
 LOG_DIR="$HOME/.claude/tmb/logs"
 LOG_FILE="$LOG_DIR/mcp-health.log"
 STATE_FILE="$LOG_DIR/mcp-health.state"
@@ -42,7 +46,7 @@ chmod +x "$STUB_DIR/pgrep"
 export PATH="$STUB_DIR:$PATH"
 
 cleanup() {
-  rm -rf "$STUB_DIR"
+  rm -rf "$STUB_DIR" "$HOME"
 }
 trap cleanup EXIT
 

--- a/tests/l3-integration/hooks/no-worktree-branch-create.test.sh
+++ b/tests/l3-integration/hooks/no-worktree-branch-create.test.sh
@@ -82,3 +82,5 @@ assert_eq "" "$out" "no DB = not TMB = allow"
 test_case "no DB (not a TMB project): pass even on --detach"
 out=$(run_hook "$(input 'Bash' 'git worktree add --detach .claude/worktrees/x fix/foo')")
 assert_eq "" "$out" "no DB = not TMB = allow detach too"
+
+summarize

--- a/tests/l3-integration/hooks/stay-on-base-guard.test.sh
+++ b/tests/l3-integration/hooks/stay-on-base-guard.test.sh
@@ -124,3 +124,5 @@ export TRAJECTORY_DB_PATH="/nonexistent-path/trajectory.db"
 out=$(run_hook "git checkout feat/open-task")
 assert_eq "" "$out" "no DB = not TMB = allow"
 export TRAJECTORY_DB_PATH="$ORIG_DB"
+
+summarize


### PR DESCRIPTION
Closes #1015, closes #1038.

- **#1015** append `summarize` to the 4 files that never called it (activation-routine, no-worktree-branch-create, stay-on-base-guard, ensure-gitignore) so failing assertions actually exit non-zero; new `tests/l1-lint/test-summarize-present.sh` meta-lint guards against regression.
- **#1038** sandbox $HOME in the health-check tests, hard-fail dep-less security-gate tests, fix the ensure-kuzu tautology, drive the real agent-spawn-dispatch script, migrate retired `plugin_config.pr_target` seeds to `repos.target_branch`, combine the leaked EXIT traps.

`bash tests/l3-integration/hooks/run.sh` → 63/63; new meta-lint passes. pr-reviewer: PASS. Auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)