### PR TITLE
🐛 fix(tests): pin bun in L0/canary Dockerfiles; release canary builds --no-cache (#1100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (SemVer guarantees apply as of v1.0.0).
 
+## Unreleased
+
+### Fixed
+- **Release canary pins bun and rebuilds cache-clean** (#52): the L0/canary Dockerfiles pin bun via `ARG BUN_VERSION=1.3.4` before the install layer, and `release.sh`'s canary build runs `--no-cache`, so the canary can no longer validate the committed `bun.lock` with a months-stale layer-cached bun.
+
 ## v1.0.0 — 2026-07-10
 
 First stable release. The core is v0.10.0-rc.9 — the first release candidate whose tag-triggered gate ran fully green (the rc.1–rc.9 entries below are the complete delta since v0.9.0) — plus a post-rc.9 hardening sprint, rolled up below.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -238,9 +238,13 @@ if confirm "Step 5: Run L5 release canary (re-clone tag in Docker, run install-s
       # Wrap the build in `timeout` so a stalled buildkit can't hang the release
       # indefinitely (#643). Default 600s; override with TMB_CANARY_TIMEOUT.
       CANARY_TIMEOUT="${TMB_CANARY_TIMEOUT:-600}"
+      # --no-cache: the canary runs once per release and must never reuse a
+      # stale layer (a cache-pinned bun would validate the lockfile with the
+      # wrong version). Minutes of rebuild buys a canary that can't be poisoned.
       if (cd "$CANARY_DIR/plugin" && timeout "$CANARY_TIMEOUT" docker build \
             -f tests/l0-install/install-smoke.Dockerfile \
             -t "tmb-canary-$NEW_VERSION" \
+            --no-cache \
             --quiet .); then
         printf "  ✓ Canary PASSED — published %s installs cleanly from a fresh clone\n\n" "$NEW_TAG"
       else

--- a/tests/l0-install/install-smoke.Dockerfile
+++ b/tests/l0-install/install-smoke.Dockerfile
@@ -18,8 +18,13 @@ FROM node:22-slim
 # the entire native-binding bug class that broke v0.2.0.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends curl unzip git ca-certificates sqlite3 \
- && rm -rf /var/lib/apt/lists/* \
- && curl -fsSL https://bun.sh/install | bash
+ && rm -rf /var/lib/apt/lists/*
+
+# Pin bun so the install layer's cache key tracks the version: the canary must
+# never validate the committed bun.lock with a cache-stale bun. Declared right
+# before the install RUN so changing BUN_VERSION invalidates this layer.
+ARG BUN_VERSION=1.3.4
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
 ENV PATH="/root/.bun/bin:${PATH}"
 
 # Copy the plugin tree as it would be served from the marketplace

--- a/tests/l0-install/release-canary.Dockerfile
+++ b/tests/l0-install/release-canary.Dockerfile
@@ -29,8 +29,13 @@ FROM node:22-slim
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       curl unzip git ca-certificates sqlite3 jq coreutils \
- && rm -rf /var/lib/apt/lists/* \
- && curl -fsSL https://bun.sh/install | bash
+ && rm -rf /var/lib/apt/lists/*
+
+# Pin bun so the install layer's cache key tracks the version: the canary must
+# never validate the committed bun.lock with a cache-stale bun. Declared right
+# before the install RUN so changing BUN_VERSION invalidates this layer.
+ARG BUN_VERSION=1.3.4
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
 ENV PATH="/root/.bun/bin:${PATH}"
 
 # 2. Marketplace install simulation. Place the plugin tree where CC's


### PR DESCRIPTION
Closes #1100 (milestone v1.0.1).

The v1.0.0 release canary false-failed `bun install --frozen-lockfile` because Docker's layer cache served a months-stale bun. This pins bun via `ARG BUN_VERSION=1.3.4` immediately before the install layer in both `tests/l0-install` Dockerfiles (pin change ⇒ cache-key change) and adds `--no-cache` to release.sh's once-per-release step-5 canary build so it can never be poisoned by local layer cache. Wrappers/CI untouched: both runners are `pipefail`-correct and CI runners are cache-clean.

Verification: full `docker build --no-cache` of install-smoke green (31/31 assertions under pinned bun 1.3.4), `release-script-safety` + `changelog-current` L1 lints green, pr-reviewer verdict **pass** (attempt 1, validation_record).

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)