### PR TITLE
🐛 fix(hooks): slash-detect INSERT retries through writer locks and fails loudly

### DIFF
--- a/scripts/hooks/roundtable-slash-detect.sh
+++ b/scripts/hooks/roundtable-slash-detect.sh
@@ -7,7 +7,8 @@
 # The audit row is the load-bearing signal — bro can't fake it from prose
 # because UserPromptSubmit hooks run outside the LLM's context.
 #
-# Silent on failure.
+# The INSERT retries through writer locks; on final failure it warns loudly on
+# stderr but always exits 0 — the hook is fail-open and must never block the prompt.
 
 set -uo pipefail
 
@@ -34,10 +35,24 @@ DB_PATH=$(tmb_db_path 2>/dev/null || true)
 
 SUMMARY=$(printf '%s' "$PROMPT" | head -c 200 | sed "s/'/''/g")
 
-sqlite3 -cmd '.timeout 3000' "$DB_PATH" <<SQL 2>&1 >/dev/null || true
+# Bounded retry: the audit row is load-bearing, but a long writer lock can
+# outlast a single busy timeout. Retry a few times before giving up loudly.
+inserted=0
+for attempt in 1 2 3; do
+  if sqlite3 -cmd '.timeout 5000' "$DB_PATH" <<SQL >/dev/null 2>&1
 INSERT INTO audit (issue_id, branch_id, from_node, event_type, summary, content_json, created_at)
 VALUES (-1, NULL, 'system', 'roundtable_slash_invoked',
         'User typed /roundtable: $SUMMARY', '{}', datetime('now'));
 SQL
+  then
+    inserted=1
+    break
+  fi
+  [ "$attempt" -lt 3 ] && sleep 0.5
+done
+
+if [ "$inserted" -ne 1 ]; then
+  echo "tmb slash-detect: FAILED to record roundtable_slash_invoked after 3 attempts ($DB_PATH) — roundtable_create's gate will refuse" >&2
+fi
 
 exit 0

--- a/tests/l3-integration/hooks/roundtable-slash-detect.test.sh
+++ b/tests/l3-integration/hooks/roundtable-slash-detect.test.sh
@@ -124,4 +124,41 @@ wait "$HOLDER_PID" 2>/dev/null || true
 COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM audit WHERE event_type='roundtable_slash_invoked';")
 assert_eq "1" "$COUNT" "audit row inserted after waiting out the concurrent write lock"
 
+# ── bounded retry: lock held ~2s, then released ──────────────────────────────
+# A writer holds the lock for ~2s before releasing. The bounded retry loop
+# waits it out and the audit row still lands; the hook exits 0.
+
+test_case "/roundtable retry lands the audit row after a ~2s write lock releases"
+sqlite3 "$DB" "DELETE FROM audit;"
+( printf 'BEGIN IMMEDIATE;\n'; sleep 2; printf 'COMMIT;\n' ) | sqlite3 "$DB" &
+HOLDER_PID=$!
+sleep 0.2
+OUT=$(echo '{"prompt":"/roundtable retry lands"}' | TRAJECTORY_DB_PATH="$DB" bash "$HOOK" 2>&1)
+RC=$?
+wait "$HOLDER_PID" 2>/dev/null || true
+assert_eq "0" "$RC" "hook must exit 0 while retrying through the lock"
+COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM audit WHERE event_type='roundtable_slash_invoked';")
+assert_eq "1" "$COUNT" "the retry must land the audit row once the lock releases"
+
+# ── bounded retry exhausted: lock outlasts every attempt ─────────────────────
+# The writer holds the lock longer than all three attempts (3 x 5s + sleeps).
+# The hook gives up, warns loudly on stderr, leaves no row, and still exits 0.
+
+test_case "/roundtable warns loudly and exits 0 when the lock outlasts all retries"
+sqlite3 "$DB" "DELETE FROM audit;"
+( printf 'BEGIN IMMEDIATE;\n'; sleep 30; printf 'COMMIT;\n' ) | sqlite3 "$DB" &
+HOLDER_PID=$!
+sleep 0.2
+OUT=$(echo '{"prompt":"/roundtable permanent lock"}' | TRAJECTORY_DB_PATH="$DB" bash "$HOOK" 2>&1)
+RC=$?
+kill "$HOLDER_PID" 2>/dev/null || true
+wait "$HOLDER_PID" 2>/dev/null || true
+assert_eq "0" "$RC" "hook must exit 0 even when the INSERT never lands (fail-open)"
+COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM audit WHERE event_type='roundtable_slash_invoked';")
+assert_eq "0" "$COUNT" "no audit row when the lock outlasts every attempt"
+case "$OUT" in
+  *"FAILED to record roundtable_slash_invoked after 3 attempts"*) echo "  ✓ loud stderr warning emitted on final failure" ;;
+  *) echo "FAIL: expected FAILED warning on stderr, got: $OUT"; exit 1 ;;
+esac
+
 summarize


### PR DESCRIPTION
Closes #1134. Completes #1115.

The 3s busy timeout from #1115 narrowed the slash-detect drop window but a single attempt still loses to writer locks held longer (embedding batches, checkpoints) — and its `|| true` swallowed the loss silently, so roundtable_create's gate refused with no trace (redded an rc.1 gate attempt and the 2026-07-17 fresh-chain step 13, while the same morning's run passed). The INSERT now retries 3×5s with early break, and a final failure prints one loud stderr line naming the dropped event; the hook stays fail-open (exit 0). L3 14/14 with lock-then-release and permanent-lock cases. pr-reviewer verdict PASS (validation row 57).

Runtime (hooks) change — full fresh L6 chain before the tag per Phase B rule 5.


https://claude.ai/code/session_012eyVsy9f2Wmx1akd88Nszc

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)