### PR TITLE
🐛 fix(tests): row 04 code-review candidate description drops the push-gate-load-bearing claim

### DIFF
--- a/tests/l5-l6/rows/04/04-cheatcode-install-plugins/setup-l5.sh
+++ b/tests/l5-l6/rows/04/04-cheatcode-install-plugins/setup-l5.sh
@@ -25,7 +25,7 @@ cat > "$SEARCH_FIXTURE" <<'JSON'
   { "name": "feature-dev", "kind": "plugin", "source_url": "https://github.com/example-org/feature-dev",
     "description": "feature development plugin for swe agents implementing specs", "registry": "anthropic-official", "tier": 1 },
   { "name": "code-review", "kind": "plugin", "source_url": "https://github.com/example-org/code-review",
-    "description": "code review plugin for pr-reviewer agents gating pushes", "registry": "anthropic-official", "tier": 1 }
+    "description": "optional code-review linting conveniences for pr-reviewer agents", "registry": "anthropic-official", "tier": 1 }
 ]
 JSON
 


### PR DESCRIPTION
Closes #1117 (leave open until the L6 chain proves it — dev merges don't auto-close).

The L6 row 09 coin-flip, direction (a): row 04's install fixture described the code-review candidate as "gating pushes", the description rode the install into the cheatcodes table, and at row 09 bro would sometimes read it as removing its own push gate and hold at the concerns-protocol (which the TEST MODE preamble sanctions) while the outcome scorers demand the uninstall. The candidate is now "optional code-review linting conveniences for pr-reviewer agents" — no load-bearing claim, no plausible concern trigger, and the row keeps testing the uninstall ceremony. One line; no prompt.txt, scorer, or row 09 file touched. pr-reviewer verdict PASS (validation row 49).


https://claude.ai/code/session_012eyVsy9f2Wmx1akd88Nszc

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)