### PR TITLE
🐛 fix(tests): L6 resume-inherit rewrites absolute DB paths to the new run dir

### DIFF
--- a/tests/l5-l6/run-l6-chain.sh
+++ b/tests/l5-l6/run-l6-chain.sh
@@ -222,6 +222,30 @@ if [ "$START_FROM" -gt 1 ]; then
     SCRATCH=$(l5_setup_scratch_project)
     mv "$SCRATCH" "$PROJECT"
   fi
+
+  # Rewrite stale absolute paths in the inherited trajectory DB. The DB we
+  # just restored (checkpoint.db or the copied live project) was written by
+  # the prior run, whose project dir differs from this run's. Hooks resolve
+  # the workspace from repos.path, so a stale path deadlocks spawn-gate
+  # remedies against the prior run's dir. repos.path is the ONLY absolute-path
+  # column in schema.sql (agents/cheatcodes.file_path and tasks.repo are
+  # repo-relative). Each rewrite is guarded by a table-existence check so
+  # older inherited DBs without a given table don't error, and any sqlite3
+  # failure fails the resume loudly — a silently stale path is the bug here.
+  INHERITED_DB="$PROJECT/.claude/tmb/trajectory.db"
+  OLD_PROJECT_ABS="${PRIOR_RUN%/}/project"
+  if [ -n "${PRIOR_RUN:-}" ] && [ -f "$INHERITED_DB" ] && [ "$OLD_PROJECT_ABS" != "$PROJECT" ]; then
+    printf '  path-rewrite: repos.path %s → %s\n' "$OLD_PROJECT_ABS" "$PROJECT"
+    HAS_REPOS=$(sqlite3 -cmd '.timeout 3000' "$INHERITED_DB" \
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='repos';" 2>/dev/null)
+    if [ "$HAS_REPOS" = "repos" ]; then
+      if ! sqlite3 -cmd '.timeout 3000' "$INHERITED_DB" \
+        "UPDATE repos SET path = REPLACE(path, '$OLD_PROJECT_ABS', '$PROJECT') WHERE path LIKE '$OLD_PROJECT_ABS%';"; then
+        printf '❌ resume path-rewrite failed for repos.path in %s\n' "$INHERITED_DB" >&2
+        exit 1
+      fi
+    fi
+  fi
 else
   # Full run: fresh project. Mirror l5_setup_scratch_project's init steps
   # but put the project inside RUN_DIR so it survives for later resumes.


### PR DESCRIPTION
Closes #1142.

The chain runner's --from N resume copies the prior run's project (trajectory DB included) but left repos.path pointing at the prior run's directory — any hook resolving the repo through the DB then operated on the stale dir. Observed at step 14 (2026-07-19 resumed run): the spawn-gate remedy named the old path, bro ran it there, the gate kept checking the current repo, deadlock. The inherit step now rewrites repos.path to the new run dir (derived vars, table-existence guard, loud exit-1 on sqlite error, fresh path untouched); a schema grep confirms repos.path is the only absolute-path column. Harness-only. pr-reviewer verdict PASS (validation row 61).


https://claude.ai/code/session_012eyVsy9f2Wmx1akd88Nszc

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)