### PR TITLE
⏪ revert(tests): restore pre-1128 TEST MODE preamble — exception destabilized row 11

### DIFF
--- a/tests/l5-l6/lib/flow-helpers.sh
+++ b/tests/l5-l6/lib/flow-helpers.sh
@@ -67,7 +67,7 @@ l5_preserve_trajectory() {
 # by the L1 auq-shape lint.
 _l5_test_prompt_prefix() {
   cat <<'EOF'
-[TEST MODE] Do not call AskUserQuestion. Apply sensible defaults and continue; where a skill's normal flow is to hold for the Human (e.g. concerns-protocol), record the note and hold — don't push past it. Exception — authorization already given: when the user's prompt itself explicitly instructs the action (e.g. 'install X', 'uninstall Y'), that instruction IS the Human decision for the ceremony's approval step — record it via the ceremony's approval tool (e.g. cheatcode_approve) and proceed to execution. This exception covers the approval step of a ceremony the prompt asked for; it does not silence doubt — when you genuinely disagree with the instruction itself (wrong scope, foreseeable breakage), follow the concerns-protocol: record the concern via discussion_append, then hold. The Human is not in the loop here. TEST MODE does NOT bypass routing hints from PreToolUse / UserPromptSubmit hooks — when a hook injects a `[tmb consultant-spawn enforcement]` or similar enforcement context, follow it exactly as you would in production. The ceremony (e.g. `/tmb:agent-create`) is the test purpose.
+[TEST MODE] Do not call AskUserQuestion. Apply sensible defaults and continue; where a skill's normal flow is to hold for the Human (e.g. concerns-protocol), record the note and hold — don't push past it. The Human is not in the loop here. TEST MODE does NOT bypass routing hints from PreToolUse / UserPromptSubmit hooks — when a hook injects a `[tmb consultant-spawn enforcement]` or similar enforcement context, follow it exactly as you would in production. The ceremony (e.g. `/tmb:agent-create`) is the test purpose.
 
 EOF
 }


### PR DESCRIPTION
Part of #1117. Reverts #1128 and #1129 (byte-identical restore of flow-helpers.sh to revision 97fecf3).

Evidence for the revert: row 11 (concerns-protocol) was stable pre-1128 (control worktree pass) and failed 3 post-1128/1129 runs in two DIFFERENT modes (chat-hold without recording; proceed-with-edit) — the exception made the row unstable rather than fixing a class. Additionally, bro in an unrelated row flagged the exception's `cheatcode_approve` example as a suspected injected routing instruction (injection-distrust class): the example leaked cheatcode vocabulary into every row's context.

Row 04's coin-flip gets its proper fix separately: a Human edit to the frozen prompt.txt that pre-authorizes the caution-tier install explicitly (direction c from the issue). Row 09 remains covered by its fixture fix (#1123), which is preamble-independent. pr-reviewer verdict PASS (validation row 54).

⚠️ prompt-bearing — held for Human merge.


https://claude.ai/code/session_012eyVsy9f2Wmx1akd88Nszc

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)