### PR TITLE
✨ feat(ci): tag-triggered release-gate inherits a green same-SHA dispatch verdict

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -25,8 +25,44 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  verdict-check:
+    name: Same-SHA verdict check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+    outputs:
+      short_circuit: ${{ steps.check.outputs.short_circuit }}
+    steps:
+      - name: Inherit a green same-SHA dispatch verdict (tag events only)
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "event=${{ github.event_name }} — dispatch runs the full gate, never inherits."
+            echo "short_circuit=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          SHA="${{ github.sha }}"
+          CUTOFF=$(date -u -d '48 hours ago' +%s 2>/dev/null || date -u -v-48H +%s)
+          HIT=$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/release-gate.yml/runs?event=workflow_dispatch&status=completed&per_page=100" \
+            --jq "[.workflow_runs[] | select(.head_sha == \"$SHA\" and .conclusion == \"success\" and (.created_at | fromdateiso8601) >= $CUTOFF) | .id] | first // empty")
+          if [ -n "$HIT" ]; then
+            echo "short_circuit=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::verdict inherited from run $HIT (same SHA)"
+            echo "Inheriting green dispatch verdict from run $HIT for $SHA — heavy jobs will skip."
+          else
+            echo "short_circuit=false" >> "$GITHUB_OUTPUT"
+            echo "No green same-SHA dispatch verdict within 48h; running the full gate."
+          fi
+
   tests:
     name: L1+L2+L3+L4 (+ L6 chain)
+    needs: verdict-check
+    if: ${{ needs.verdict-check.outputs.short_circuit != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
@@ -119,7 +155,8 @@ jobs:
   install-smoke:
     name: L0 docker install-smoke
     # L0 docker smoke stays release-only; PR gate is L1–L4 (run-all.sh).
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
+    needs: verdict-check
+    if: ${{ needs.verdict-check.outputs.short_circuit != 'true' && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Closes #1136.

The rc doctrine validates dev via workflow_dispatch before tagging, then the tag push re-ran the full ~35min gate on the identical commit. A new verdict-check first job (tag events only) queries this workflow's runs for a completed green workflow_dispatch at the exact head_sha within 48h — on a hit both heavy jobs skip and the run concludes success with a "verdict inherited from run <id> (same SHA)" annotation, which await-release-gate.sh/publish-rc-channel.sh consume unchanged. Dispatch events and verdict misses run the full gate exactly as today; every failure direction falls through to running more, never less. Per rule 6, the full release-gate dispatch on THIS branch passed before merge: run 29669269606. pr-reviewer verdict PASS (validation row 64).


https://claude.ai/code/session_012eyVsy9f2Wmx1akd88Nszc

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)