### PR TITLE
🐛 fix(hooks): drift banner names a remedy that actually reboots the MCP server (#1086)

### DIFF
--- a/docs/reference/UPGRADE.md
+++ b/docs/reference/UPGRADE.md
@@ -27,7 +27,7 @@ The SessionStart project inventory also prints a `Plugin version:` line at the t
 CC can fetch a newer version into its marketplace cache while the **older** MCP server / hooks keep running until you reload. When that happens, the SessionStart inventory appends a line:
 
 ```
-newer plugin version <X.Y.Z> is installed but <A.B.C> is still running — restart Claude Code (or /reload-plugins) to apply
+newer plugin version <X.Y.Z> is installed but <A.B.C> is still running — restart Claude Code (or reconnect the trajectory-server via /mcp) to apply
 ```
 
 That is your cue to reload — the new files are on disk but inert until the MCP server reboots (see below). The line disappears once the running version matches the highest cached version. It is read-only and never blocks the session.

--- a/scripts/hooks/session-start-prescan.sh
+++ b/scripts/hooks/session-start-prescan.sh
@@ -131,7 +131,7 @@ $COLD_NOTE"
 # Version-skew note (#602) — only when a newer version sits in the cache but
 # the older one is still running.
 [ -n "$NEWER_CACHED_VERSION" ] && COLD_SUFFIX="${COLD_SUFFIX}
-newer plugin version ${NEWER_CACHED_VERSION} is installed but ${PLUGIN_VERSION} is still running — restart Claude Code (or /reload-plugins) to apply"
+newer plugin version ${NEWER_CACHED_VERSION} is installed but ${PLUGIN_VERSION} is still running — restart Claude Code (or reconnect the trajectory-server via /mcp) to apply"
 
 PLUGIN_VERSION_LINE="(unknown)"
 [ -n "$PLUGIN_VERSION" ] && PLUGIN_VERSION_LINE="$PLUGIN_VERSION"


### PR DESCRIPTION
Version-drift banner now says 'restart Claude Code (or reconnect the trajectory-server via /mcp) to apply' — /reload-plugins cannot restart the MCP server process. UPGRADE.md's verbatim quote synced. Closes #1086. pr-reviewer PASS (attempt 1); shellcheck + link-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)