### PR TITLE
🐛 fix(hooks): intent hints skip synthetic turns and match install intent at word boundaries

### DIFF
--- a/scripts/hooks/prompt-intent-hints.sh
+++ b/scripts/hooks/prompt-intent-hints.sh
@@ -34,6 +34,15 @@ command -v jq >/dev/null 2>&1 || exit 0
 PROMPT_RAW=$(printf '%s' "$INPUT" | jq -r '.prompt // ""' 2>/dev/null)
 [ -n "$PROMPT_RAW" ] || exit 0
 
+# Synthetic-turn early-exit — harness-generated turns (subagent reports,
+# system notifications) carry embedded content ("bun install", plugin/mcp
+# paths) that trips the matchers, but no hint class applies to them: every
+# hint class describes HUMAN intent. Markers are case-sensitive as produced
+# by the harness. Exit before any matcher.
+case "$PROMPT_RAW" in
+  *"<task-notification>"*|*"[SYSTEM NOTIFICATION"*) exit 0 ;;
+esac
+
 LOWER=$(printf '%s' "$PROMPT_RAW" | tr '[:upper:]' '[:lower:]')
 
 emit_context() {
@@ -142,11 +151,14 @@ EOF
       cheatcode_install_match="in scope"
       ;;
     *install*)
-      case "$LOWER" in
-        *plugin*|*skill*|*mcp*|*cheatcode*)
-          cheatcode_install_match="install capability"
-          ;;
-      esac
+      # Word-bounded install intent: an `install`/`installing` token AND a
+      # capability object noun, EXCLUDING package-manager installs
+      # (npm/bun/pip/... install → dependencies, never a cheatcode).
+      if printf '%s' "$LOWER" | grep -qE '\b(install|installing)\b' \
+        && printf '%s' "$LOWER" | grep -qE '\b(plugin|plugins|skill|skills|mcp|cheatcode|cheatcodes)\b' \
+        && ! printf '%s' "$LOWER" | grep -qE '\b(npm|npx|bun|yarn|pnpm|pip|pipx|brew|apt|apt-get|cargo|gem)[[:space:]]+install(ing)?\b'; then
+        cheatcode_install_match="install capability"
+      fi
       ;;
   esac
 

--- a/tests/l1-lint/no-raw-sql-interpolation.allowlist
+++ b/tests/l1-lint/no-raw-sql-interpolation.allowlist
@@ -30,8 +30,8 @@ scripts/hooks/cheatcode-healthcheck.sh:139
 # prompt-intent-hints.sh has_word(): `case "$text" in ... "${word}" ...` is shell
 # glob word-matching, not SQL. A consultant-spawn sqlite3 heredoc closes ~15 lines
 # above; the proximity heuristic still flags this case block. No SQL here.
-scripts/hooks/prompt-intent-hints.sh:78
-scripts/hooks/prompt-intent-hints.sh:79
-scripts/hooks/prompt-intent-hints.sh:80
-scripts/hooks/prompt-intent-hints.sh:81
-scripts/hooks/prompt-intent-hints.sh:82
+scripts/hooks/prompt-intent-hints.sh:87
+scripts/hooks/prompt-intent-hints.sh:88
+scripts/hooks/prompt-intent-hints.sh:89
+scripts/hooks/prompt-intent-hints.sh:90
+scripts/hooks/prompt-intent-hints.sh:91

--- a/tests/l3-integration/hooks/prompt-intent-hints.test.sh
+++ b/tests/l3-integration/hooks/prompt-intent-hints.test.sh
@@ -114,6 +114,35 @@ out=$(run_hook "install dependencies before running the build")
 assert_not_contains "$out" "cheatcode-routing" "install dependencies must not fire"
 
 # ---------------------------------------------------------------------------
+# synthetic-turn early-exit: harness-generated turns emit NOTHING
+# ---------------------------------------------------------------------------
+
+test_case "synthetic-turn: <task-notification> body emits nothing"
+out=$(run_hook "<task-notification>swe reports: ran bun install in plugin/mcp/ to rebuild the dist</task-notification>")
+assert_not_contains "$out" "additionalContext" "task-notification turn must be fully silent"
+
+test_case "synthetic-turn: [SYSTEM NOTIFICATION] body emits nothing"
+out=$(run_hook "[SYSTEM NOTIFICATION - NOT USER INPUT] pr-reviewer finished reviewing plugin/mcp/dist")
+assert_not_contains "$out" "additionalContext" "system-notification turn must be fully silent"
+
+# ---------------------------------------------------------------------------
+# cheatcode-install: package-manager installs never route to cheatcodes
+# ---------------------------------------------------------------------------
+
+test_case "cheatcode-install: 'bun install to fix the plugin build' does NOT fire"
+out=$(run_hook "i ran bun install to fix the plugin build")
+assert_not_contains "$out" "cheatcode-install routing" "bun install + plugin noun must not fire"
+
+test_case "cheatcode-install: 'npm install left the mcp dist stale' does NOT fire"
+out=$(run_hook "npm install left the mcp dist stale")
+assert_not_contains "$out" "cheatcode-install routing" "npm install + mcp noun must not fire"
+
+test_case "cheatcode-routing: 'add the code-review skill for swe' fires capability-on-agent"
+out=$(run_hook "add the code-review skill for swe")
+assert_contains "$out" "cheatcode-routing" "add-skill-for-agent must fire capability-on-agent"
+assert_not_contains "$out" "cheatcode-install routing" "capability-on-agent must not also fire install hint"
+
+# ---------------------------------------------------------------------------
 # consultant-spawn: domain keyword + advisory shape required
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1062.

## Problem
prompt-intent-hints.sh scans every incoming prompt, but harness-generated turns (subagent task-notifications, system notifications) embed SWE/pr-reviewer reports whose text reliably contains "bun install" plus plugin/mcp paths — tripping the cheatcode-install matcher's bare substring co-occurrence and injecting an imperative approve→install instruction on turns with no cheatcode in play (observed 4× in one session). Same substring-matching bug class as the closed git-guard issues.

## Fix
1. Case-sensitive early-exit before any matcher when the prompt carries `<task-notification>` or `[SYSTEM NOTIFICATION` — every hint class describes human intent; synthetic turns get none.
2. The direct-install matcher now requires a word-bounded `install|installing` token AND a word-bounded object noun, and excludes package-manager-prefixed installs (npm/bun/pip/… install). Hint texts, the in-scope arm, and the capability-on-agent branch unchanged.

Ripple: `tests/l1-lint/no-raw-sql-interpolation.allowlist` line anchors 78-82 → 87-91 (same five entries, shifted by the early-exit insertion) — judged behavior-neutral by pr-reviewer, accepted via audited scope-gate waiver.

## Verification
- pr-reviewer PASS (task 17, attempt 1, mcp_available=1).
- L3 hook suite 69/69 (5 new cases: two synthetic-turn silences, two package-manager no-fires, one capability-hint regression guard); repo-wide L1 loop green.

Hook + test only (no prompt surfaces) — auto-merge per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)