### PR TITLE
🔖 chore(release): bump to v1.0.0 + CHANGELOG (#48)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "0.10.0-rc.9",
+  "version": "1.0.0",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (pre-1.0: breaking changes may happen on minor bumps).
 
+## v1.0.0 — 2026-07-09
+
+First stable release. Functionally identical to v0.10.0-rc.9: the v0.10.0 release-candidate line (rc.1–rc.9, entries below) is the complete delta since v0.9.0, and rc.9 passed the tag-triggered release-gate green end to end.
+
 ## v0.10.0-rc.9 — 2026-07-09
 
 Ninth release candidate for v0.10.0 — closes the two release-gate holes that turned rc.8's tag run red.

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "mcp/trajectory-server": {
       "name": "@trustmybot/trajectory-server",
-      "version": "0.10.0-rc.9",
+      "version": "1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.0",

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "0.10.0-rc.9",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "0.10.0-rc.9",
+  "version": "1.0.0",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Release-prep for the stable v1.0.0 cut (local issue #48, task 25).

- \`bump-version.sh 1.0.0\`: plugin.json, root package.json, mcp/trajectory-server package.json
- bun.lock workspace version line synced (bump-script gap, local #39)
- \`## v1.0.0 — 2026-07-09\` CHANGELOG section — functionally identical to v0.10.0-rc.9, whose tag-triggered gate ran fully green

Verification: L1 version-sync + changelog-current PASS; pr-reviewer verdict PASS (attempt 1). Pre-tag CI dispatch skipped per Human directive; stable tags are not re-gated by design (functional-identity rule, #630).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)