### PR TITLE
🔖 chore(release): bump to 1.0.2 + CHANGELOG rollup

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb",
-  "version": "1.0.2-rc.3",
+  "version": "1.0.2",
   "description": "TMB plugin \u2014 bro orchestrates swe + pr-reviewer across a task-close and a push gate, backed by an MCP server: a SQLite trajectory log plus a kuzu world model that helps agents understand and navigate complex codebases.",
   "author": {
     "name": "trustmybot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable user-visible changes to the TMB plugin. Versions follow [SemVer](https://semver.org/) (SemVer guarantees apply as of v1.0.0).
 
+## v1.0.2 — 2026-07-19
+
+Patch release rolling up the fixes validated across rc.1–rc.3.
+
+### Fixed
+- **cheatcode_install materializes every attachment target** (GH 1137): materialization keyed solely off the optional target arg, so installs recording attachment rows could skip the on-disk agent materialization when the caller omitted it — the DB said attached, the agent never loaded the capability. The handler now materializes each distinct attachment target (union with the explicit arg) and surfaces `materialized[]` per write.
+- **SWE spawn-gate deny remedy is runnable in remoteless repos** (GH 1132): the prescribed branch-create hardcoded `origin/<base>`, fatal without an origin remote; the remedy now probes the remote and substitutes the task's concrete parent branch.
+- **Verification gate denies with a visible reason and a budget that fits the full suite** (GH 1121): the timeout and verification-failed branches emitted `denyReason` — a field Claude Code does not surface — so swe received reasonless denials. All three branches now emit `permissionDecisionReason` with the resolved budget named in timeout messages, and the default `TMB_VERIFICATION_TIMEOUT_S` rises 240→900s so specs listing `tests/run-all.sh` (~295s) no longer force the waiver escape hatch.
+- **slash-detect audit INSERT survives writer locks** (GH 1134): the single 3s-timeout attempt with silent failure could drop the `roundtable_slash_invoked` row under longer WAL writer locks; now 3 attempts × 5s with a loud stderr warning on final failure, still fail-open.
+
 ## v1.0.2-rc.3 — 2026-07-19
 
 Release-mechanics only — no user-visible plugin changes since rc.2. Bundles the internal CI/test/docs deltas that landed on dev after the rc.2 tag so the stable v1.0.2 build is cut from a gate-validated dev tip: tag-triggered release-gate inherits a green same-SHA dispatch (GH 1146), sandbox https-push probe accepts connection-level failures (GH 1145), and the CONTRIBUTING functional-identity rule is scoped to shipped surfaces (GH 1144).

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "mcp/trajectory-server": {
       "name": "@trustmybot/trajectory-server",
-      "version": "1.0.2-rc.3",
+      "version": "1.0.2",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.0",

--- a/mcp/trajectory-server/package.json
+++ b/mcp/trajectory-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustmybot/trajectory-server",
-  "version": "1.0.2-rc.3",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmb-plugin",
-  "version": "1.0.2-rc.3",
+  "version": "1.0.2",
   "description": "TMB multi-agent Claude Code plugin \u2014 workspace root. Shipped content is declared in .claude-plugin/plugin.json; this file exists only to wire the two Node subpackages together.",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Promotes rc.3 → stable v1.0.2. Bumps the 4 manifests and rolls the user-visible fixes validated across rc.1–rc.3 (GH 1137, 1132, 1121, 1134) into a v1.0.2 CHANGELOG section. rc.3 tag gate (29674750360 @ 4fe9f9d) is green; the stable tag inherits that verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code), powered by [Bro](https://github.com/trustmybot/plugin)