### PR TITLE
🔖 chore(release): bump to 1.0.2-rc.3 + CHANGELOG

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "1.0.2-rc.2",
+  "version": "1.0.2-rc.3",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (SemVer guarantees apply as of v1.0.0).
 
+## v1.0.2-rc.3 — 2026-07-19
+
+Release-mechanics only — no user-visible plugin changes since rc.2. Bundles the internal CI/test/docs deltas that landed on dev after the rc.2 tag so the stable v1.0.2 build is cut from a gate-validated dev tip: tag-triggered release-gate inherits a green same-SHA dispatch (GH 1146), sandbox https-push probe accepts connection-level failures (GH 1145), and the CONTRIBUTING functional-identity rule is scoped to shipped surfaces (GH 1144).
+
 ## v1.0.2-rc.2 — 2026-07-18
 
 ### Fixed

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "mcp/trajectory-server": {
       "name": "@trustmybot/trajectory-server",
-      "version": "1.0.2-rc.2",
+      "version": "1.0.2-rc.3",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.0",

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "1.0.2-rc.2",
+  "version": "1.0.2-rc.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "1.0.2-rc.2",
+  "version": "1.0.2-rc.3",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Release-mechanics bump so the stable **v1.0.2** tag is cut from a gate-validated dev tip.

**No user-visible changes since rc.2.** Bundles the internal CI/test/docs deltas that landed on dev after the rc.2 tag:
- #1146 — tag-triggered release-gate inherits a green same-SHA dispatch
- #1145 — sandbox https-push probe accepts connection-level failures
- #1144 — CONTRIBUTING functional-identity rule scoped to shipped surfaces

release-gate already ran green at `6fcf494` (the pre-bump dev tip); this bump touches only the 4 version manifests + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)