### PR TITLE
🔒 fix(hooks): Rule 2 protects every workflow base, not just protected_branches

### DIFF
--- a/scripts/hooks/git-guards.sh
+++ b/scripts/hooks/git-guards.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Hook: Enforce git workflow rules driven by the repo's branching model.
 # 1. PR must target pr_target
-# 2. No direct commits to protected_branches
+# 2. No direct commits/merges/rebases to any shared workflow base
 # 3. No force push to protected_branches
 # 4. New branches must be based on latest pr_target
 set -euo pipefail
@@ -223,7 +223,15 @@ if [ -n "$_RULE1_FORGE" ]; then
   fi
 fi
 
-# --- Rule 2: No direct commits/merges/rebases to protected_branches (worktree-aware) ---
+# --- Rule 2: No direct commits/merges/rebases to any shared workflow base (worktree-aware) ---
+# The protected set is the union of every branch that serves as a shared base:
+# repos.protected_branches, the repo's target_branch (PR_TARGET), repos.pr_target
+# (when that column exists), and every task's parent_branch_id. A local
+# merge/rebase into any of these bypasses the PR gate, so Rule 2 denies it
+# regardless of the repo's onboarding config. Fail-soft: the DB-driven rows
+# (pr_target, parent_branch_id) are added only when the DB is reachable; the
+# protected_branches + target_branch fallbacks (both with safe defaults) keep the
+# guard closed when it is not.
 # Uses cmd_effective_branch so detached-HEAD worktrees resolve via DB lookup.
 # Match the git subcommand by word boundary to avoid false-positives on plumbing
 # (commit-tree, commit-graph) or "git commit" appearing inside argument text.
@@ -235,10 +243,45 @@ _rule2_match() {
   # Spaces around the separator are consumed to handle `cd /x && git commit`.
   printf '%s' "$cmd" | grep -qE '(^|[[:space:]]*([;&]|[|][|]|[&][&])[[:space:]]*)git[[:space:]]+(commit|merge|rebase|cherry-pick)([[:space:]]|$)'
 }
+
+# rule2_protected_bases
+# Print (one per line, deduped) every workflow base that must not accept a direct
+# commit/merge/rebase: protected_branches ∪ target_branch (PR_TARGET) ∪ pr_target
+# (when the column exists) ∪ DISTINCT tasks.parent_branch_id (this repo, plus
+# NULL-repo tasks for single-repo installs). DB rows are added only when the DB is
+# reachable; the protected_branches/target_branch fallbacks keep the set non-empty.
+rule2_protected_bases() {
+  {
+    printf '%s\n' "$PROTECTED_BRANCHES"
+    [ -n "$PR_TARGET" ] && printf '%s\n' "$PR_TARGET"
+    if [ -n "$_DB" ] && [ -f "$_DB" ] && tmb_have_sqlite; then
+      local root_sql repo_name repo_filter
+      root_sql=$(tmb_sql_quote "$_GIT_ROOT")
+      if [ -n "$(tmb_sqlite_ro "$_DB" "SELECT 1 FROM pragma_table_info('repos') WHERE name='pr_target' LIMIT 1;")" ]; then
+        tmb_sqlite_ro "$_DB" "SELECT pr_target FROM repos WHERE path = '${root_sql}' AND pr_target IS NOT NULL AND pr_target != '';"
+      fi
+      repo_name=$(tmb_sqlite_ro "$_DB" "SELECT name FROM repos WHERE path = '${root_sql}' LIMIT 1;")
+      if [ -n "$repo_name" ]; then
+        repo_filter="(repo = '$(tmb_sql_quote "$repo_name")' OR repo IS NULL)"
+      else
+        repo_filter="repo IS NULL"
+      fi
+      tmb_sqlite_ro "$_DB" "SELECT DISTINCT parent_branch_id FROM tasks WHERE parent_branch_id IS NOT NULL AND parent_branch_id != '' AND ${repo_filter};"
+    fi
+  } | grep -v '^[[:space:]]*$' | sort -u
+}
+
 if _rule2_match "$CMD"; then
     BRANCH=$(cmd_effective_branch "$CMD")
-    if [ -n "$BRANCH" ] && branch_is_protected "$BRANCH"; then
-      jq -nc --arg r "BLOCKED: No direct commits to ${BRANCH}. Create a feature branch first." \
+    RULE2_PROTECTED=$(rule2_protected_bases || true)
+    if [ -n "$BRANCH" ] && printf '%s\n' "$RULE2_PROTECTED" | grep -qxF "$BRANCH"; then
+      _HAS_REMOTE=$(git -C "$_CMD_CWD" remote get-url origin 2>/dev/null || true)
+      if [ -n "$_HAS_REMOTE" ]; then
+        _RULE2_RECOVERY="Push your feature branch and open a PR into ${PR_TARGET}: git push origin <branch> && gh pr create --base ${PR_TARGET} --head <branch>."
+      else
+        _RULE2_RECOVERY="This repo has no remote — leave the branch unmerged and surface it to the Human for integration."
+      fi
+      jq -nc --arg r "BLOCKED: ${BRANCH} is a shared workflow base — no direct commits/merges/rebases. ${_RULE2_RECOVERY}" \
         '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
       exit 0
     fi

