### PR TITLE
🐛 fix(tests): TEST MODE preamble treats prompt-given instructions as Human authorization

### DIFF
--- a/tests/l5-l6/lib/flow-helpers.sh
+++ b/tests/l5-l6/lib/flow-helpers.sh
@@ -67,7 +67,7 @@ l5_preserve_trajectory() {
 # by the L1 auq-shape lint.
 _l5_test_prompt_prefix() {
   cat <<'EOF'
-[TEST MODE] Do not call AskUserQuestion. Apply sensible defaults and continue; where a skill's normal flow is to hold for the Human (e.g. concerns-protocol), record the note and hold — don't push past it. The Human is not in the loop here. TEST MODE does NOT bypass routing hints from PreToolUse / UserPromptSubmit hooks — when a hook injects a `[tmb consultant-spawn enforcement]` or similar enforcement context, follow it exactly as you would in production. The ceremony (e.g. `/tmb:agent-create`) is the test purpose.
+[TEST MODE] Do not call AskUserQuestion. Apply sensible defaults and continue; where a skill's normal flow is to hold for the Human (e.g. concerns-protocol), record the note and hold — don't push past it. Exception — authorization already given: when the user's prompt itself explicitly instructs the action (e.g. 'install X', 'uninstall Y'), that instruction IS the Human decision for the ceremony's approval step — record it via the ceremony's approval tool (e.g. cheatcode_approve) and proceed to execution. Hold only for decisions the prompt did not give. The Human is not in the loop here. TEST MODE does NOT bypass routing hints from PreToolUse / UserPromptSubmit hooks — when a hook injects a `[tmb consultant-spawn enforcement]` or similar enforcement context, follow it exactly as you would in production. The ceremony (e.g. `/tmb:agent-create`) is the test purpose.
 
 EOF
 }


### PR DESCRIPTION
Part of #1117 (rows 04/09 judgment coin-flip class). Human-ratified design (AskUserQuestion, 2026-07-14).

The TEST MODE preamble sanctioned holding at every Human-gate, including ceremonies the user's own prompt had already authorized — while outcome scorers demand execution. Rows exercising approval ceremonies (04 install under a deterministic caution vet, 09 uninstall of a "load-bearing" cheatcode) coin-flipped between proceed and hold. The preamble now carries a positive exception: a prompt-instructed action IS the Human decision — record it via the ceremony's approval tool and proceed; hold only for decisions the prompt did not give. The original hold instruction stands for unauthorized decisions.

One line, harness text only. pr-reviewer verdict PASS (validation row 52).

⚠️ prompt-bearing — held for Human merge per prompt-surface policy. On merge, the chain resumes --from 4 (harness-only fix; steps 1–3 green stand).


https://claude.ai/code/session_012eyVsy9f2Wmx1akd88Nszc

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)