### PR TITLE
🐛 fix(hooks): verification gate denies with permissionDecisionReason + 900s default budget

### DIFF
--- a/scripts/hooks/swe-verification-gate.sh
+++ b/scripts/hooks/swe-verification-gate.sh
@@ -26,10 +26,10 @@
 #   - waive_verification_gate_reason (>=10 chars) → allow + audit row
 #   - Verification passes          → allow
 #   - Verification fails           → DENY with failing command + output tail
-#   - Total timeout (default 240s) → DENY with timeout message
+#   - Total timeout (default 900s) → DENY with timeout message
 #
 # Environment:
-#   TMB_VERIFICATION_TIMEOUT_S — total seconds (default 240)
+#   TMB_VERIFICATION_TIMEOUT_S — total seconds (default 900)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -190,7 +190,7 @@ fi
 # hook-process PATH. See lib/resolve-toolchain-path.sh.
 TOOLCHAIN_PATH=$(tmb_resolve_toolchain_path "$PATH" 2>/dev/null || printf '%s' "$PATH")
 
-TIMEOUT_S="${TMB_VERIFICATION_TIMEOUT_S:-240}"
+TIMEOUT_S="${TMB_VERIFICATION_TIMEOUT_S:-900}"
 START_TS=$(date +%s 2>/dev/null || echo 0)
 
 FAILED_CMD=""
@@ -209,7 +209,7 @@ while IFS= read -r line; do
   REMAINING=$(( TIMEOUT_S - ELAPSED ))
   if [ "$REMAINING" -le 0 ]; then
     jq -nc --arg t "$TIMEOUT_S" \
-      '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: verification timed out after " + $t + "s total. Increase TMB_VERIFICATION_TIMEOUT_S or fix slow verification commands.")}}'
+      '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":("BLOCKED: verification timed out after " + $t + "s total. Increase TMB_VERIFICATION_TIMEOUT_S or fix slow verification commands. (current budget: " + $t + "s via TMB_VERIFICATION_TIMEOUT_S, default 900).")}}'
     exit 0
   fi
 
@@ -219,7 +219,7 @@ while IFS= read -r line; do
     CMD_RC=$?
     if [ "$CMD_RC" -eq 124 ]; then
       jq -nc --arg cmd "$CMD" --arg t "$TIMEOUT_S" \
-        '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","denyReason":("BLOCKED: verification timed out after " + $t + "s total budget while running: " + $cmd + ". Increase TMB_VERIFICATION_TIMEOUT_S or fix slow verification commands.")}}'
+        '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":("BLOCKED: verification timed out after " + $t + "s total budget while running: " + $cmd + ". Increase TMB_VERIFICATION_TIMEOUT_S or fix slow verification commands. (current budget: " + $t + "s via TMB_VERIFICATION_TIMEOUT_S, default 900).")}}'
       exit 0
     fi
     FAILED_CMD="$CMD"
@@ -234,7 +234,7 @@ if [ -n "$FAILED_CMD" ]; then
     {"hookSpecificOutput":{
       "hookEventName":"PreToolUse",
       "permissionDecision":"deny",
-      "denyReason":("BLOCKED: verification failed.\nFailing command: " + $cmd + "\n\nOutput (last 20 lines):\n" + $out)
+      "permissionDecisionReason":("BLOCKED: verification failed.\nFailing command: " + $cmd + "\n\nOutput (last 20 lines):\n" + $out)
     }}
   '
   exit 0

--- a/tests/l3-integration/hooks/swe-verification-gate.test.sh
+++ b/tests/l3-integration/hooks/swe-verification-gate.test.sh
@@ -129,6 +129,16 @@ out=$(cd "$REPO_DIR" && run_hook "$(make_input swe completed 3)")
 assert_contains "$out" '"permissionDecision":"deny"' "failing verification should deny"
 assert_contains "$out" "verification failed" "deny reason should say verification failed"
 
+# ---- Failing verification: deny carries permissionDecisionReason (not denyReason) ---
+# Claude Code only surfaces hookSpecificOutput.permissionDecisionReason; a
+# denyReason field would render as a silent deny with no explanation.
+test_case "failing verification: deny uses permissionDecisionReason with a non-empty value, no denyReason"
+out=$(cd "$REPO_DIR" && run_hook "$(make_input swe completed 3)")
+REASON=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null || true)
+assert_contains "$REASON" "verification failed" "deny must carry a non-empty permissionDecisionReason"
+HAS_DENY_REASON=$(printf '%s' "$out" | jq -r 'if (.hookSpecificOutput | has("denyReason")) then "yes" else "no" end' 2>/dev/null || echo "no")
+assert_eq "no" "$HAS_DENY_REASON" "deny must not carry a denyReason key"
+
 # ---- Multi-command verification that passes: allowed ------------------------
 test_case "SWE completing task with multi-command verification (all pass): allowed"
 out=$(cd "$REPO_DIR" && run_hook "$(make_input swe completed 4)")
@@ -171,6 +181,23 @@ out=$(cd "$REPO_DIR" && \
   TMB_VERIFICATION_TIMEOUT_S=0 run_hook "$(make_input swe completed 99)")
 assert_contains "$out" '"permissionDecision":"deny"' "timeout should deny"
 assert_contains "$out" "timed out" "deny reason should mention timeout"
+
+# ---- Timeout mid-command: deny carries permissionDecisionReason mentioning timeout ---
+# Drive a real per-command timeout (budget 1s, command sleeps 5s) so the deny is
+# emitted from the mid-command branch, and assert it surfaces via the field CC
+# reads (permissionDecisionReason), not denyReason.
+test_case "timeout path: deny uses permissionDecisionReason mentioning the timeout, no denyReason"
+sqlite3 "$DB" "
+  INSERT INTO tasks VALUES (98, 1, 'feat/slow-mid', 'plugin', 'pending', '', '[\"sleep 5\"]');
+"
+mkdir -p "$WT_ROOT/slow-mid"
+out=$(cd "$REPO_DIR" && \
+  TMB_VERIFICATION_TIMEOUT_S=1 run_hook "$(make_input swe completed 98)")
+assert_contains "$out" '"permissionDecision":"deny"' "mid-command timeout should deny"
+REASON=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null || true)
+assert_contains "$REASON" "timed out" "timeout deny must carry permissionDecisionReason mentioning the timeout"
+HAS_DENY_REASON=$(printf '%s' "$out" | jq -r 'if (.hookSpecificOutput | has("denyReason")) then "yes" else "no" end' 2>/dev/null || echo "no")
+assert_eq "no" "$HAS_DENY_REASON" "timeout deny must not carry a denyReason key"
 
 # ---- SQL injection via task_id: treated as missing ---------------------------
 test_case "Injection: task_id='1; DROP TABLE tasks;--' treated as missing (no SQL error, no row)"


### PR DESCRIPTION
Closes #1121.

The gate's timeout and verification-failed deny branches emitted `denyReason`, a field Claude Code doesn't surface, so denials reached swe with no explanation — all three branches now emit `permissionDecisionReason` (matching the worktree-not-found branch), with the resolved budget named in the timeout messages. The default `TMB_VERIFICATION_TIMEOUT_S` rises 240→900s: the old budget was shorter than tests/run-all.sh (~295s), which specs are required to list, making the gate structurally un-passable for full-suite tasks and forcing the waiver escape hatch. L3 test extends to assert the emitted field on both the failure and timeout paths (42/42 green). Local L1–L4 sweep green; pr-reviewer verdict PASS (validation row 48).


https://claude.ai/code/session_012eyVsy9f2Wmx1akd88Nszc

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)