### PR TITLE
🐛 fix(tests): sandbox https-push probe accepts connection-level failures

### DIFF
--- a/tests/l3-integration/hooks/sandbox-isolation.test.sh
+++ b/tests/l3-integration/hooks/sandbox-isolation.test.sh
@@ -55,7 +55,7 @@ fi
 test_case "git push to https remote is blocked — sandbox, transport, or credential-prompt suppressed"
 if echo "$https_out" | grep -q "tmb sandbox"; then
   _pass
-elif echo "$https_out" | grep -qiE "transport|blocked|disabled|Couldn.t connect|Failed to connect|Connection refused|terminal prompts disabled|could not read Username|Device not configured|Authentication failed"; then
+elif echo "$https_out" | grep -qiE "transport|blocked|disabled|Couldn.t connect|Failed to connect|Connection refused|Connection reset|Connection timed out|SSL_ERROR_SYSCALL|Could not resolve host|unable to access|terminal prompts disabled|could not read Username|Device not configured|Authentication failed"; then
   _pass
 else
   _fail "git push https: expected sandbox or network-blocked or credential-suppressed message, got: $https_out"


### PR DESCRIPTION
Closes #1124.

The probe's intent is "the push must not succeed" — but its accepted-message set only knew sandbox/network-blocked/credential-suppressed shapes, so a mid-handshake TLS reset (SSL_ERROR_SYSCALL under degraded network + suite CPU load) redded the whole L3 layer while the probe passed in isolation. The set now includes connection-level signatures (reset/refused/timed out/DNS/unable-to-access); a genuine push success still fails the probe. Test-only; permitted post-rc delta per amended rule 10. pr-reviewer verdict PASS (validation row 63).


https://claude.ai/code/session_012eyVsy9f2Wmx1akd88Nszc

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)