### PR TITLE
🔖 chore(release): bump to 1.0.2-rc.1 + CHANGELOG

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "1.0.1",
+  "version": "1.0.2-rc.1",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (SemVer guarantees apply as of v1.0.0).
 
+## v1.0.2-rc.1 — 2026-07-12
+
+### Fixed
+- **Verification gate denies with a visible reason and a budget that fits the full suite** (GH 1121): the timeout and verification-failed branches emitted `denyReason` — a field Claude Code does not surface — so swe received reasonless denials. All three branches now emit `permissionDecisionReason` with the resolved budget named in timeout messages, and the default `TMB_VERIFICATION_TIMEOUT_S` rises 240→900s so specs listing `tests/run-all.sh` (~295s) no longer force the waiver escape hatch.
+- **L6 row 09 judgment coin-flip removed** (GH 1117): the row 04 install fixture described the code-review candidate as "gating pushes", which bro could read at row 09 as removing its own push gate and hold at the concerns-protocol. The candidate description is now an optional linting convenience, so the row deterministically tests the uninstall ceremony.
+
 ## v1.0.1 — 2026-07-11
 
 ### Fixed

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "mcp/trajectory-server": {
       "name": "@trustmybot/trajectory-server",
-      "version": "1.0.1",
+      "version": "1.0.2-rc.1",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.0",

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "1.0.1",
+  "version": "1.0.2-rc.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2-rc.1",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Release mechanics — no issue. CONTRIBUTING Phase A step 2 for the v1.0.2 cycle: bump 1.0.1 → 1.0.2-rc.1 across the three manifests + bun.lock, new CHANGELOG section covering the verification-gate fix (#1121) and the L6 row 09 coin-flip fixture fix (#1117). Lands before the L6 pre-flight so the chain runs on the exact tree to tag. pr-reviewer verdict PASS (validation row 50); local L1–L4 green except the known network-flake probe (#1124, passes in isolation).


https://claude.ai/code/session_012eyVsy9f2Wmx1akd88Nszc

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)