### PR TITLE
🔖 chore(release): bump to v0.10.0-rc.8 + CHANGELOG

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.10.0-rc.7",
+  "version": "0.10.0-rc.8",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
+## v0.10.0-rc.8 — 2026-07-07
+
+Eighth release candidate for v0.10.0 — a single intent-hints correctness fix.
+
+### Fixed
+- **Intent hints skip synthetic turns** (#1062): `prompt-intent-hints.sh` no longer scans harness-generated task-notification/system-notification turns (embedded subagent reports tripped the cheatcode-install hint), and the direct-install matcher requires word-bounded install intent with a package-manager exclusion instead of bare substring co-occurrence.
+
 ## v0.10.0-rc.7 — 2026-07-02
 
 Seventh release candidate for v0.10.0 — a pre-release deep-scan hardening pass: closes hook guard bypasses and a branch-name SQL injection, fixes MCP-server correctness (validation gating, scan lock/retire, pagination, task state machine, issue-sync backend), reconciles stale docs to the v27 schema, and enforces test integrity.

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.10.0-rc.7",
+  "version": "0.10.0-rc.8",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.10.0-rc.7",
+  "version": "0.10.0-rc.8",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
rc.8 cut: dev moved past the rc.7 tag with the #1062 intent-hints fix (PR #1068), so the next validated rc must contain it. Single-bullet CHANGELOG section; three-manifest atomic bump via bump-version.sh.

pr-reviewer PASS (task 18, attempt 1); L1 loop green (version-sync, changelog-current). On merge: local L6 chain → CI release-gate dispatch → tag v0.10.0-rc.8 → publish-rc-channel. Per the recorded Human decision on the carrier issue: a fully green rc.8 promotes to stable as v1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)