### PR TITLE
🔧 chore(release): gate rc-channel publish + GitHub release on the tag-run verdict (#45)

### DIFF
--- a/scripts/lib/README.md
+++ b/scripts/lib/README.md
@@ -9,6 +9,7 @@ Shared shell helpers sourced by the top-level `scripts/` and by the hook engine.
 | `resolve-plugin-name.sh` | Single source of truth for plugin-name resolution. Source it, then call `tmb_resolve_plugin_name` (reads the `name` field from `plugin.json`). |
 | `resolve-hook.sh` | Version-agnostic hook resolver. Lets `/onboard` materialize a stable copy of a hook at a fixed path so version-pinned cache paths don't orphan it. |
 | `sqlite3-fallback.sh` | `sqlite3` wrappers for the MCP write path, used when the MCP server is unavailable. Each wrapper validates the caller's role against the underlying MCP tool before writing. |
+| `await-release-gate.sh` | Source it, then call `await_release_gate <tag> [timeout]` to poll the tag-triggered `release-gate` run via `gh` and return distinct codes for green / red / no-run / timeout. `publish-rc-channel.sh` and `release.sh` refuse to make a build public unless it concluded success. |
 
 ## How it fits
 

--- a/scripts/lib/await-release-gate.sh
+++ b/scripts/lib/await-release-gate.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# scripts/lib/await-release-gate.sh — await the tag-triggered release-gate verdict.
+#
+# Sourced (not exec'd) by scripts/publish-rc-channel.sh and scripts/release.sh.
+# Pushing a vX.Y.Z[-rc.N] tag auto-fires .github/workflows/release-gate.yml, but
+# nothing downstream used to consult that run — an rc was published and its
+# cut-issue closed minutes before the tag gate went red into an empty room. These
+# publish/release choke points now refuse to make a build public until the tag's
+# gate has concluded `success`.
+#
+# Provides:
+#   await_release_gate <tag> [timeout_seconds]
+#     Resolve the release-gate run whose headBranch == <tag> (tag-triggered runs
+#     report the tag name as the branch, so a dev workflow_dispatch run is never
+#     matched), poll every 30s while it is queued/in_progress, and return:
+#       0  — run concluded success (the ONLY publishing state)
+#       2  — no run found for the tag
+#       3  — run concluded non-success (red gate — do NOT publish)
+#       4  — timed out while still queued/in_progress (inconclusive, not green)
+#       1  — usage error / missing dependency (gh, jq)
+#     Timeout precedence: <timeout_seconds> arg, else env TMB_GATE_TIMEOUT, else
+#     1800s. Prints what it is waiting on, with the run URL.
+
+await_release_gate() {
+  local tag="${1:-}"
+  local timeout="${2:-${TMB_GATE_TIMEOUT:-1800}}"
+  local repo="trustmybot/plugin"
+  local poll_interval=30
+  local waited=0
+  local run_json status conclusion run_url
+
+  if [ -z "$tag" ]; then
+    printf "❌ await_release_gate: missing <tag> argument.\n" >&2
+    return 1
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    printf "❌ await_release_gate: gh CLI is required to read the release-gate run.\n" >&2
+    return 1
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    printf "❌ await_release_gate: jq is required to parse the release-gate run.\n" >&2
+    return 1
+  fi
+
+  while :; do
+    run_json="$(gh run list \
+      --repo "$repo" \
+      --workflow=release-gate \
+      --branch "$tag" \
+      --json databaseId,status,conclusion,url \
+      --limit 1 2>/dev/null || true)"
+
+    if [ -z "$run_json" ] || [ "$run_json" = "[]" ]; then
+      printf "❌ No release-gate run found for tag %s.\n" "$tag" >&2
+      printf "   Tag runs auto-fire on push — wait for GitHub to register it, or\n" >&2
+      printf "   confirm the tag was pushed: git ls-remote --tags origin refs/tags/%s\n" "$tag" >&2
+      return 2
+    fi
+
+    status="$(printf '%s' "$run_json" | jq -r '.[0].status // empty')"
+    conclusion="$(printf '%s' "$run_json" | jq -r '.[0].conclusion // empty')"
+    run_url="$(printf '%s' "$run_json" | jq -r '.[0].url // empty')"
+
+    case "$status" in
+      completed)
+        if [ "$conclusion" = "success" ]; then
+          printf "✓ release-gate for %s concluded success.\n" "$tag"
+          printf "  Run: %s\n" "$run_url"
+          return 0
+        fi
+        printf "❌ release-gate for %s concluded %s — refusing to publish.\n" "$tag" "${conclusion:-unknown}" >&2
+        printf "   Run: %s\n" "$run_url" >&2
+        printf "   A red tag gate means: roll back the channel/tag and ship a new rc\n" >&2
+        printf "   (never publish over a failing gate). Investigate the run above.\n" >&2
+        return 3
+        ;;
+      queued|in_progress|waiting|requested|pending)
+        if [ "$waited" -ge "$timeout" ]; then
+          printf "❌ release-gate for %s still %s after %ss — timed out.\n" "$tag" "$status" "$timeout" >&2
+          printf "   Run: %s\n" "$run_url" >&2
+          printf "   Inconclusive is not green — do NOT publish. Re-run this check once\n" >&2
+          printf "   the run concludes (raise the budget with TMB_GATE_TIMEOUT=<seconds>).\n" >&2
+          return 4
+        fi
+        printf "… waiting on release-gate for %s (status=%s, %ss/%ss)\n" "$tag" "$status" "$waited" "$timeout"
+        printf "  Run: %s\n" "$run_url"
+        sleep "$poll_interval"
+        waited=$((waited + poll_interval))
+        ;;
+      *)
+        if [ "$waited" -ge "$timeout" ]; then
+          printf "❌ release-gate for %s: unexpected status '%s' after %ss — timed out.\n" "$tag" "${status:-empty}" "$timeout" >&2
+          printf "   Run: %s\n" "$run_url" >&2
+          printf "   Inconclusive is not green — do NOT publish. Re-run this check.\n" >&2
+          return 4
+        fi
+        printf "… release-gate for %s reported status '%s'; re-checking (%ss/%ss)\n" "$tag" "${status:-empty}" "$waited" "$timeout"
+        sleep "$poll_interval"
+        waited=$((waited + poll_interval))
+        ;;
+    esac
+  done
+}

