### PR TITLE
🔖 chore(release): bump to v1.0.1 + CHANGELOG rollup

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "1.0.1-rc.1",
+  "version": "1.0.1",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (SemVer guarantees apply as of v1.0.0).
 
-## v1.0.1-rc.1 — 2026-07-11
+## v1.0.1 — 2026-07-11
 
 ### Fixed
 - **release.sh re-pins the rc channel to the new stable tag** (#55): CONTRIBUTING Phase-D step 14 (re-pin `trustmybot/marketplace-rc` to the released `vX.Y.Z` so rc-channel installs converge on the stable build) was the only Phase-D step with no tooling, so it got dropped at v1.0.0 — the rc channel kept serving `rc.9` until it was caught manually. `publish-rc-channel.sh` gains a `--stable-repin` mode (reuses its temp-clone/verify/commit/push machinery; enforces a stable-tag regex and skips the release-gate pre-check, since stable tags fire no gate — the content was gated at its rc), and `release.sh` gains a confirmed, fail-forward step 6 that invokes it with the just-released tag. The default `publish-rc-channel.sh` path is byte-for-byte unchanged (still rc-only, still gate-checked).

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "mcp/trajectory-server": {
       "name": "@trustmybot/trajectory-server",
-      "version": "1.0.1-rc.1",
+      "version": "1.0.1",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.0",

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "1.0.1-rc.1",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "1.0.1-rc.1",
+  "version": "1.0.1",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Release mechanics — no issue. CONTRIBUTING Phase D step 9: final bump 1.0.1-rc.1 → 1.0.1 across the three manifests + bun.lock, CHANGELOG rc.1 section retitled to v1.0.1 (body unchanged, single-rc cycle). Functional-identity rule holds: dev HEAD == v1.0.1-rc.1 tag; rc gate run 29154790713 green. Local L1–L4 sweep green; pr-reviewer verdict PASS (validation row 47).


https://claude.ai/code/session_012eyVsy9f2Wmx1akd88Nszc

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)