### PR TITLE
🐛 fix(hooks): orphan scan + drift warn resolve the session's own server, never a bystander (#1078)

### DIFF
--- a/scripts/hooks/deferred-tools-drift-warn.sh
+++ b/scripts/hooks/deferred-tools-drift-warn.sh
@@ -11,26 +11,75 @@
 #
 # Silent no-op when:
 #   - pgrep is not available (and no TMB_MCP_PID_OVERRIDE)
-#   - No trajectory-server child is running
+#   - The current session has no trajectory-server child running
 #   - dist/tools/ directory does not exist
 #   - No tool source files are newer than the running child
 #   - ps start-time parse fails (defensive — avoid false alarms)
 #
+# The running server is resolved to the CURRENT session's own child: walk this
+# hook's ancestry to the owning CC process, then pick the trajectory-server
+# whose parent chain contains it. A global pgrep would pick a DIFFERENT
+# project's server (live repro 2026-07-09); the own-child walk prevents that.
+#
 # Test overrides (env vars):
-#   TMB_MCP_PID_OVERRIDE   — inject a known PID (skips pgrep)
+#   TMB_MCP_PID_OVERRIDE   — inject a known PID (skips resolution)
 #   TMB_MCP_START_OVERRIDE — inject epoch seconds for child start-time (skips ps)
 #   TMB_TOOL_DIR_OVERRIDE  — inject alternate dist/tools path (skips PLUGIN_ROOT)
+#   TMB_DRIFT_SELF_PID     — pin the ancestry-walk start pid (skips $$)
 
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
+# POSIX ps ancestry helpers (no /proc dependence) — portable macOS + Linux.
+proc_ppid() { ps -o ppid= -p "$1" 2>/dev/null | tr -d ' ' || printf ''; }
+proc_cmd()  { ps -o command= -p "$1" 2>/dev/null || printf ''; }
+is_cc_cmd() {
+  case "$1" in
+    claude|claude\ *|*/claude|*/claude\ *) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+# Nearest Claude Code ancestor of a pid (pid included), or empty.
+nearest_cc_ancestor() {
+  local pid="$1" guard=0
+  while [ -n "$pid" ] && [ "$pid" -gt 1 ] 2>/dev/null; do
+    guard=$((guard + 1)); [ "$guard" -gt 40 ] && break
+    if is_cc_cmd "$(proc_cmd "$pid")"; then printf '%s' "$pid"; return 0; fi
+    pid=$(proc_ppid "$pid")
+  done
+  printf ''
+}
+# True when target appears anywhere in pid's ancestry (pid included).
+chain_contains() {
+  local pid="$1" target="$2" guard=0
+  [ -n "$target" ] || return 1
+  while [ -n "$pid" ] && [ "$pid" -gt 1 ] 2>/dev/null; do
+    guard=$((guard + 1)); [ "$guard" -gt 40 ] && break
+    [ "$pid" = "$target" ] && return 0
+    pid=$(proc_ppid "$pid")
+  done
+  return 1
+}
+# The current session's own trajectory-server child, or empty.
+resolve_own_server() {
+  local own_cc pid
+  own_cc=$(nearest_cc_ancestor "${TMB_DRIFT_SELF_PID:-$$}")
+  [ -n "$own_cc" ] || return 0
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    [ "$pid" = "$own_cc" ] && continue   # the CC proc is never its own server child
+    if chain_contains "$pid" "$own_cc"; then printf '%s' "$pid"; return 0; fi
+  done < <(pgrep -f 'trajectory-server/dist/index.js' 2>/dev/null || true)
+  return 0
+}
+
 if [ -n "${TMB_MCP_PID_OVERRIDE:-}" ]; then
   MCP_PID="$TMB_MCP_PID_OVERRIDE"
 else
   command -v pgrep >/dev/null 2>&1 || exit 0
-  MCP_PID=$(pgrep -f 'trajectory-server/dist/index.js' 2>/dev/null | head -1 || true)
+  MCP_PID=$(resolve_own_server)
   [ -n "$MCP_PID" ] || exit 0
 fi
 

--- a/scripts/hooks/orphan-scan.sh
+++ b/scripts/hooks/orphan-scan.sh
@@ -4,7 +4,10 @@
 # Detects (and, only when explicitly opted in, cleans) TMB artifacts left
 # behind by version upgrades, scoped STRICTLY to the CURRENT project:
 #   1. Stale old-layout / 0-byte trajectory DBs of THIS project.
