### PR TITLE
🔖 chore(release): bump to 1.0.2-rc.2 + CHANGELOG

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "1.0.2-rc.1",
+  "version": "1.0.2-rc.2",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (SemVer guarantees apply as of v1.0.0).
 
+## v1.0.2-rc.2 — 2026-07-18
+
+### Fixed
+- **cheatcode_install materializes every attachment target** (GH 1137): materialization keyed solely off the optional target arg, so installs recording attachment rows could skip the on-disk agent materialization when the caller omitted it — DB said attached, the agent never loaded the capability. The handler now materializes each distinct attachment target (union with the explicit arg) and surfaces `materialized[]` per write.
+- **SWE spawn-gate deny remedy is runnable in remoteless repos** (GH 1132): the prescribed branch-create hardcoded `origin/<base>`, fatal without an origin remote; the remedy now probes the remote and substitutes the task's concrete parent branch.
+- **slash-detect audit INSERT retries through writer locks** (GH 1134): the single 3s-timeout attempt with silent failure could drop the `roundtable_slash_invoked` row under longer WAL writer locks; now 3 attempts × 5s with a loud stderr warning on final failure, still fail-open.
+
 ## v1.0.2-rc.1 — 2026-07-12
 
 ### Fixed

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "mcp/trajectory-server": {
       "name": "@trustmybot/trajectory-server",
-      "version": "1.0.2-rc.1",
+      "version": "1.0.2-rc.2",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.0",

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "1.0.2-rc.1",
+  "version": "1.0.2-rc.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "1.0.2-rc.1",
+  "version": "1.0.2-rc.2",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Release mechanics — no issue. Phase A bump for the rc.2 cut: rc.1's tag gate redded on the install-materialization gap (#1137, fixed in #1138), invalidating rc.1 under the functional-identity rule. CHANGELOG's rc.2 section covers #1137 plus the post-rc.1 hook fixes (#1132, #1134). pr-reviewer verdict PASS (validation row 59).


https://claude.ai/code/session_012eyVsy9f2Wmx1akd88Nszc

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)