### PR TITLE
🔖 chore(release): bump to v0.10.0-rc.9 + CHANGELOG (#46)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.10.0-rc.8",
+  "version": "0.10.0-rc.9",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
+## v0.10.0-rc.9 — 2026-07-09
+
+Ninth release candidate for v0.10.0 — closes the two release-gate holes that turned rc.8's tag run red.
+
+### Fixed
+- **task_provision enforces the world-model-cold registry gate** (#1080): closes the fail-open path where bro could provision a task on a cold world model without a `scan_run`.
+- **publish/release await the tag-gate verdict** (#1079): `publish-rc-channel.sh` and `release.sh` wait for the tag-triggered release-gate verdict and refuse on red — no more publishing before the gate reports.
+
 ## v0.10.0-rc.8 — 2026-07-07
 
 Eighth release candidate for v0.10.0 — a single intent-hints correctness fix.

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "mcp/trajectory-server": {
       "name": "@trustmybot/trajectory-server",
-      "version": "0.10.0-rc.6",
+      "version": "0.10.0-rc.9",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.0",

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.10.0-rc.8",
+  "version": "0.10.0-rc.9",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.10.0-rc.8",
+  "version": "0.10.0-rc.9",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Summary
Mechanical release-prep for v0.10.0-rc.9 (the v1.0.0 promote candidate — rc.8's tag gate is red 2/2 and does not promote per policy).

- Three-manifest bump to `0.10.0-rc.9` via `scripts/maintenance/bump-version.sh`.
- CHANGELOG section with the two fixes since rc.8: #1080 (task_provision registry-cold gate) and #1079 (publish/release await the tag-gate verdict).
- bun.lock workspace version string refreshed (pre-existing rc.6 drift, the known bump-version.sh gap tracked in local #39).

## Verification
- version-sync.sh PASS, changelog-current.sh PASS; all three manifests jq-verified at 0.10.0-rc.9.
- pr-reviewer verdict: PASS (validation attempt 1, verified at the SHA in an isolated worktree).

After merge: workflow_dispatch release-gate on dev → on full green, tag v0.10.0-rc.9 → gated rc-channel publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)