-#   2. A stale duplicate trajectory-server proc holding THIS project's live DB.
+#   2. A stale duplicate trajectory-server proc holding THIS project's live DB
+#      whose owning CC session is dead. The current session's own server is
+#      excluded; a live other session's server is reported as a lock-conflict
+#      and never killed.
 #   3. Cache version dirs referenced by NO installed_plugins.json entry
 #      (globally unused — safe to clean regardless of project).
 #
@@ -144,45 +147,100 @@ if [ "${#UNUSED_CACHE[@]}" -gt 0 ]; then
   done
 fi
 
-# --- (2) stale duplicate MCP proc on THIS project's live DB -----------------
-# Only flag a trajectory-server node proc that holds THIS project's live DB.
-# A proc holding any OTHER project's DB is never enumerated. lsof absence
-# degrades gracefully (we simply report nothing).
-DUP_PROCS=()
-if [ -s "$LIVE_DB" ] && command -v lsof >/dev/null 2>&1 && _within_deadline; then
-  # PIDs with the live DB file open.
-  HOLDERS=$(lsof -t -- "$LIVE_DB" 2>/dev/null | sort -u || printf '')
-  if [ -n "$HOLDERS" ]; then
-    HOLDER_COUNT=$(printf '%s\n' "$HOLDERS" | grep -c . || printf '0')
-    # A single holder is the live server — not a duplicate. Only when more
-    # than one trajectory-server holds the SAME live DB is there a stale dup.
-    if [ "$HOLDER_COUNT" -gt 1 ]; then
-      while IFS= read -r pid; do
-        [ -n "$pid" ] || continue
-        # Confirm it is a trajectory-server node proc (not an unrelated reader).
-        if ps -p "$pid" -o command= 2>/dev/null | grep -q 'trajectory-server'; then
-          DUP_PROCS+=("$pid")
-        fi
-      done < <(printf '%s\n' "$HOLDERS")
-    fi
+# --- (2) MCP procs holding THIS project's live DB ---------------------------
+# Only trajectory-server node procs that hold THIS project's live DB are
+# enumerated (a proc holding any OTHER project's DB is never touched). Each
+# holder is classified so the CURRENT session's own server is never flagged:
+#   - own session's server (its parent chain contains this session's CC proc)
+#     → excluded entirely.
+#   - a holder whose owning CC session is still alive → lock-conflict; reported
+#     but NEVER a clean-mode kill target.
+#   - a holder whose owning CC session is dead/absent → stale duplicate;
+#     reported and eligible for clean-mode termination.
+# POSIX ps -o pid=,ppid= ancestry walks (no /proc dependence) keep this
+# portable across macOS and Linux. lsof absence degrades gracefully.
+
+# ppid of a pid (empty on failure — never trips the ERR trap).
+proc_ppid() { ps -o ppid= -p "$1" 2>/dev/null | tr -d ' ' || printf ''; }
+# full command of a pid (empty on failure).
+proc_cmd()  { ps -o command= -p "$1" 2>/dev/null || printf ''; }
+
+# A Claude Code process is the `claude` CLI binary (argv[0] basename 'claude').
+# The shell-snapshot wrappers that merely reference a `.claude/` path and the
+# `node .../trajectory-server` child are deliberately NOT matched.
+is_cc_cmd() {
+  case "$1" in
+    claude|claude\ *|*/claude|*/claude\ *) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Walk a pid's ancestry (starting at pid itself) up to init; echo the pid of
+# the nearest Claude Code ancestor, or empty when none is found. Always 0.
+nearest_cc_ancestor() {
+  local pid="$1" guard=0
+  while [ -n "$pid" ] && [ "$pid" -gt 1 ] 2>/dev/null; do
+    guard=$((guard + 1)); [ "$guard" -gt 40 ] && break
+    if is_cc_cmd "$(proc_cmd "$pid")"; then printf '%s' "$pid"; return 0; fi
+    pid=$(proc_ppid "$pid")
+  done
+  printf ''
+}
+
+# True when target appears anywhere in pid's ancestry (pid included).
+chain_contains() {
+  local pid="$1" target="$2" guard=0
+  [ -n "$target" ] || return 1
+  while [ -n "$pid" ] && [ "$pid" -gt 1 ] 2>/dev/null; do
+    guard=$((guard + 1)); [ "$guard" -gt 40 ] && break
+    [ "$pid" = "$target" ] && return 0
+    pid=$(proc_ppid "$pid")
+  done
+  return 1
+}
+
+# Holders of the live DB: a test override (whitespace-separated PIDs) wins so
+# L3 can drive fabricated process trees; otherwise lsof enumerates real ones.
+resolve_holders() {
+  if [ -n "${TMB_ORPHAN_SCAN_HOLDERS_OVERRIDE:-}" ]; then
+    printf '%s\n' "$TMB_ORPHAN_SCAN_HOLDERS_OVERRIDE" | tr ' ' '\n'
+    return 0
   fi
+  command -v lsof >/dev/null 2>&1 || return 0
+  lsof -t -- "$LIVE_DB" 2>/dev/null | sort -u || printf ''
+}
+
+# Resolve the CURRENT session's own CC proc by walking this hook's ancestry.
+# TMB_ORPHAN_SCAN_SELF_PID pins the start pid so L3 can drive it.
+OWN_CC=$(nearest_cc_ancestor "${TMB_ORPHAN_SCAN_SELF_PID:-$$}")
+
+LOCK_CONFLICTS=()   # live-owner holders — reported, never killed
+STALE_PROCS=()      # dead-owner holders — reported and clean-mode killable
+if [ -s "$LIVE_DB" ] && _within_deadline; then
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    # Confirm it is a trajectory-server node proc (not an unrelated reader).
+    ps -p "$pid" -o command= 2>/dev/null | grep -q 'trajectory-server' || continue
+    # Never flag the current session's own server.
+    chain_contains "$pid" "$OWN_CC" && continue
+    # Classify by owner liveness.
+    owner=$(nearest_cc_ancestor "$pid")
+    if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
+      LOCK_CONFLICTS+=("$pid")
+    else
+      STALE_PROCS+=("$pid")
+    fi
+  done < <(resolve_holders)
 fi
 