--- a/scripts/publish-rc-channel.sh
+++ b/scripts/publish-rc-channel.sh
@@ -17,14 +17,17 @@
 #   1. Resolve VERSION (arg or .claude-plugin/plugin.json .version) → TAG=v$VERSION.
 #   2. Refuse unless VERSION is rc-only (X.Y.Z-rc.N).
 #   3. Verify the tag exists on origin (must be pushed first).
-#   4. Clone trustmybot/marketplace-rc into a temp dir (trap cleanup).
-#   5. Set .claude-plugin/marketplace.json plugins[0].source.ref → TAG; validate JSON.
-#   6. Ensure a marketplace-rc README.md exists.
-#   7. Show the diff, confirm y/N (skipped by --yes), then commit + push origin main.
+#   4. Await the tag's release-gate run; refuse unless it concluded success
+#      (read-only — runs in --dry-run too).
+#   5. Clone trustmybot/marketplace-rc into a temp dir (trap cleanup).
+#   6. Set .claude-plugin/marketplace.json plugins[0].source.ref → TAG; validate JSON.
+#   7. Ensure a marketplace-rc README.md exists.
+#   8. Show the diff, confirm y/N (skipped by --yes), then commit + push origin main.
 #
 # Idempotent + safety-checked:
 #   - Refuses any non-rc version.
 #   - Refuses if the rc tag is not on origin.
+#   - Refuses unless the tag's release-gate run concluded success (no bypass flag).
 #   - Never operates on a hardcoded local catalog path — always a fresh temp clone.
 #   - If the ref already points at TAG AND the README is present → prints
 #     'already published' and exits 0.
@@ -36,6 +39,9 @@ PLUGIN_REPO="https://github.com/trustmybot/plugin.git"
 CATALOG_REPO="https://github.com/trustmybot/marketplace-rc.git"
 
 PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=scripts/lib/await-release-gate.sh
+. "$PLUGIN_ROOT/scripts/lib/await-release-gate.sh"
 
 # ---------- parse args ----------
 
@@ -92,6 +98,16 @@ if [ -z "$(git ls-remote --tags "$PLUGIN_REPO" "refs/tags/$TAG" 2>/dev/null)" ];
   printf "   then re-run this script.\n" >&2
   exit 1
 fi
+
+# ---------- await the tag-triggered release-gate verdict ----------
+#
+# Pushing the rc tag auto-fired .github/workflows/release-gate.yml. Refuse to
+# point the rc channel at a tag whose gate has not concluded success. Read-only,
+# so it runs in --dry-run too. No bypass flag: a red tag gate means roll back
+# the channel/tag and ship a new rc.
+
+printf "Checking the release-gate run for %s ...\n" "$TAG"
+await_release_gate "$TAG" || exit $?
 
 # ---------- clone the catalog into a temp dir ----------
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,8 +11,9 @@
 # What it does (each step asks for explicit y/N + skips if already done):
 #   1. Tag main HEAD as v<plugin.json version>
 #   2. Push the tag to origin