--- a/tests/l3-integration/hooks/git-guards.test.sh
+++ b/tests/l3-integration/hooks/git-guards.test.sh
@@ -812,4 +812,69 @@ out=$(run_hook_in_repo "git  push  -f origin main")
 assert_contains "$out" '"permissionDecision":"deny"' "double-space -f force push to main must block"
 cleanup_repo
 
+# ---- #1070: Rule 2 protects every workflow base, not just protected_branches ----
+# Rule 2's protected set is protected_branches ∪ target_branch ∪ pr_target ∪
+# DISTINCT tasks.parent_branch_id. A shared integration base (some task's
+# parent_branch_id, or the repo's target_branch) must reject a direct
+# merge/rebase even when protected_branches doesn't list it.
+
+setup_taskparent_repo() {
+  # $1 = protected_branches JSON (e.g. '[\"main\"]' or '[]')
+  # $2 = target_branch (e.g. main)
+  local protected="$1" target="$2"
+  local dir
+  dir=$(mktemp -d -t tmb-guards-taskparent-XXXX)
+  (
+    cd "$dir" || exit 1
+    git init -q -b main
+    git config user.email t@t.t
+    git config user.name T
+    echo init > README.md
+    git add . && git commit -qm init
+    # 'staging' is a shared integration base referenced by a task's
+    # parent_branch_id but NOT listed in protected_branches. 'feat/plain' is an
+    # ordinary feature branch (no task parents it, not protected/target).
+    git branch staging HEAD
+    git branch feat/plain HEAD
+    mkdir -p .claude/tmb
+    sqlite3 .claude/tmb/trajectory.db < "$PLUGIN_ROOT/mcp/trajectory-server/src/schema.sql" >/dev/null
+    local root
+    root=$(git rev-parse --show-toplevel)
+    sqlite3 .claude/tmb/trajectory.db \
+      "INSERT INTO repos (name, path, target_branch, branching_model, protected_branches) VALUES ('fixture', '$root', '$target', 'github-flow', '$protected');" >/dev/null
+    sqlite3 .claude/tmb/trajectory.db "
+      INSERT OR IGNORE INTO issues (id, objective, description, status, created_at, updated_at)
+        VALUES (1, 'test', 'test', 'open', datetime('now'), datetime('now'));
+      INSERT INTO tasks (id, issue_id, branch_id, parent_branch_id, title, description, status, spec_body, created_at, updated_at)
+        VALUES (1, 1, 'feat/child', 'staging', 'test task', 'd', 'pending', '', datetime('now'), datetime('now'));
+    " >/dev/null
+  )
+  REPO_PATH="$dir"
+}
+
+test_case "#1070: git merge into a task's parent_branch_id (absent from protected_branches) IS blocked"
+setup_taskparent_repo '["main"]' 'main'
+git -C "$REPO_PATH" checkout -q staging
+out=$(run_hook_in_repo "git merge feat/child")
+assert_contains "$out" '"permissionDecision":"deny"' "merge into task-parent base 'staging' must block"
+assert_contains "$out" "staging" "deny message must name the shared base"
+assert_contains "$out" "surface it to the Human" "no-remote deny message must teach the surface-to-Human recovery"
+cleanup_repo
+
+test_case "#1070: git merge into a plain feature branch (not protected/target/task-parent) is ALLOWED"
+setup_taskparent_repo '["main"]' 'main'
+git -C "$REPO_PATH" checkout -q feat/plain
+out=$(run_hook_in_repo "git merge feat/child")
+assert_not_contains "$out" '"permissionDecision":"deny"' "merge into an ordinary feature branch must be allowed"
+cleanup_repo
+
+test_case "#1070: git merge into target_branch is blocked even when protected_branches is empty"
+setup_taskparent_repo '[]' 'main'
+# Repo stays on 'main' (init branch); protected_branches=[] so only the
+# target_branch entry in the union protects it.
+out=$(run_hook_in_repo "git merge feat/child")
+assert_contains "$out" '"permissionDecision":"deny"' "merge into target_branch 'main' must block despite empty protected_branches"
+assert_contains "$out" "main" "deny message must name the target base"
+cleanup_repo
+
 summarize


### PR DESCRIPTION
Closes #1070. Last blocker for the rc.8 tag (L6 step-10).

git-guards Rule 2 denied local merges/rebases only for repos.protected_branches, so a shared base outside the configured list (the L6 chain's dev under a github-flow row protecting only main — or any real user's hand-made integration branch) accepted local merges, leaving merge-via-PR doctrine without a structural backstop. Sandbox bro exercised exactly that hole in L6 run 20260707-214208 step 10.

Rule 2's protected set is now the deduped union: protected_branches ∪ target_branch ∪ repos.pr_target (pragma-guarded) ∪ repo-scoped DISTINCT tasks.parent_branch_id. Deny text teaches the recovery (push + PR with a remote; leave unmerged and surface without one). Fail-soft DB path keeps a non-empty default set. Plain feature-branch merges unchanged.

pr-reviewer PASS (task 19, attempt 1); L3 git-guards 122/122 (3 new cases); repo-wide L1 loop green in provisioned worktrees. Hook + test only — auto-merge per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)