-if [ "${#DUP_PROCS[@]}" -gt 1 ]; then
-  # Keep the lowest PID (oldest / live); the rest are stale duplicates.
-  SORTED=$(printf '%s\n' "${DUP_PROCS[@]}" | sort -n)
-  KEEP=$(printf '%s\n' "$SORTED" | head -1)
-  STALE_PROCS=()
-  while IFS= read -r pid; do
-    [ "$pid" = "$KEEP" ] && continue
-    STALE_PROCS+=("$pid")
-  done < <(printf '%s\n' "$SORTED")
-  for pid in "${STALE_PROCS[@]}"; do
-    add_report "stale duplicate trajectory-server on this project's live DB: pid $pid"
-  done
-else
-  STALE_PROCS=()
-fi
+for pid in "${LOCK_CONFLICTS[@]:-}"; do
+  [ -n "$pid" ] || continue
+  add_report "lock-conflict: another live session's server holds this project's live DB (pid $pid)"
+done
+for pid in "${STALE_PROCS[@]:-}"; do
+  [ -n "$pid" ] || continue
+  add_report "stale duplicate trajectory-server on this project's live DB: pid $pid"
+done
 
 # --- cleanup (gated) --------------------------------------------------------
 # Default OFF. When on, act ONLY on the project-scoped candidates above plus

--- a/tests/l3-integration/hooks/deferred-tools-drift-warn.test.sh
+++ b/tests/l3-integration/hooks/deferred-tools-drift-warn.test.sh
@@ -11,7 +11,14 @@ PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
 HOOK="$PLUGIN_ROOT/scripts/hooks/deferred-tools-drift-warn.sh"
 
 TMPDIR_BASE=$(mktemp -d)
-trap 'rm -rf "$TMPDIR_BASE"' EXIT
+PIDS_TO_KILL=()
+cleanup() {
+  for p in "${PIDS_TO_KILL[@]:-}"; do
+    [ -n "$p" ] && kill "$p" 2>/dev/null || true
+  done
+  rm -rf "$TMPDIR_BASE"
+}
+trap cleanup EXIT
 
 TOOL_DIR="$TMPDIR_BASE/dist/tools"
 mkdir -p "$TOOL_DIR"