-#   3. Create the GitHub release with notes extracted from CHANGELOG.md
-#   4. Run the L5 release canary (re-clone the tag in Docker, run install-smoke)
+#   3. Await the tag's release-gate run; refuse unless it concluded success
+#   4. Create the GitHub release with notes extracted from CHANGELOG.md
+#   5. Run the L5 release canary (re-clone the tag in Docker, run install-smoke)
 #
 # Idempotent + safety-checked:
 #   - Refuses to run unless current branch is `main`.
@@ -20,11 +21,16 @@
 #   - Refuses to run unless plugin.json version matches a v<version>
 #     section in CHANGELOG.md (catches release-prep merges that didn't land).
 #   - Refuses to run if mcp pkg.json version disagrees with plugin.json.
+#   - Refuses to create the release unless the tag's release-gate run concluded
+#     success (no bypass flag).
 
 set -euo pipefail
 
 PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$PLUGIN_ROOT"
+
+# shellcheck source=scripts/lib/await-release-gate.sh
+. "$PLUGIN_ROOT/scripts/lib/await-release-gate.sh"
 
 # ---------- read version from plugin.json (single source of truth) ----------
 
@@ -161,12 +167,22 @@ else
   printf "  Step 2: %s already pushed to origin — skipping.\n\n" "$NEW_TAG"
 fi
 
-# ---------- step 3: create the GitHub release ----------
+# ---------- step 3: await the tag-triggered release-gate verdict ----------
+#
+# Pushing the tag auto-fired .github/workflows/release-gate.yml. Refuse to make
+# the release public unless that run concluded success — a red stable-tag gate
+# must stop here, not 13 minutes after the release is already live.
+
+printf "  Step 3: Awaiting the release-gate run for %s ...\n" "$NEW_TAG"
+await_release_gate "$NEW_TAG" || exit $?
+printf "\n"
+
+# ---------- step 4: create the GitHub release ----------
 
 if gh release view "$NEW_TAG" >/dev/null 2>&1; then
-  printf "  Step 3: GitHub release %s already exists — skipping.\n\n" "$NEW_TAG"
+  printf "  Step 4: GitHub release %s already exists — skipping.\n\n" "$NEW_TAG"
 else
-  if confirm "Step 3: Create GitHub release $NEW_TAG with the CHANGELOG body?"; then
+  if confirm "Step 4: Create GitHub release $NEW_TAG with the CHANGELOG body?"; then
     NOTES_FILE="$(mktemp -t tmb-release-notes.XXXXXX)"
     trap 'rm -f "$NOTES_FILE"' EXIT
     awk -v target="^## ${NEW_TAG} " '
@@ -190,7 +206,7 @@ else
   fi
 fi
 
-# ---------- step 4: L5 release canary (post-tag verify) ----------
+# ---------- step 5: L5 release canary (post-tag verify) ----------
 #
 # Re-clones the freshly-tagged release into a temp dir and runs the
 # install-smoke Dockerfile against it. Catches "the published artifact
@@ -200,7 +216,7 @@ fi
 # Skipped if Docker is unavailable; warning instead of failure since the
 # release is already public at this point.
 
-if confirm "Step 4: Run L5 release canary (re-clone tag in Docker, run install-smoke)?"; then
+if confirm "Step 5: Run L5 release canary (re-clone tag in Docker, run install-smoke)?"; then
   if ! command -v docker >/dev/null 2>&1; then
     printf "  ⊘ docker not available — skipping canary. Run manually before announcing the release:\n"
     printf "      bash tests/l0-install/run-install-smoke.sh\n"


### PR DESCRIPTION
## Summary
- New `scripts/lib/await-release-gate.sh`: `await_release_gate <tag> [timeout]` resolves the tag-triggered release-gate run (headBranch == tag, so a dev workflow_dispatch green never counts), polls while queued/in_progress, and returns distinct exits for green / no-run / red / timeout.
- `scripts/publish-rc-channel.sh` refuses to point the rc channel at a tag whose gate run hasn't concluded success (also checked in `--dry-run`; no bypass flag).
- `scripts/release.sh` awaits the stable tag's gate between tag-push and GitHub-release creation.

## Why
v0.10.0-rc.8 (and rc.7) were published to the rc channel while their tag-triggered release-gate runs were still executing; both went red minutes later with nobody watching. This enforces the "never publish/release on a red or unconcluded tag gate" policy structurally, at the two choke points. Closes #45.

## Verification
- `bash -n` + `shellcheck -x` clean on all three scripts.
- Live red-path: `await_release_gate v0.10.0-rc.7 120` → exit 3 with rollback guidance (that run is permanently `completed/failure`).
- pr-reviewer verdict: PASS (validation attempt 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)