### PR TITLE
🐛 fix(hooks): spawn-gate remedy resolves the base ref — remoteless repos get a runnable command

### DIFF
--- a/scripts/hooks/require-feature-branch-active.sh
+++ b/scripts/hooks/require-feature-branch-active.sh
@@ -33,11 +33,12 @@ SAFE_TASK_ID=$(tmb_sql_int "$TASK_ID")
 DB=$(tmb_db_path 2>/dev/null || true)
 if [ -z "$DB" ] || ! tmb_have_sqlite; then exit 0; fi
 
-ROW=$(sqlite3 "$DB" "SELECT branch_id, repo FROM tasks WHERE id=${SAFE_TASK_ID};" 2>/dev/null || true)
+ROW=$(sqlite3 "$DB" "SELECT branch_id, repo, parent_branch_id FROM tasks WHERE id=${SAFE_TASK_ID};" 2>/dev/null || true)
 [ -n "$ROW" ] || exit 0
 
 EXPECTED=$(echo "$ROW" | cut -d'|' -f1)
 REPO=$(echo "$ROW" | cut -d'|' -f2)
+PARENT_BRANCH=$(echo "$ROW" | cut -d'|' -f3)
 
 WORKSPACE_ROOT="$(dirname "$(dirname "$(dirname "$DB")")")"
 
@@ -70,8 +71,18 @@ fi
 # The prerequisite is that <feature> EXISTS (bro pre-created it), not that the
 # main checkout is on it — the main checkout stays on <base>.
 if ! git -C "$REPO_ABS" show-ref --verify --quiet "refs/heads/$EXPECTED"; then
-  jq -nc --arg id "$TASK_ID" --arg branch "$EXPECTED" --arg repo "$REPO_ABS" \
-    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":("BLOCKED: SWE spawn for task "+$id+" needs branch "+$branch+" to exist first — bro pre-creates it (\"git -C "+$repo+" branch "+$branch+" origin/<base>\") and stays on <base>; SWE'\''s worktree owns the branch.")}}'
+  # The remedy is a create command the executor runs verbatim, so it must be
+  # correct for this repo. Use the task's concrete parent branch when known,
+  # else a <base> placeholder. Prefix origin/ only when the repo actually has
+  # an origin remote — a remoteless repo would choke on origin/<base>.
+  BASE="${PARENT_BRANCH:-<base>}"
+  if git -C "$REPO_ABS" remote get-url origin >/dev/null 2>&1; then
+    BASE_REF="origin/$BASE"
+  else
+    BASE_REF="$BASE"
+  fi
+  jq -nc --arg id "$TASK_ID" --arg branch "$EXPECTED" --arg repo "$REPO_ABS" --arg base "$BASE" --arg baseref "$BASE_REF" \
+    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":("BLOCKED: SWE spawn for task "+$id+" needs branch "+$branch+" to exist first — bro pre-creates it (\"git -C "+$repo+" branch "+$branch+" "+$baseref+"\") and stays on "+$base+"; SWE'\''s worktree owns the branch.")}}'
   exit 0
 fi
 

--- a/tests/l3-integration/hooks/require-feature-branch-active.test.sh
+++ b/tests/l3-integration/hooks/require-feature-branch-active.test.sh
@@ -42,12 +42,14 @@ setup_db() {
 
 # Insert a minimal issue + task row.
 insert_task() {
-  local db="$1" task_id="$2" branch_id="$3"
+  local db="$1" task_id="$2" branch_id="$3" parent_branch_id="${4:-}"
+  local parent_sql="NULL"
+  [ -n "$parent_branch_id" ] && parent_sql="'$parent_branch_id'"
   sqlite3 "$db" "
     INSERT OR IGNORE INTO issues (id, objective, description, status, created_at, updated_at)
       VALUES (1, 'test', 'test', 'open', datetime('now'), datetime('now'));
-    INSERT INTO tasks (id, issue_id, branch_id, title, description, status, spec_body, created_at, updated_at)
-      VALUES ($task_id, 1, '$branch_id', 'task $task_id', 'd', 'pending', '## body', datetime('now'), datetime('now'));
+    INSERT INTO tasks (id, issue_id, branch_id, parent_branch_id, title, description, status, spec_body, created_at, updated_at)
+      VALUES ($task_id, 1, '$branch_id', $parent_sql, 'task $task_id', 'd', 'pending', '## body', datetime('now'), datetime('now'));
   " >/dev/null
 }
 
@@ -99,6 +101,28 @@ out=$(run_hook "$payload" "$db")
 assert_contains "$out" '"permissionDecision":"deny"' "missing branch must produce deny decision"
 assert_contains "$out" "fix/1-foo" "block message must name the expected branch"
 assert_contains "$out" "exist" "block message must say the branch must exist"
+cleanup
+
+test_case "remoteless repo: missing-branch remedy prescribes the plain local base, no origin/"
+setup_repo "dev"
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "fix/1-foo" "dev"
+payload=$(make_payload "swe" "task_id=1 You are SWE.")
+out=$(run_hook "$payload" "$db")
+assert_contains "$out" '"permissionDecision":"deny"' "missing branch must produce deny decision"
+assert_contains "$out" "branch fix/1-foo dev" "remoteless remedy must prescribe the plain local base (parent branch)"
+assert_not_contains "$out" "origin/" "remoteless remedy must NOT reference origin/"
+cleanup
+
+test_case "with-remote repo: missing-branch remedy keeps the origin/<base> form"
+setup_repo "dev"
+git -C "$REPO_PATH" remote add origin "https://example.com/foo.git"
+db=$(setup_db "$REPO_PATH")
+insert_task "$db" 1 "fix/1-foo" "dev"
+payload=$(make_payload "swe" "task_id=1 You are SWE.")
+out=$(run_hook "$payload" "$db")
+assert_contains "$out" '"permissionDecision":"deny"' "missing branch must produce deny decision"
+assert_contains "$out" "branch fix/1-foo origin/dev" "with-remote remedy must keep the origin/<base> form"
 cleanup
 
 test_case "non-swe agent passes: architect bypasses the hook"


### PR DESCRIPTION
Closes #1132.

The spawn-gate deny remedy prescribed `git branch <branch> origin/<base>` unconditionally — fatal in a repo with no origin remote (the L6 sandbox, or any remoteless project), so an executor following the prescription loops on a broken command while the gate keeps re-denying with it (redded L6 chain step 14). The remedy now probes `remote get-url origin` and prescribes origin/<base> only when a remote exists, plain local base otherwise, substituting the task's concrete parent_branch_id for the placeholder when known. The gate's pass/deny condition is byte-unchanged. L3 file 18/18 with new remoteless and with-origin remedy cases. pr-reviewer verdict PASS (validation row 56).

Runtime (hooks) change — full fresh L6 chain before the v1.0.2-rc.1 tag per Phase B rule 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eyVsy9f2Wmx1akd88Nszc