@@ -64,5 +71,49 @@ touch -t "$OLD_MTIME" "$TOOL_DIR/tasks.js"
 out=$(TMB_MCP_PID_OVERRIDE="$FAKE_PID" TMB_MCP_START_OVERRIDE="$FUTURE_EPOCH" \
   TMB_TOOL_DIR_OVERRIDE="$TOOL_DIR" run_hook)
 assert_eq "" "$out" "child started after files = silent"
+
+# --- own-child resolution (no PID override) ---------------------------------
+# Without TMB_MCP_PID_OVERRIDE the hook must resolve the CURRENT session's own
+# trajectory-server child (walk this session's ancestry to its CC proc, then
+# the server whose parent chain contains it) — NOT a bystander project's
+# server matched by a global pgrep. Fabricate two trees: an "own" CC with a
+# server + hook surrogate, and a bystander CC with a server. TMB_DRIFT_SELF_PID
+# pins the ancestry-walk start pid to the own session's hook surrogate.
+# The server argv is passed via the environment so the literal path never
+# appears in the "CC" bash command line — mirroring production, where a global
+# pgrep -f 'trajectory-server/dist/index.js' matches only real server procs.
+export SRV_ARGV="node /x/mcp/trajectory-server/dist/index.js"
+spawn_live_tree() {
+  local pf="$1"
+  ( exec -a claude bash -c '
+      ( exec -a "$SRV_ARGV" sleep 300 ) &
+      echo "SRV $!" >> "'"$pf"'"
+      ( exec -a "cc-hook-runner" sleep 300 ) &
+      echo "HOOK $!" >> "'"$pf"'"
+      wait
+    ' ) &
+  echo "CC $!" >> "$pf"
+  disown "$!" 2>/dev/null || true
+}
+
+PF_OWN="$TMPDIR_BASE/own.pids"; : > "$PF_OWN"
+PF_BY="$TMPDIR_BASE/by.pids"; : > "$PF_BY"
+spawn_live_tree "$PF_OWN"
+spawn_live_tree "$PF_BY"
+sleep 0.6
+OWN_SRV=$(awk '/^SRV/{print $2}' "$PF_OWN")
+OWN_HOOK=$(awk '/^HOOK/{print $2}' "$PF_OWN")
+OWN_CC=$(awk '/^CC/{print $2}' "$PF_OWN")
+BY_SRV=$(awk '/^SRV/{print $2}' "$PF_BY")
+BY_HOOK=$(awk '/^HOOK/{print $2}' "$PF_BY")
+BY_CC=$(awk '/^CC/{print $2}' "$PF_BY")
+PIDS_TO_KILL+=("$OWN_SRV" "$OWN_HOOK" "$OWN_CC" "$BY_SRV" "$BY_HOOK" "$BY_CC")
+
+test_case "own-child resolution names this session's server, not a bystander"
+touch -t "$NEW_MTIME" "$TOOL_DIR/index.js"
+out=$(TMB_DRIFT_SELF_PID="$OWN_HOOK" TMB_MCP_START_OVERRIDE="$PAST_EPOCH" \
+  TMB_TOOL_DIR_OVERRIDE="$TOOL_DIR" run_hook)
+assert_contains "$out" "PID $OWN_SRV)" "resolves the own session's server"
+assert_not_contains "$out" "PID $BY_SRV)" "never names the bystander server"
 
 summarize

--- a/tests/l3-integration/hooks/orphan-scan.test.sh
+++ b/tests/l3-integration/hooks/orphan-scan.test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Tests for scripts/hooks/orphan-scan.sh — self-PID exclusion and owner-liveness
+# classification of trajectory-server procs holding THIS project's live DB.
+#
+# Cases:
+#   (a) the current session's own server is never flagged
+#   (b) a live other-session server is reported as a lock-conflict and survives
+#       clean mode (TMB_ORPHAN_SCAN_CLEAN=1)
+#   (c) a dead-owner server is flagged stale and IS killed in clean mode
+#
+# Process trees are fabricated with sleep subprocesses re-parented as needed:
+#   - a "CC" proc is a bash renamed to `claude` (argv[0]) via `exec -a`
+#   - a "server" child is a sleep renamed so its argv contains
+#     trajectory-server/dist/index.js
+#   - DB holders are injected via TMB_ORPHAN_SCAN_HOLDERS_OVERRIDE (no lsof)
+#   - the own-CC ancestry-walk start pid is pinned via TMB_ORPHAN_SCAN_SELF_PID
+# All state lives under a mktemp sandbox; project + HOME are pinned so the real
+# artifacts are never touched.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../lib/assert.sh"
+PLUGIN_ROOT="$(cd "$HERE/../../.." && pwd)"
+HOOK="$PLUGIN_ROOT/scripts/hooks/orphan-scan.sh"
+
+TMPDIR_BASE=$(mktemp -d)
+PIDS_TO_KILL=()
+cleanup() {
+  for p in "${PIDS_TO_KILL[@]:-}"; do
+    [ -n "$p" ] && kill "$p" 2>/dev/null || true
+  done
+  rm -rf "$TMPDIR_BASE"
+}
+trap cleanup EXIT
+
+cd "$TMPDIR_BASE"
+assert_not_in_plugin_repo "$PLUGIN_ROOT"
+
+PROJECT_DIR="$TMPDIR_BASE/project"
+SCAN_HOME="$TMPDIR_BASE/home"
+mkdir -p "$PROJECT_DIR/.claude/tmb" "$SCAN_HOME/.claude"
+LIVE_DB="$PROJECT_DIR/.claude/tmb/trajectory.db"
+printf 'live' > "$LIVE_DB"   # non-empty so the [ -s "$LIVE_DB" ] gate is true
+
+SRV_ARGV="node /x/mcp/trajectory-server/dist/index.js"
+
+# Spawn a live "CC" (argv[0]=claude) with a trajectory-server child and a hook
+# surrogate child. Writes "CC/SRV/HOOK <pid>" lines to $1. All three survive
+# until killed in cleanup.
+spawn_live_tree() {
+  local pf="$1"
+  ( exec -a claude bash -c '
+      ( exec -a "'"$SRV_ARGV"'" sleep 300 ) &
+      echo "SRV $!" >> "'"$pf"'"
+      ( exec -a "cc-hook-runner" sleep 300 ) &
+      echo "HOOK $!" >> "'"$pf"'"
+      wait
+    ' ) &
+  echo "CC $!" >> "$pf"
+  disown "$!" 2>/dev/null || true   # keep job-control termination noise quiet
+}
+
+# Spawn a trajectory-server child whose "CC" parent exits immediately, leaving
+# the server re-parented to init (dead owner). Writes "SRV <pid>" to $1.
+spawn_dead_owner_tree() {
+  local pf="$1"
+  ( exec -a claude bash -c '
+      ( exec -a "'"$SRV_ARGV"'" sleep 300 ) &
+      echo "SRV $!" >> "'"$pf"'"
+    ' ) &
+  echo "CC $!" >> "$pf"
+  disown "$!" 2>/dev/null || true
+}
+
+run_hook() {
+  echo '{}' | bash "$HOOK" 2>&1 || true
+}
+
+# --- shared "current session" context (a live CC + hook surrogate) ----------
+PF_SELF="$TMPDIR_BASE/self.pids"; : > "$PF_SELF"
+spawn_live_tree "$PF_SELF"
+sleep 0.6
+SELF_CC=$(awk '/^CC/{print $2}' "$PF_SELF")
+SELF_SRV=$(awk '/^SRV/{print $2}' "$PF_SELF")
+SELF_HOOK=$(awk '/^HOOK/{print $2}' "$PF_SELF")
+PIDS_TO_KILL+=("$SELF_CC" "$SELF_SRV" "$SELF_HOOK")
+
+# --- (a) own-session server is never flagged --------------------------------
+test_case "own-session server is never flagged (self-PID exclusion)"
+out=$(TMB_ORPHAN_SCAN_PROJECT_DIR="$PROJECT_DIR" TMB_ORPHAN_SCAN_HOME="$SCAN_HOME" \
+      TMB_ORPHAN_SCAN_HOLDERS_OVERRIDE="$SELF_SRV" \
+      TMB_ORPHAN_SCAN_SELF_PID="$SELF_HOOK" run_hook)
+assert_not_contains "$out" "trajectory-server" "own server produces no proc report"
+assert_not_contains "$out" "lock-conflict" "own server is not a lock-conflict"
+assert_eq "" "$out" "own server → silent"
+
+# --- (b) live other-session server → lock-conflict, survives clean mode ------
+PF_OTHER="$TMPDIR_BASE/other.pids"; : > "$PF_OTHER"
+spawn_live_tree "$PF_OTHER"
+sleep 0.6
+OTHER_CC=$(awk '/^CC/{print $2}' "$PF_OTHER")
+OTHER_SRV=$(awk '/^SRV/{print $2}' "$PF_OTHER")
+OTHER_HOOK=$(awk '/^HOOK/{print $2}' "$PF_OTHER")
+PIDS_TO_KILL+=("$OTHER_CC" "$OTHER_SRV" "$OTHER_HOOK")
+
+test_case "live other-session server is reported as a lock-conflict"
+out=$(TMB_ORPHAN_SCAN_PROJECT_DIR="$PROJECT_DIR" TMB_ORPHAN_SCAN_HOME="$SCAN_HOME" \
+      TMB_ORPHAN_SCAN_HOLDERS_OVERRIDE="$OTHER_SRV" \
+      TMB_ORPHAN_SCAN_SELF_PID="$SELF_HOOK" run_hook)
+assert_contains "$out" "lock-conflict" "live other server → lock-conflict"
+assert_contains "$out" "pid $OTHER_SRV" "lock-conflict names the holder pid"
+assert_not_contains "$out" "stale duplicate" "live owner is never called stale"
+
+test_case "live other-session server is NOT killed in clean mode"
+out=$(TMB_ORPHAN_SCAN_PROJECT_DIR="$PROJECT_DIR" TMB_ORPHAN_SCAN_HOME="$SCAN_HOME" \
+      TMB_ORPHAN_SCAN_HOLDERS_OVERRIDE="$OTHER_SRV" \
+      TMB_ORPHAN_SCAN_SELF_PID="$SELF_HOOK" TMB_ORPHAN_SCAN_CLEAN=1 run_hook)
+sleep 0.2
+if kill -0 "$OTHER_SRV" 2>/dev/null; then _pass; else _fail "live other server was killed in clean mode"; fi
+
+# --- (c) dead-owner server → stale, killed in clean mode --------------------
+PF_DEAD="$TMPDIR_BASE/dead.pids"; : > "$PF_DEAD"
+spawn_dead_owner_tree "$PF_DEAD"
+sleep 0.8
+DEAD_SRV=$(awk '/^SRV/{print $2}' "$PF_DEAD")
+PIDS_TO_KILL+=("$DEAD_SRV")
+
+test_case "dead-owner server is flagged stale"
+out=$(TMB_ORPHAN_SCAN_PROJECT_DIR="$PROJECT_DIR" TMB_ORPHAN_SCAN_HOME="$SCAN_HOME" \
+      TMB_ORPHAN_SCAN_HOLDERS_OVERRIDE="$DEAD_SRV" \
+      TMB_ORPHAN_SCAN_SELF_PID="$SELF_HOOK" run_hook)
+assert_contains "$out" "stale duplicate trajectory-server" "dead-owner server → stale"
+assert_contains "$out" "pid $DEAD_SRV" "stale report names the holder pid"
+
+test_case "dead-owner server IS killed in clean mode"
+out=$(TMB_ORPHAN_SCAN_PROJECT_DIR="$PROJECT_DIR" TMB_ORPHAN_SCAN_HOME="$SCAN_HOME" \
+      TMB_ORPHAN_SCAN_HOLDERS_OVERRIDE="$DEAD_SRV" \
+      TMB_ORPHAN_SCAN_SELF_PID="$SELF_HOOK" TMB_ORPHAN_SCAN_CLEAN=1 run_hook)
+sleep 0.3
+if kill -0 "$DEAD_SRV" 2>/dev/null; then _fail "dead-owner server survived clean mode"; else _pass; fi
+
+summarize


### PR DESCRIPTION
Orphan scan now excludes the current session's own trajectory-server (ancestry walk to the owning CC process) and classifies remaining DB holders by owner liveness: live other session → lock-conflict report, never killed under TMB_ORPHAN_SCAN_CLEAN=1; dead owner → stale + killable. Drift hook resolves the session's own server child instead of a global pgrep that could name another project's server. L3: orphan-scan 10/10, drift-warn 11/11, full hooks suite 64/64. Closes #1078. pr-reviewer PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)