### PR TITLE
🐛 fix(release): stable-tag cut resolves the gate verdict from the promoted rc run (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable user-visible changes to the TMB plugin. Versions follow [SemVer](htt
 
 First stable release. Functionally identical to v0.10.0-rc.9: the v0.10.0 release-candidate line (rc.1–rc.9, entries below) is the complete delta since v0.9.0, and rc.9 passed the tag-triggered release-gate green end to end.
 
+### Fixed
+- **release.sh stable cuts resolve the gate verdict from the promoted rc** (#49): step 3 awaited a release-gate run for the stable tag, but the gate fires only on rc tags (#630) — every stable cut aborted after pushing the tag. A stable tag now awaits the newest rc tag in its ancestry; refuse-on-red is unchanged.
+
 ## v0.10.0-rc.9 — 2026-07-09
 
 Ninth release candidate for v0.10.0 — closes the two release-gate holes that turned rc.8's tag run red.

--- a/scripts/lib/await-release-gate.sh
+++ b/scripts/lib/await-release-gate.sh
@@ -9,6 +9,15 @@
 # gate has concluded `success`.
 #
 # Provides:
+#   resolve_gate_tag <tag>
+#     Map a tag to the tag whose release-gate run carries its verdict. The gate
+#     fires only on rc tags (#630), so an rc tag resolves to itself. A stable tag
+#     resolves to the newest v*-rc.* tag merged into HEAD — after a dev → main
+#     promotion the promoted rc is always an ancestor, and it is functionally
+#     identical to the stable cut, so its concluded run is the stable tag's
+#     verdict. Returns:
+#       0  — echoes the resolved rc tag on stdout
+#       2  — stable tag with no rc tag in HEAD's ancestry (verdict unresolvable)
 #   await_release_gate <tag> [timeout_seconds]
 #     Resolve the release-gate run whose headBranch == <tag> (tag-triggered runs
 #     report the tag name as the branch, so a dev workflow_dispatch run is never
@@ -20,6 +29,36 @@
 #       1  — usage error / missing dependency (gh, jq)
 #     Timeout precedence: <timeout_seconds> arg, else env TMB_GATE_TIMEOUT, else
 #     1800s. Prints what it is waiting on, with the run URL.
+
+resolve_gate_tag() {
+  local tag="${1:-}"
+
+  if [ -z "$tag" ]; then
+    printf "❌ resolve_gate_tag: missing <tag> argument.\n" >&2
+    return 1
+  fi
+
+  case "$tag" in
+    *-rc.*)
+      printf '%s\n' "$tag"
+      return 0
+      ;;
+  esac
+
+  local rc_tag
+  rc_tag="$(git tag --list 'v*-rc.*' --merged HEAD --sort=-creatordate | head -1)"
+
+  if [ -z "$rc_tag" ]; then
+    printf "❌ resolve_gate_tag: no v*-rc.* tag in HEAD's ancestry for stable tag %s.\n" "$tag" >&2
+    printf "   The release gate fires only on rc tags (#630), so a stable cut's\n" >&2
+    printf "   functional-identity verdict is the promoted rc's run — but none is an\n" >&2
+    printf "   ancestor of HEAD. Promote a green rc into main before cutting %s.\n" "$tag" >&2
+    return 2
+  fi
+
+  printf '%s\n' "$rc_tag"
+  return 0
+}
 
 await_release_gate() {
   local tag="${1:-}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -169,12 +169,21 @@ fi
 
 # ---------- step 3: await the tag-triggered release-gate verdict ----------
 #
-# Pushing the tag auto-fired .github/workflows/release-gate.yml. Refuse to make
-# the release public unless that run concluded success — a red stable-tag gate
-# must stop here, not 13 minutes after the release is already live.
+# The release gate fires only on rc tags (#630) — a stable cut is functionally
+# identical to the rc it promotes, so it is never re-gated. resolve_gate_tag maps
+# the tag we push to the tag whose run carries the verdict: an rc tag to itself,
+# a stable tag to the newest rc tag in HEAD's ancestry (the promoted rc). Refuse
+# to make the release public unless that run concluded success — refuse-on-red is
+# unchanged: a red or missing rc verdict must stop here, not 13 minutes after the
+# release is already live.
 
-printf "  Step 3: Awaiting the release-gate run for %s ...\n" "$NEW_TAG"
-await_release_gate "$NEW_TAG" || exit $?
+GATE_TAG="$(resolve_gate_tag "$NEW_TAG")" || exit $?
+if [ "$GATE_TAG" != "$NEW_TAG" ]; then
+  printf "  Step 3: Awaiting the release-gate run for %s (the promoted rc's verdict for %s) ...\n" "$GATE_TAG" "$NEW_TAG"
+else
+  printf "  Step 3: Awaiting the release-gate run for %s ...\n" "$GATE_TAG"
+fi
+await_release_gate "$GATE_TAG" || exit $?
 printf "\n"
 
 # ---------- step 4: create the GitHub release ----------


### PR DESCRIPTION
Found while executing the v1.0.0 cut: release.sh step 3 (#1079) awaited a release-gate run for the stable tag, but the gate fires only on rc tags (#630) — await returns "no run found" and the release aborts AFTER the tag is pushed. First stable cut since #1079 would have hit it.

Fix: new `resolve_gate_tag()` in scripts/lib/await-release-gate.sh — rc tags pass through; a stable tag resolves to the newest rc tag in HEAD's ancestry (the promoted rc), whose concluded run carries the verdict (functional-identity rule). Refuse-on-red unchanged; a missing rc verdict still blocks (return 2).

Verification: bash -n both scripts, release-script-safety.sh 10/10, resolve_gate_tag v1.0.0 → v0.10.0-rc.9, changelog-current.sh PASS. pr-reviewer verdict PASS (attempt 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)